### PR TITLE
Add TLS/mTLS Support for Milvus Connection

### DIFF
--- a/src/main/scala/zilliztech/spark/milvus/MilvusConnection.scala
+++ b/src/main/scala/zilliztech/spark/milvus/MilvusConnection.scala
@@ -19,15 +19,22 @@ object MilvusConnection {
         .withPort(milvusOptions.port)
         .withAuthorization(milvusOptions.userName, milvusOptions.password)
         .withDatabaseName(milvusOptions.databaseName)
-        .withServerPemPath(milvusOptions.caCert)
-        .withServerName(milvusOptions.servername)
-      
+
       if (milvusOptions.secure) {
-        if (!milvusOptions.clientCert.isEmpty) {
-          builder.withServerName(milvusOptions.host)
-          builder.withCaPemPath(milvusOptions.caCert)
-          builder.withClientKeyPath(milvusOptions.clientKey)
-          builder.withClientPemPath(milvusOptions.clientCert)
+        if (milvusOptions.serverPemPath.nonEmpty) {
+          // TLS Configuration
+          builder.withServerPemPath(milvusOptions.serverPemPath)
+            .withServerName(milvusOptions.serverName)
+        } else if (milvusOptions.caCert.nonEmpty && milvusOptions.clientCert.nonEmpty && milvusOptions.clientKey.nonEmpty) {
+          // mTLS Configuration
+          builder.withServerName(milvusOptions.serverName)
+            .withCaPemPath(milvusOptions.caCert)
+            .withClientKeyPath(milvusOptions.clientKey)
+            .withClientPemPath(milvusOptions.clientCert)
+        } else {
+          throw new IllegalArgumentException(
+            "Secure connection requires either serverPemPath (for TLS) OR caCert, clientCert, and clientKey (for mTLS)."
+          )
         }
       }
       
@@ -37,15 +44,22 @@ object MilvusConnection {
       val builder = ConnectParam.newBuilder
         .withUri(milvusOptions.uri)
         .withToken(milvusOptions.token)
-        .withServerPemPath(milvusOptions.caCert)
-        .withServerName(milvusOptions.servername)
       
       if (milvusOptions.secure) {
-        if (!milvusOptions.clientCert.isEmpty) {
-          builder.withServerName(milvusOptions.host)
-          builder.withCaPemPath(milvusOptions.caCert)
-          builder.withClientKeyPath(milvusOptions.clientKey)
-          builder.withClientPemPath(milvusOptions.clientCert)
+        if (milvusOptions.serverPemPath.nonEmpty) {
+          // TLS Configuration
+          builder.withServerPemPath(milvusOptions.serverPemPath)
+          .withServerName(milvusOptions.serverName)
+        } else if (milvusOptions.caCert.nonEmpty && milvusOptions.clientCert.nonEmpty && milvusOptions.clientKey.nonEmpty) {
+          // mTLS Configuration
+          builder.withServerName(milvusOptions.serverName)
+            .withCaPemPath(milvusOptions.caCert)
+            .withClientKeyPath(milvusOptions.clientKey)
+            .withClientPemPath(milvusOptions.clientCert)
+        } else {
+          throw new IllegalArgumentException(
+            "Secure connection requires either serverPemPath (for TLS) OR caCert, clientCert, and clientKey (for mTLS)."
+          )
         }
       }
       

--- a/src/main/scala/zilliztech/spark/milvus/MilvusOptions.scala
+++ b/src/main/scala/zilliztech/spark/milvus/MilvusOptions.scala
@@ -8,14 +8,17 @@ object MilvusOptions {
   val MILVUS_URI = "milvus.uri"
   val MILVUS_TOKEN = "milvus.token"
   val MILVUS_HOST = "milvus.host"
-  val MILVUS_SEVERNAME = "milvus.servername"
   val MILVUS_PORT = "milvus.port"
   val MILVUS_USERNAME = "milvus.username"
   val MILVUS_PASSWORD = "milvus.password"
+
+  //configs for secure connection with milvus Tls/mTls
   val MILVUS_SECURE = "milvus.secure"
-  val MILVUS_CA_CERT = "milvus.caCert"
-  val MILVUS_CLIENT_CERT = "milvus.clientCert"
-  val MILVUS_CLIENT_KEY = "milvus.clientKey"
+  val MILVUS_SEVERNAME = "milvus.secure.serverName"
+  val MILVUS_SERVER_PEMPATH = "milvus.secure.serverPemPath"
+  val MILVUS_CA_CERT = "milvus.secure.caCert"
+  val MILVUS_CLIENT_CERT = "milvus.secure.clientCert"
+  val MILVUS_CLIENT_KEY = "milvus.secure.clientKey"
 
 
 
@@ -60,13 +63,14 @@ class MilvusOptions(config: CaseInsensitiveStringMap) extends Serializable {
   val password: String = config.getOrDefault(MILVUS_PASSWORD, "milvus")
   val uri: String = config.getOrDefault(MILVUS_URI, "")
   val token: String = config.getOrDefault(MILVUS_TOKEN, "")
-  val servername: String = config.getOrDefault(MILVUS_SEVERNAME, "localhost")
   val secure: Boolean = config.getBoolean(MILVUS_SECURE, false)
+  val serverName: String = config.getOrDefault(MILVUS_SEVERNAME, "localhost")
+  val serverPemPath: String = config.getOrDefault(MILVUS_SERVER_PEMPATH, "")
   val caCert: String = config.getOrDefault(MILVUS_CA_CERT, "")
   val clientKey: String = config.getOrDefault(MILVUS_CLIENT_KEY, "")
   val clientCert: String = config.getOrDefault(MILVUS_CLIENT_CERT, "")
-  if (secure && (caCert.isEmpty || clientCert.isEmpty || clientKey.isEmpty)) {
-    throw new IllegalArgumentException("Secure connection requires caCert, clientKey, and clientCert to be provided.")
+  if (secure && serverPemPath.isEmpty && (caCert.isEmpty || clientCert.isEmpty || clientKey.isEmpty)) {
+    throw new IllegalArgumentException("Secure connection requires either serverPemPath (for TLS) OR all three: caCert, clientCert, and clientKey (for mTLS).")
   }
 
   // zilliz cloud

--- a/src/main/scala/zilliztech/spark/milvus/MilvusOptions.scala
+++ b/src/main/scala/zilliztech/spark/milvus/MilvusOptions.scala
@@ -8,9 +8,16 @@ object MilvusOptions {
   val MILVUS_URI = "milvus.uri"
   val MILVUS_TOKEN = "milvus.token"
   val MILVUS_HOST = "milvus.host"
+  val MILVUS_SEVERNAME = "milvus.servername"
   val MILVUS_PORT = "milvus.port"
   val MILVUS_USERNAME = "milvus.username"
   val MILVUS_PASSWORD = "milvus.password"
+  val MILVUS_SECURE = "milvus.secure"
+  val MILVUS_CA_CERT = "milvus.caCert"
+  val MILVUS_CLIENT_CERT = "milvus.clientCert"
+  val MILVUS_CLIENT_KEY = "milvus.clientKey"
+
+
 
   // configs for milvus storage, only used when using MilvusUtils
   val MILVUS_BUCKET = "milvus.bucket"
@@ -53,6 +60,14 @@ class MilvusOptions(config: CaseInsensitiveStringMap) extends Serializable {
   val password: String = config.getOrDefault(MILVUS_PASSWORD, "milvus")
   val uri: String = config.getOrDefault(MILVUS_URI, "")
   val token: String = config.getOrDefault(MILVUS_TOKEN, "")
+  val servername: String = config.getOrDefault(MILVUS_SEVERNAME, "localhost")
+  val secure: Boolean = config.getBoolean(MILVUS_SECURE, false)
+  val caCert: String = config.getOrDefault(MILVUS_CA_CERT, "")
+  val clientKey: String = config.getOrDefault(MILVUS_CLIENT_KEY, "")
+  val clientCert: String = config.getOrDefault(MILVUS_CLIENT_CERT, "")
+  if (secure && (caCert.isEmpty || clientCert.isEmpty || clientKey.isEmpty)) {
+    throw new IllegalArgumentException("Secure connection requires caCert, clientKey, and clientCert to be provided.")
+  }
 
   // zilliz cloud
   val zillizCloudRegion: String = config.getOrDefault(ZILLIZCLOUD_REGION, "")
@@ -81,7 +96,7 @@ class MilvusOptions(config: CaseInsensitiveStringMap) extends Serializable {
   // insert option
   val maxBatchSize: Int = config.getInt(MILVUS_INSERT_MAX_BATCHSIZE, 200)
 
-  override def toString = s"MilvusOptions($host, $port, $uri, $token, $userName)"
+  override def toString = s"MilvusOptions($host, $port, $uri, $token, $userName, secure=$secure)"
 
   def zillizInstanceID(): String = {
     zillizInstanceIDAndRegion()._1


### PR DESCRIPTION
### Description
This commit introduces support for TLS and mTLS connections in Milvus when using 
the Spark-Milvus connector. Previously, only plain-text connections were supported. 
With this update, users can now establish secure connections using TLS or mutual TLS (mTLS).

### Changes Introduced
- Added support for TLS authentication via `milvus.caCert`
- Extended mTLS support with `milvus.client.key` and `milvus.client.cert`
- Introduced `milvus.secure` option to toggle TLS mode

### Usage

#### 1. Connecting to Milvus with TLS
```python
sample_df.write \
    .mode("append") \
    .option("milvus.host", "hostname") \
    .option("milvus.port", "19530") \
    .option("milvus.collection.name", "hello_spark_milvus_tls") \
    .option("milvus.collection.vectorField", "vec") \
    .option("milvus.collection.vectorDim", "8") \
    .option("milvus.collection.primaryKeyField", "id") \
    .option("milvus.database.name", "default") \
    .option("milvus.username", "username") \
    .option("milvus.password", "password") \
    .option("milvus.secure", "true") \
    .option("milvus.secure.serverName", "servername") \
    .option("milvus.secure.serverPemPath", "path/to/server.pem") \
    .format("milvus") \
    .save()
```
2. Connecting to Milvus with mTLS
```
sample_df.write \
    .mode("append") \
    .option("milvus.host", "hostname") \
    .option("milvus.port", "19530") \
    .option("milvus.collection.name", "hello_spark_milvus_tls") \
    .option("milvus.collection.vectorField", "vec") \
    .option("milvus.collection.vectorDim", "8") \
    .option("milvus.collection.primaryKeyField", "id") \
    .option("milvus.database.name", "default") \
    .option("milvus.username", "usename") \
    .option("milvus.password", "password") \
    .option("milvus.secure", "true") \
     .option("milvus.secure.serverName", "hostname") \
    .option("milvus.secure.caCert", "path/ca.pem") \
    .option("milvus.secure.clientCert", "/path/client.pem") \  
    .option("milvus.secure.clientKey", "/path/client.key") \ 

    .format("milvus") \
    .save()
```

Backward Compatibility
Non-TLS connections remain unaffected.
If milvus.secure is not specified, the connection defaults to non-TLS mode.

