### PR TITLE
feat: add backfill API for Milvus added field collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,9 @@ lazy val root = (project in file("."))
     run / fork := true,
     Test / fork := true,
 
+    // Show test logs immediately (don't buffer)
+    Test / logBuffered := false,
+
     // JVM options for run
     run / javaOptions ++= Seq(
       "-Xss2m",
@@ -102,6 +105,8 @@ lazy val root = (project in file("."))
       "-Xss2m",
       "-Xmx4g",
       "-Djava.library.path=.",
+      "-Dlog4j2.configurationFile=log4j2.properties",
+      "-Dlog4j2.debug=true",
       "--add-opens=java.base/java.nio=ALL-UNNAMED",
       "--add-opens=java.base/java.lang=ALL-UNNAMED",
       "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -67,6 +67,8 @@ object MilvusOption {
 
   val MilvusExtraColumns = "milvus.extra.columns"
   val MilvusExtraColumnPartition = "partition"
+  val MilvusExtraColumnSegmentID = "segment_id"
+  val MilvusExtraColumnRowOffset = "row_offset"
 
   // reader config
   val ReaderPath = Constants.LogReaderPathParamName
@@ -109,6 +111,9 @@ object MilvusOption {
   val FsGcpNativeWithoutAuth = Constants.FsGcpNativeWithoutAuth
   val FsGcpCredentialJson = Constants.FsGcpCredentialJson
   val FsUseCustomPartUpload = Constants.FsUseCustomPartUpload
+
+  // Writer config
+  val WriterCustomPath = "milvus.writer.customPath"
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {

--- a/src/main/scala/example/MilvusStorageMain.scala
+++ b/src/main/scala/example/MilvusStorageMain.scala
@@ -78,7 +78,7 @@ object MilvusStorageMain {
       reader.create(updatedManifest, schema, neededColumns, readerProperties)
 
       // Read data using Arrow C Data Interface
-      val recordBatchReaderPtr = reader.getRecordBatchReaderScala(null, 1024, 8 * 1024 * 1024)
+      val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
 
       // Wrap the C++ ArrowArrayStream pointer with Arrow Java's ArrowArrayStream
       val allocator = ArrowUtils.getAllocator

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -1,0 +1,142 @@
+package com.zilliz.spark.connector.operations.backfill
+
+/**
+ * Configuration for backfill operation
+ *
+ * @param milvusUri Milvus server URI (e.g., "http://localhost:19530")
+ * @param milvusToken Authentication token in format "username:password"
+ * @param databaseName Milvus database name
+ * @param collectionName Milvus collection name to backfill
+ * @param partitionName Optional specific partition name to backfill
+ * @param s3Endpoint S3/Minio endpoint (e.g., "localhost:9000")
+ * @param s3BucketName S3 bucket name
+ * @param s3AccessKey S3 access key ID
+ * @param s3SecretKey S3 secret access key
+ * @param s3UseSSL Whether to use SSL for S3 connections
+ * @param s3RootPath Root path in S3 bucket
+ * @param s3Region S3 region
+ * @param pkFieldToRead Primary key field ID to read for join operation
+ * @param batchSize Batch size for writing data
+ * @param customOutputPath Optional custom output path override
+ */
+case class BackfillConfig(
+    // Milvus connection
+    milvusUri: String,
+    milvusToken: String = "",
+    databaseName: String = "default",
+    collectionName: String,
+    partitionName: Option[String] = None,
+
+    // S3 storage configuration
+    s3Endpoint: String,
+    s3BucketName: String,
+    s3AccessKey: String,
+    s3SecretKey: String,
+    s3UseSSL: Boolean = false,
+    s3RootPath: String = "files",
+    s3Region: String = "us-east-1",
+
+    // Field configuration
+    pkFieldToRead: Int,
+
+    // Writer configuration
+    batchSize: Int = 1024,
+    customOutputPath: Option[String] = None
+) {
+  /**
+   * Validate that all required fields are set
+   */
+  def validate(): Either[String, Unit] = {
+    if (milvusUri.isEmpty) {
+      Left("milvusUri cannot be empty")
+    } else if (collectionName.isEmpty) {
+      Left("collectionName cannot be empty")
+    } else if (s3Endpoint.isEmpty) {
+      Left("s3Endpoint cannot be empty")
+    } else if (s3BucketName.isEmpty) {
+      Left("s3BucketName cannot be empty")
+    } else if (s3AccessKey.isEmpty) {
+      Left("s3AccessKey cannot be empty")
+    } else if (s3SecretKey.isEmpty) {
+      Left("s3SecretKey cannot be empty")
+    } else if (batchSize <= 0) {
+      Left("batchSize must be positive")
+    } else {
+      Right(())
+    }
+  }
+
+  /**
+   * Get Milvus read options as a Map for DataSource
+   * Only reads the primary key field to minimize data transfer for join operation
+   */
+  def getMilvusReadOptions: Map[String, String] = {
+    var options = Map(
+      "milvus.uri" -> milvusUri,
+      "milvus.token" -> milvusToken,
+      "milvus.database.name" -> databaseName,
+      "milvus.collection.name" -> collectionName,
+      "milvus.extra.columns" -> "segment_id,row_offset", // this is used to match with the original sequence of rows for each segment
+      "milvus.field.ids" -> pkFieldToRead.toString, // Only read PK field for join
+      "fs.address" -> s3Endpoint,
+      "fs.bucket_name" -> s3BucketName,
+      "fs.root_path" -> s3RootPath,
+      "fs.access_key_id" -> s3AccessKey,
+      "fs.access_key_value" -> s3SecretKey,
+      "fs.use_ssl" -> s3UseSSL.toString
+    )
+
+    // Add optional configurations
+    partitionName.foreach(p => options = options + ("milvus.partition.name" -> p))
+
+    options
+  }
+
+  /**
+   * Get S3 write options as a Map for MilvusLoonWriter
+   */
+  def getS3WriteOptions(collectionId: Long, partitionId: Long, segmentId: Long): Map[String, String] = {
+    val outputPath = customOutputPath.getOrElse(
+      s"$s3BucketName/$s3RootPath/insert_log/$collectionId/$partitionId/$segmentId/new_field"
+    )
+
+    Map(
+      "fs.storage_type" -> "remote",
+      "fs.address" -> s3Endpoint,
+      "fs.bucket_name" -> s3BucketName,
+      "fs.root_path" -> s3RootPath,
+      "fs.access_key_id" -> s3AccessKey,
+      "fs.access_key_value" -> s3SecretKey,
+      "fs.use_ssl" -> s3UseSSL.toString,
+      "fs.region" -> s3Region,
+      "milvus.collection.name" -> s"segment_${segmentId}_backfill",
+      "milvus.writer.customPath" -> outputPath,
+      "milvus.insertMaxBatchSize" -> batchSize.toString
+    )
+  }
+}
+
+object BackfillConfig {
+  /**
+   * Create a minimal config for testing
+   */
+  def forTest(
+      collectionName: String,
+      pkFieldToRead: Int = 100,
+      milvusUri: String = "http://localhost:19530",
+      milvusToken: String = "root:Milvus",
+      s3Endpoint: String = "localhost:9000",
+      s3BucketName: String = "a-bucket"
+  ): BackfillConfig = {
+    BackfillConfig(
+      milvusUri = milvusUri,
+      milvusToken = milvusToken,
+      collectionName = collectionName,
+      pkFieldToRead = pkFieldToRead,
+      s3Endpoint = s3Endpoint,
+      s3BucketName = s3BucketName,
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin"
+    )
+  }
+}

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -96,6 +96,7 @@ case class BackfillConfig(
    * Get S3 write options as a Map for MilvusLoonWriter
    */
   def getS3WriteOptions(collectionId: Long, partitionId: Long, segmentId: Long): Map[String, String] = {
+    // TODO: this should be changed to field id based on the collection schema once Milvus snapshot feature is ready
     val outputPath = customOutputPath.getOrElse(
       s"$s3BucketName/$s3RootPath/insert_log/$collectionId/$partitionId/$segmentId/new_field"
     )

--- a/src/main/scala/operations/backfill/BackfillError.scala
+++ b/src/main/scala/operations/backfill/BackfillError.scala
@@ -1,0 +1,116 @@
+package com.zilliz.spark.connector.operations.backfill
+
+/**
+ * Sealed trait representing all possible errors during backfill operations
+ */
+sealed trait BackfillError {
+  def message: String
+  def cause: Option[Throwable]
+}
+
+/**
+ * Error connecting to Milvus or retrieving metadata
+ */
+case class ConnectionError(
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * Error validating schema compatibility between original collection and new field data
+ */
+case class SchemaValidationError(
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * Error reading new field data from the provided path
+ */
+case class DataReadError(
+    path: String,
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * Error processing a specific segment during backfill
+ */
+case class SegmentProcessingError(
+    segmentId: Long,
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * Error writing backfill data for a segment
+ */
+case class WriteError(
+    segmentId: Long,
+    outputPath: String,
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * Error with Spark configuration or join strategy
+ */
+case class SparkConfigError(
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+/**
+ * General unexpected error during backfill
+ */
+case class UnexpectedError(
+    message: String,
+    cause: Option[Throwable] = None
+) extends BackfillError
+
+object BackfillError {
+  /**
+   * Helper to create error from exception
+   */
+  def fromException(e: Throwable): BackfillError = {
+    UnexpectedError(
+      message = s"Unexpected error: ${e.getMessage}",
+      cause = Some(e)
+    )
+  }
+
+  /**
+   * Helper to create connection error from exception
+   */
+  def connectionError(message: String, e: Throwable): ConnectionError = {
+    ConnectionError(message, Some(e))
+  }
+
+  /**
+   * Helper to create schema validation error
+   */
+  def schemaError(message: String): SchemaValidationError = {
+    SchemaValidationError(message)
+  }
+
+  /**
+   * Helper to create data read error
+   */
+  def dataReadError(path: String, message: String, e: Option[Throwable] = None): DataReadError = {
+    DataReadError(path, message, e)
+  }
+
+  /**
+   * Helper to create segment processing error
+   */
+  def segmentError(segmentId: Long, message: String, e: Throwable): SegmentProcessingError = {
+    SegmentProcessingError(segmentId, message, Some(e))
+  }
+
+  /**
+   * Helper to create write error
+   */
+  def writeError(segmentId: Long, path: String, message: String, e: Throwable): WriteError = {
+    WriteError(segmentId, path, message, Some(e))
+  }
+}

--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -1,0 +1,112 @@
+package com.zilliz.spark.connector.operations.backfill
+
+/**
+ * Result of backfilling a single segment
+ */
+case class SegmentBackfillResult(
+    segmentId: Long,
+    rowCount: Long,
+    manifestPaths: Seq[String],
+    outputPath: String,
+    executionTimeMs: Long
+)
+
+/**
+ * Comprehensive result of backfill operation
+ */
+case class BackfillResult(
+    success: Boolean,
+    segmentsProcessed: Int,
+    totalRowsWritten: Long,
+    manifestPaths: Seq[String],
+    segmentResults: Map[Long, SegmentBackfillResult],
+    executionTimeMs: Long,
+    collectionId: Long,
+    partitionId: Long,
+    newFieldNames: Seq[String]
+) {
+  /**
+   * Get a summary string of the backfill operation
+   */
+  def summary: String = {
+    s"""Backfill Summary:
+       |  Status: ${if (success) "SUCCESS" else "FAILED"}
+       |  Segments Processed: $segmentsProcessed
+       |  Total Rows Written: $totalRowsWritten
+       |  Execution Time: ${executionTimeMs}ms
+       |  Collection ID: $collectionId
+       |  Partition ID: $partitionId
+       |  New Fields: ${newFieldNames.mkString(", ")}
+       |  Manifest Paths: ${manifestPaths.size} files
+       |""".stripMargin
+  }
+
+  /**
+   * Get detailed per-segment results
+   */
+  def segmentSummary: String = {
+    val segmentLines = segmentResults.toSeq.sortBy(_._1).map { case (segId, result) =>
+      s"    Segment $segId: ${result.rowCount} rows, ${result.executionTimeMs}ms, ${result.manifestPaths.size} manifests"
+    }
+    s"Segment Details:\n${segmentLines.mkString("\n")}"
+  }
+
+  /**
+   * Check if all segments were processed successfully
+   */
+  def allSegmentsSuccessful: Boolean = success && segmentsProcessed == segmentResults.size
+
+  /**
+   * Get total execution time in seconds
+   */
+  def executionTimeSec: Double = executionTimeMs / 1000.0
+}
+
+object BackfillResult {
+  /**
+   * Create a successful result
+   */
+  def success(
+      segmentResults: Map[Long, SegmentBackfillResult],
+      executionTimeMs: Long,
+      collectionId: Long,
+      partitionId: Long,
+      newFieldNames: Seq[String]
+  ): BackfillResult = {
+    val totalRows = segmentResults.values.map(_.rowCount).sum
+    val allManifests = segmentResults.values.flatMap(_.manifestPaths).toSeq
+
+    BackfillResult(
+      success = true,
+      segmentsProcessed = segmentResults.size,
+      totalRowsWritten = totalRows,
+      manifestPaths = allManifests,
+      segmentResults = segmentResults,
+      executionTimeMs = executionTimeMs,
+      collectionId = collectionId,
+      partitionId = partitionId,
+      newFieldNames = newFieldNames
+    )
+  }
+
+  /**
+   * Create a failed result
+   */
+  def failure(
+      executionTimeMs: Long,
+      collectionId: Long = -1,
+      partitionId: Long = -1
+  ): BackfillResult = {
+    BackfillResult(
+      success = false,
+      segmentsProcessed = 0,
+      totalRowsWritten = 0,
+      manifestPaths = Seq.empty,
+      segmentResults = Map.empty,
+      executionTimeMs = executionTimeMs,
+      collectionId = collectionId,
+      partitionId = partitionId,
+      newFieldNames = Seq.empty
+    )
+  }
+}

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1,0 +1,569 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.slf4j.LoggerFactory
+
+import com.zilliz.spark.connector.write.{MilvusLoonBatchWrite, MilvusLoonCommitMessage, MilvusLoonWriter}
+import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusOption}
+
+import scala.collection.JavaConverters._
+
+
+/**
+ * Backfill operation for Milvus collections
+ *
+ * This object provides functionality to backfill new fields into existing Milvus collections
+ * by reading the original data, joining with new field data, and writing per-segment binlog files.
+ */
+object MilvusBackfill {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Backfill new fields into a Milvus collection
+   *
+   * @param spark SparkSession
+   * @param backfillDataPath Path to Parquet file containing new field data with schema (pk, new_field1, new_field2, ...)
+   * @param config Backfill configuration
+   * @return Either error or successful result
+   */
+  def run(
+      spark: SparkSession,
+      backfillDataPath: String,
+      config: BackfillConfig
+  ): Either[BackfillError, BackfillResult] = {
+
+    val startTime = System.currentTimeMillis()
+
+    // Validate configuration
+    config.validate() match {
+      case Left(error) => return Left(SchemaValidationError(s"Invalid configuration: $error"))
+      case Right(_) => // Continue
+    }
+
+    try {
+      // Read backfill data from Parquet
+      val backfillDF = readBackfillData(spark, backfillDataPath) match {
+        case Left(error) => return Left(error)
+        case Right(df) => df
+      }
+
+      // Read original collection data with segment metadata
+      val originalDF = readCollectionWithMetadata(spark, config) match {
+        case Left(error) => return Left(error)
+        case Right(df) => df
+      }
+
+      // Validate schema compatibility and get primary key name
+      val pkName = validateSchemaCompatibility(originalDF, backfillDF, config) match {
+        case Left(error) => return Left(error)
+        case Right(name) => name
+      }
+
+      // Perform Sort Merge Join
+      val joinedDF = performJoin(originalDF, backfillDF, pkName)
+
+      // Retrieve Milvus metadata (collection ID, partition ID)
+      // TODO: Currently get through milvus client, once Milvus snapshot feature is ready,
+      // we can get the collection ID and partition ID from the snapshot file.
+      val (collectionID, partitionID) = retrieveMilvusMetadata(config) match {
+        case Left(error) => return Left(error)
+        case Right(ids) => ids
+      }
+
+      // Extract new field names
+      val newFieldNames = backfillDF.schema.fields
+        .map(_.name)
+        .filterNot(_ == "pk")
+        .toSeq
+
+      // Process each segment
+      val segmentResults = processSegments(
+        spark,
+        joinedDF,
+        collectionID,
+        partitionID,
+        config,
+        newFieldNames
+      ) match {
+        case Left(error) => return Left(error)
+        case Right(results) => results
+      }
+
+      // Build final result
+      val executionTime = System.currentTimeMillis() - startTime
+      val result = BackfillResult.success(
+        segmentResults = segmentResults,
+        executionTimeMs = executionTime,
+        collectionId = collectionID,
+        partitionId = partitionID,
+        newFieldNames = newFieldNames
+      )
+
+      Right(result)
+
+    } catch {
+      case e: Exception =>
+        val executionTime = System.currentTimeMillis() - startTime
+        logger.error("Backfill operation failed", e)
+        Left(BackfillError.fromException(e))
+    }
+  }
+
+  /**
+   * Read backfill data from Parquet file
+   */
+  private def readBackfillData(
+      spark: SparkSession,
+      path: String
+  ): Either[BackfillError, DataFrame] = {
+    try {
+      val df = spark.read.parquet(path)
+
+      // Validate that it has a 'pk' column
+      if (!df.columns.contains("pk")) {
+        return Left(DataReadError(
+          path = path,
+          message = "Backfill data must contain a 'pk' column"
+        ))
+      }
+
+      // Validate that it has at least one other column
+      if (df.columns.length < 2) {
+        return Left(DataReadError(
+          path = path,
+          message = "New field data must contain at least one field besides 'pk'"
+        ))
+      }
+
+      Right(df)
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to read Parquet file from $path", e)
+        Left(DataReadError(
+          path = path,
+          message = s"Failed to read Parquet file: ${e.getMessage}",
+          cause = Some(e)
+        ))
+    }
+  }
+
+  /**
+   * Read collection data with segment_id and row_offset metadata
+   * segment_id and row_offset are used to match with the original sequence of rows for each segment
+   */
+  private def readCollectionWithMetadata(
+      spark: SparkSession,
+      config: BackfillConfig
+  ): Either[BackfillError, DataFrame] = {
+    try {
+      val options = config.getMilvusReadOptions
+      val df = spark.read
+        .format("milvus")
+        .options(options)
+        .load()
+
+      // Validate that segment_id and row_offset are present
+      if (!df.columns.contains("segment_id") || !df.columns.contains("row_offset")) {
+        return Left(ConnectionError(
+          message = "Failed to read collection data with segment_id and row_offset. " +
+            "Ensure milvus.extra.columns is set correctly."
+        ))
+      }
+
+      Right(df)
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to read Milvus collection ${config.collectionName}", e)
+        Left(ConnectionError(
+          message = s"Failed to read Milvus collection ${config.collectionName}: ${e.getMessage}",
+          cause = Some(e)
+        ))
+    }
+  }
+
+  /**
+   * Validate schema compatibility between original and new field data
+   * Returns the primary key field name if validation succeeds
+   */
+  private def validateSchemaCompatibility(
+      originalDF: DataFrame,
+      backfillDF: DataFrame,
+      config: BackfillConfig
+  ): Either[BackfillError, String] = {
+    // Get the actual primary key field name from Milvus collection
+    var client: MilvusClient = null
+    try {
+      client = MilvusClient(
+        MilvusConnectionParams(
+          uri = config.milvusUri,
+          token = config.milvusToken,
+          databaseName = config.databaseName
+        )
+      )
+
+      val pkName = client.getPKName(config.databaseName, config.collectionName) match {
+        case scala.util.Success(name) => name
+        case scala.util.Failure(e) =>
+          return Left(ConnectionError(
+            message = s"Failed to get primary key name for collection ${config.collectionName}: ${e.getMessage}",
+            cause = Some(e)
+          ))
+      }
+
+      // Find the primary key field in original data
+      val pkField = originalDF.schema.fields.find(_.name == pkName)
+        .getOrElse {
+          return Left(SchemaValidationError(
+            s"Original collection data must have primary key field '$pkName'"
+          ))
+        }
+
+      // Find the pk field in new field data
+      val newPkField = backfillDF.schema.fields.find(_.name == "pk")
+        .getOrElse {
+          return Left(SchemaValidationError("New field data must have 'pk' field"))
+        }
+
+      // Validate types match
+      if (pkField.dataType != newPkField.dataType) {
+        return Left(SchemaValidationError(
+          s"Primary key type mismatch: original=${pkField.dataType}, new=${newPkField.dataType}"
+        ))
+      }
+
+      Right(pkName)
+
+    } catch {
+      case e: Exception =>
+        logger.error("Failed to validate schema compatibility", e)
+        Left(ConnectionError(
+          message = s"Failed to validate schema compatibility: ${e.getMessage}",
+          cause = Some(e)
+        ))
+    } finally {
+      if (client != null) {
+        try {
+          client.close()
+        } catch {
+          case _: Exception => // Ignore close errors
+        }
+      }
+    }
+  }
+
+  /**
+   * Perform left join between original and new field data
+   */
+  private def performJoin(
+      originalDF: DataFrame,
+      backfillDF: DataFrame,
+      pkName: String
+  ): DataFrame = {
+    originalDF.join(backfillDF, originalDF(pkName) === backfillDF("pk"), "left")
+  }
+
+  /**
+   * Retrieve Milvus metadata (collection ID, partition ID)
+   */
+  private def retrieveMilvusMetadata(
+      config: BackfillConfig
+  ): Either[BackfillError, (Long, Long)] = {
+    var client: MilvusClient = null
+    try {
+      client = MilvusClient(
+        MilvusConnectionParams(
+          uri = config.milvusUri,
+          token = config.milvusToken,
+          databaseName = config.databaseName
+        )
+      )
+
+      val segments = client.getSegments(config.databaseName, config.collectionName)
+        .getOrElse {
+          return Left(ConnectionError(
+            message = s"No segments found for collection ${config.collectionName}"
+          ))
+        }
+
+      if (segments.isEmpty) {
+        return Left(ConnectionError(
+          message = s"Collection ${config.collectionName} has no segments"
+        ))
+      }
+
+      val firstSegment = segments.head
+      Right((firstSegment.collectionID, firstSegment.partitionID))
+
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to retrieve Milvus metadata for collection ${config.collectionName}", e)
+        Left(ConnectionError(
+          message = s"Failed to retrieve Milvus metadata: ${e.getMessage}",
+          cause = Some(e)
+        ))
+    } finally {
+      if (client != null) {
+        try {
+          client.close()
+        } catch {
+          case _: Exception => // Ignore close errors
+        }
+      }
+    }
+  }
+
+  /**
+   * Process each segment separately by distributing to Spark executors
+   * Each segment is processed by exactly one FFI writer on a single executor
+   */
+  private def processSegments(
+      spark: SparkSession,
+      joinedDF: DataFrame,
+      collectionID: Long,
+      partitionID: Long,
+      config: BackfillConfig,
+      newFieldNames: Seq[String]
+  ): Either[BackfillError, Map[Long, SegmentBackfillResult]] = {
+
+    try {
+      // Prepare data: select only needed columns and add segment_id for partitioning
+      val preparedDF = joinedDF
+        .select((Seq("segment_id", "row_offset") ++ newFieldNames).map(col): _*)
+
+      // Repartition by segment_id to ensure all rows of same segment go to same partition
+      // Sort within partitions to maintain row_offset order
+      val repartitionedDF = preparedDF
+        .repartition(col("segment_id"))
+        .sortWithinPartitions("segment_id", "row_offset")
+
+      // Get the schema for new fields only (without segment_id and row_offset)
+      val targetSchema = org.apache.spark.sql.types.StructType(
+        newFieldNames.map(fieldName =>
+          preparedDF.schema.fields.find(_.name == fieldName).get
+        )
+      )
+
+      // Broadcast configuration to executors
+      val broadcastConfig = spark.sparkContext.broadcast(config)
+      val broadcastCollectionID = spark.sparkContext.broadcast(collectionID)
+      val broadcastPartitionID = spark.sparkContext.broadcast(partitionID)
+      val broadcastTargetSchema = spark.sparkContext.broadcast(targetSchema)
+
+      // Get the underlying RDD[InternalRow] for efficient processing
+      val internalRowRDD = repartitionedDF.queryExecution.toRdd
+
+      // Process each partition (which may contain one or more segments)
+      // Each segment will be written by exactly one FFI writer
+      val results = internalRowRDD.mapPartitions { iter =>
+        if (!iter.hasNext) {
+          // Empty partition
+          Iterator.empty
+        } else {
+          val cfg = broadcastConfig.value
+          val collID = broadcastCollectionID.value
+          val partID = broadcastPartitionID.value
+          val schema = broadcastTargetSchema.value
+
+          // Group rows by segment_id within this partition
+          val segmentGroups = groupRowsBySegmentId(iter)
+
+          // Process each segment in this partition
+          segmentGroups.map { case (segmentID, rows) =>
+            processSegmentWithWriter(
+              segmentID = segmentID,
+              rows = rows,
+              collectionID = collID,
+              partitionID = partID,
+              config = cfg,
+              targetSchema = schema
+            )
+          }
+        }
+      }.collect()
+
+      // Cleanup broadcast variables
+      broadcastConfig.unpersist()
+      broadcastCollectionID.unpersist()
+      broadcastPartitionID.unpersist()
+      broadcastTargetSchema.unpersist()
+
+      // Check for failures
+      val failures = results.filter(_._2.isDefined)
+      if (failures.nonEmpty) {
+        val firstFailure = failures.head
+        val error = firstFailure._2.get
+        return Left(WriteError(
+          segmentId = firstFailure._1.segmentId,
+          outputPath = firstFailure._1.outputPath,
+          message = s"Failed to write ${failures.length} segment(s): ${error.getMessage}",
+          cause = Some(error)
+        ))
+      }
+
+      // Extract successful results
+      val successfulResults = results.map { case (result, _) =>
+        result.segmentId -> result
+      }.toMap
+
+      // Log summary statistics
+      val totalTime = results.map(_._1.executionTimeMs).sum
+      val avgTime = if (results.nonEmpty) totalTime / results.length else 0
+      val totalRows = results.map(_._1.rowCount).sum
+
+      logger.info("=== Backfill Summary ===")
+      logger.info(s"Total segments: ${results.length}")
+      logger.info(s"Total rows processed: $totalRows")
+      logger.info(s"Total time for all segments: ${totalTime}ms")
+      logger.info(s"Average time per segment: ${avgTime}ms")
+
+      Right(successfulResults)
+
+    } catch {
+      case e: Exception =>
+        logger.error("Failed to process segments", e)
+        Left(SegmentProcessingError(
+          segmentId = -1,
+          message = s"Failed to process segments: ${e.getMessage}",
+          cause = Some(e)
+        ))
+    }
+  }
+
+  /**
+   * Group InternalRows by segment_id
+   * Assumes rows are already sorted by segment_id (from sortWithinPartitions)
+   */
+  private def groupRowsBySegmentId(
+      iter: Iterator[org.apache.spark.sql.catalyst.InternalRow]
+  ): Iterator[(Long, Seq[org.apache.spark.sql.catalyst.InternalRow])] = {
+    if (!iter.hasNext) {
+      return Iterator.empty
+    }
+
+    // Use a mutable buffer to accumulate rows for current segment
+    val buffer = scala.collection.mutable.ListBuffer[(Long, Seq[org.apache.spark.sql.catalyst.InternalRow])]()
+    var currentSegmentID: Long = -1
+    var currentRows = scala.collection.mutable.ListBuffer[org.apache.spark.sql.catalyst.InternalRow]()
+
+    iter.foreach { row =>
+      val segmentID = row.getLong(0) // segment_id is first column
+
+      if (currentSegmentID == -1) {
+        // First row
+        currentSegmentID = segmentID
+        currentRows += row.copy() // Copy to avoid mutation
+      } else if (segmentID == currentSegmentID) {
+        // Same segment, accumulate
+        currentRows += row.copy()
+      } else {
+        // New segment, flush previous
+        buffer += ((currentSegmentID, currentRows.toSeq))
+        currentSegmentID = segmentID
+        currentRows = scala.collection.mutable.ListBuffer(row.copy())
+      }
+    }
+
+    // Flush last segment
+    if (currentRows.nonEmpty) {
+      buffer += ((currentSegmentID, currentRows.toSeq))
+    }
+
+    buffer.iterator
+  }
+
+  /**
+   * Process a single segment using MilvusLoonWriter
+   * Creates one FFI writer per segment for thread safety
+   */
+  private def processSegmentWithWriter(
+      segmentID: Long,
+      rows: Seq[org.apache.spark.sql.catalyst.InternalRow],
+      collectionID: Long,
+      partitionID: Long,
+      config: BackfillConfig,
+      targetSchema: org.apache.spark.sql.types.StructType
+  ): (SegmentBackfillResult, Option[Throwable]) = {
+
+    val segmentStartTime = System.currentTimeMillis()
+
+    try {
+      // Get write options for this segment
+      val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
+      val outputPath = writeOptions("milvus.writer.customPath")
+
+      logger.info(s"Executor processing segment $segmentID: ${rows.length} rows -> $outputPath")
+
+      // Create MilvusOption from write options
+      val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
+      val milvusOption = MilvusOption(optionsMap)
+
+      // Create batch write infrastructure
+      val batchWrite = new MilvusLoonBatchWrite(targetSchema, milvusOption)
+      val writerFactory = batchWrite.createBatchWriterFactory(null)
+
+      // Create a single writer for this segment
+      val writer = writerFactory.createWriter(0, System.currentTimeMillis())
+
+      try {
+        // Write all rows for this segment
+        // Extract only the new field columns (skip segment_id and row_offset)
+        rows.foreach { row =>
+          // Create a new InternalRow with only the target fields (columns 2+)
+          val targetRow = new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(
+            (2 until row.numFields).map(i => row.get(i, targetSchema.fields(i - 2).dataType)).toArray
+          )
+          writer.write(targetRow)
+        }
+
+        // Commit the writer
+        val commitMessage = writer.commit()
+
+        // Extract manifest path from commit message
+        val manifestPaths = commitMessage match {
+          case msg: MilvusLoonCommitMessage => Seq(msg.manifestPath)
+          case _ => Seq.empty
+        }
+
+        val segmentExecutionTime = System.currentTimeMillis() - segmentStartTime
+
+        logger.info(s"Segment $segmentID completed successfully in ${segmentExecutionTime}ms")
+        logger.info(s"Segment $segmentID manifest paths: ${manifestPaths.mkString(", ")}")
+
+        // Commit the batch write
+        batchWrite.commit(Array(commitMessage))
+
+        (SegmentBackfillResult(
+          segmentId = segmentID,
+          rowCount = rows.length.toLong,
+          manifestPaths = manifestPaths,
+          outputPath = outputPath,
+          executionTimeMs = segmentExecutionTime
+        ), None)
+
+      } catch {
+        case e: Exception =>
+          writer.abort()
+          throw e
+      } finally {
+        writer.close()
+      }
+
+    } catch {
+      case e: Exception =>
+        val segmentExecutionTime = System.currentTimeMillis() - segmentStartTime
+        logger.error(s"Segment $segmentID failed after ${segmentExecutionTime}ms", e)
+
+        (SegmentBackfillResult(
+          segmentId = segmentID,
+          rowCount = rows.length.toLong,
+          manifestPaths = Seq.empty,
+          outputPath = "",
+          executionTimeMs = segmentExecutionTime
+        ), Some(e))
+    }
+  }
+}

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -23,7 +23,7 @@ private class SegmentStreamingIterator(
     iter: Iterator[InternalRow],
     config: BackfillConfig,
     collectionID: Long,
-    partitionID: Long,
+    segmentToPartitionMap: Map[Long, Long],
     targetSchema: org.apache.spark.sql.types.StructType
 ) extends Iterator[(SegmentBackfillResult, Option[Throwable])] {
 
@@ -96,11 +96,16 @@ private class SegmentStreamingIterator(
     currentNullRowCount = 0
     currentSegmentStartTime = System.currentTimeMillis()
 
+    // Look up partition ID for this segment
+    val partitionID = segmentToPartitionMap.getOrElse(segmentID, {
+      throw new IllegalStateException(s"Partition ID not found for segment $segmentID")
+    })
+
     // Create writer for this segment
     val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
     currentOutputPath = writeOptions("milvus.writer.customPath")
 
-    logger.debug(s"Executor starting segment $segmentID -> $currentOutputPath")
+    logger.debug(s"Executor starting segment $segmentID (partition $partitionID) -> $currentOutputPath")
 
     val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
     val milvusOption = MilvusOption(optionsMap)
@@ -145,6 +150,11 @@ private class SegmentStreamingIterator(
     val outputPath = currentOutputPath
     val startTime = currentSegmentStartTime
 
+    // Look up partition ID for this segment
+    val partitionID = segmentToPartitionMap.getOrElse(segmentID, {
+      throw new IllegalStateException(s"Partition ID not found for segment $segmentID")
+    })
+
     currentWriter match {
       case Some(writer) =>
         try {
@@ -160,7 +170,7 @@ private class SegmentStreamingIterator(
           val executionTime = System.currentTimeMillis() - startTime
           val joinedRowCount = rowCount - nullRowCount
 
-          logger.debug(s"Segment $segmentID completed successfully in ${executionTime}ms")
+          logger.debug(s"Segment $segmentID (partition $partitionID) completed successfully in ${executionTime}ms")
           logger.debug(s"Segment $segmentID rows: total=$rowCount, joined=$joinedRowCount, un-joined(nulls)=$nullRowCount")
           logger.debug(s"Segment $segmentID manifest paths: ${manifestPaths.mkString(", ")}")
 
@@ -185,7 +195,7 @@ private class SegmentStreamingIterator(
         } catch {
           case e: Exception =>
             val executionTime = System.currentTimeMillis() - startTime
-            logger.error(s"Segment $segmentID failed after ${executionTime}ms", e)
+            logger.error(s"Segment $segmentID (partition $partitionID) failed after ${executionTime}ms", e)
             writer.abort()
             writer.close()
             currentWriter = None
@@ -237,7 +247,17 @@ object MilvusBackfill {
       case Right(_) => // Continue
     }
 
+    // Create Milvus client once for all operations
+    var client: MilvusClient = null
     try {
+      client = MilvusClient(
+        MilvusConnectionParams(
+          uri = config.milvusUri,
+          token = config.milvusToken,
+          databaseName = config.databaseName
+        )
+      )
+
       // Read backfill data from Parquet
       val backfillDF = readBackfillData(spark, backfillDataPath) match {
         case Left(error) => return Left(error)
@@ -251,7 +271,7 @@ object MilvusBackfill {
       }
 
       // Validate schema compatibility and get primary key name
-      val pkName = validateSchemaCompatibility(originalDF, backfillDF, config) match {
+      val pkName = validateSchemaCompatibility(originalDF, backfillDF, config, client) match {
         case Left(error) => return Left(error)
         case Right(name) => name
       }
@@ -259,12 +279,12 @@ object MilvusBackfill {
       // Perform Sort Merge Join
       val joinedDF = performJoin(originalDF, backfillDF, pkName)
 
-      // Retrieve Milvus metadata (collection ID, partition ID)
+      // Retrieve Milvus metadata (collection ID and segment-to-partition mapping)
       // TODO: Currently get through milvus client, once Milvus snapshot feature is ready,
-      // we can get the collection ID and partition ID from the snapshot file.
-      val (collectionID, partitionID) = retrieveMilvusMetadata(config) match {
+      // we can get the collection ID and segment-to-partition mapping from the snapshot file.
+      val (collectionID, segmentToPartitionMap) = retrieveMilvusMetadata(config, client) match {
         case Left(error) => return Left(error)
-        case Right(ids) => ids
+        case Right(metadata) => metadata
       }
 
       // Extract new field names
@@ -278,7 +298,7 @@ object MilvusBackfill {
         spark,
         joinedDF,
         collectionID,
-        partitionID,
+        segmentToPartitionMap,
         config,
         newFieldNames
       ) match {
@@ -288,11 +308,15 @@ object MilvusBackfill {
 
       // Build final result
       val executionTime = System.currentTimeMillis() - startTime
+
+      // Get all unique partition IDs that were processed
+      val partitionIDs = segmentToPartitionMap.values.toSet
+
       val result = BackfillResult.success(
         segmentResults = segmentResults,
         executionTimeMs = executionTime,
         collectionId = collectionID,
-        partitionId = partitionID,
+        partitionId = if (partitionIDs.size == 1) partitionIDs.head else -1, // -1 indicates multi-partition
         newFieldNames = newFieldNames
       )
 
@@ -303,6 +327,15 @@ object MilvusBackfill {
         val executionTime = System.currentTimeMillis() - startTime
         logger.error("Backfill operation failed", e)
         Left(BackfillError.fromException(e))
+    } finally {
+      if (client != null) {
+        try {
+          client.close()
+        } catch {
+          case e: Exception =>
+            logger.warn("Failed to close Milvus client", e)
+        }
+      }
     }
   }
 
@@ -385,19 +418,11 @@ object MilvusBackfill {
   private def validateSchemaCompatibility(
       originalDF: DataFrame,
       backfillDF: DataFrame,
-      config: BackfillConfig
+      config: BackfillConfig,
+      client: MilvusClient
   ): Either[BackfillError, String] = {
-    // Get the actual primary key field name from Milvus collection
-    var client: MilvusClient = null
     try {
-      client = MilvusClient(
-        MilvusConnectionParams(
-          uri = config.milvusUri,
-          token = config.milvusToken,
-          databaseName = config.databaseName
-        )
-      )
-
+      // Get the actual primary key field name from Milvus collection
       val pkName = client.getPKName(config.databaseName, config.collectionName) match {
         case scala.util.Success(name) => name
         case scala.util.Failure(e) =>
@@ -437,14 +462,6 @@ object MilvusBackfill {
           message = s"Failed to validate schema compatibility: ${e.getMessage}",
           cause = Some(e)
         ))
-    } finally {
-      if (client != null) {
-        try {
-          client.close()
-        } catch {
-          case _: Exception => // Ignore close errors
-        }
-      }
     }
   }
 
@@ -460,21 +477,14 @@ object MilvusBackfill {
   }
 
   /**
-   * Retrieve Milvus metadata (collection ID, partition ID)
+   * Retrieve Milvus metadata (collection ID and segment-to-partition mapping)
+   * Supports multi-partition collections by tracking partition ID for each segment
    */
   private def retrieveMilvusMetadata(
-      config: BackfillConfig
-  ): Either[BackfillError, (Long, Long)] = {
-    var client: MilvusClient = null
+      config: BackfillConfig,
+      client: MilvusClient
+  ): Either[BackfillError, (Long, Map[Long, Long])] = {
     try {
-      client = MilvusClient(
-        MilvusConnectionParams(
-          uri = config.milvusUri,
-          token = config.milvusToken,
-          databaseName = config.databaseName
-        )
-      )
-
       val segments = client.getSegments(config.databaseName, config.collectionName)
         .getOrElse {
           return Left(ConnectionError(
@@ -488,8 +498,16 @@ object MilvusBackfill {
         ))
       }
 
-      val firstSegment = segments.head
-      Right((firstSegment.collectionID, firstSegment.partitionID))
+      val collectionID = segments.head.collectionID
+
+      // Build mapping of segment ID -> partition ID to support multi-partition collections
+      val segmentToPartitionMap = segments.map { seg =>
+        seg.segmentID -> seg.partitionID
+      }.toMap
+
+      logger.info(s"Retrieved metadata for ${segments.length} segments across ${segmentToPartitionMap.values.toSet.size} partition(s)")
+
+      Right((collectionID, segmentToPartitionMap))
 
     } catch {
       case e: Exception =>
@@ -498,26 +516,19 @@ object MilvusBackfill {
           message = s"Failed to retrieve Milvus metadata: ${e.getMessage}",
           cause = Some(e)
         ))
-    } finally {
-      if (client != null) {
-        try {
-          client.close()
-        } catch {
-          case _: Exception => // Ignore close errors
-        }
-      }
     }
   }
 
   /**
    * Process each segment separately by distributing to Spark executors
    * Each segment is processed by exactly one FFI writer on a single executor
+   * Supports multi-partition collections by tracking partition ID per segment
    */
   private def processSegments(
       spark: SparkSession,
       joinedDF: DataFrame,
       collectionID: Long,
-      partitionID: Long,
+      segmentToPartitionMap: Map[Long, Long],
       config: BackfillConfig,
       newFieldNames: Seq[String]
   ): Either[BackfillError, Map[Long, SegmentBackfillResult]] = {
@@ -543,7 +554,7 @@ object MilvusBackfill {
       // Broadcast configuration to executors
       val broadcastConfig = spark.sparkContext.broadcast(config)
       val broadcastCollectionID = spark.sparkContext.broadcast(collectionID)
-      val broadcastPartitionID = spark.sparkContext.broadcast(partitionID)
+      val broadcastSegmentToPartitionMap = spark.sparkContext.broadcast(segmentToPartitionMap)
       val broadcastTargetSchema = spark.sparkContext.broadcast(targetSchema)
 
       // Get the underlying RDD[InternalRow] for efficient processing
@@ -559,17 +570,17 @@ object MilvusBackfill {
         } else {
           val cfg = broadcastConfig.value
           val collID = broadcastCollectionID.value
-          val partID = broadcastPartitionID.value
+          val segToPartMap = broadcastSegmentToPartitionMap.value
           val schema = broadcastTargetSchema.value
 
-          new SegmentStreamingIterator(iter, cfg, collID, partID, schema)
+          new SegmentStreamingIterator(iter, cfg, collID, segToPartMap, schema)
         }
       }.collect()
 
       // Cleanup broadcast variables
       broadcastConfig.unpersist()
       broadcastCollectionID.unpersist()
-      broadcastPartitionID.unpersist()
+      broadcastSegmentToPartitionMap.unpersist()
       broadcastTargetSchema.unpersist()
 
       // Check for failures

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -14,208 +14,6 @@ import scala.collection.JavaConverters._
 
 
 /**
- * Streaming iterator that processes rows segment-by-segment without buffering
- *
- * Creates and closes writers automatically as segment_id changes in the sorted iterator.
- * Tracks null counts for un-joined rows.
- */
-private class SegmentStreamingIterator(
-    iter: Iterator[InternalRow],
-    config: BackfillConfig,
-    collectionID: Long,
-    segmentToPartitionMap: Map[Long, Long],
-    targetSchema: org.apache.spark.sql.types.StructType
-) extends Iterator[(SegmentBackfillResult, Option[Throwable])] {
-
-  private val logger = LoggerFactory.getLogger(getClass)
-
-  private var currentSegmentID: Long = -1
-  private var currentWriter: Option[DataWriter[InternalRow]] = None
-  private var currentRowCount: Long = 0
-  private var currentNullRowCount: Long = 0
-  private var currentSegmentStartTime: Long = 0
-  private var currentOutputPath: String = ""
-  private var hasNextResult = false
-  private var nextResult: (SegmentBackfillResult, Option[Throwable]) = null
-
-  override def hasNext: Boolean = {
-    if (hasNextResult) {
-      true
-    } else if (iter.hasNext) {
-      true
-    } else {
-      // No more rows, flush final segment if exists
-      if (currentWriter.isDefined) {
-        nextResult = flushCurrentSegment()
-        hasNextResult = true
-        true
-      } else {
-        false
-      }
-    }
-  }
-
-  override def next(): (SegmentBackfillResult, Option[Throwable]) = {
-    if (hasNextResult) {
-      hasNextResult = false
-      nextResult
-    } else {
-      // Process rows until segment changes
-      while (iter.hasNext) {
-        val row = iter.next()
-        val segmentID = row.getLong(0) // segment_id is first column
-
-        if (currentSegmentID == -1) {
-          // First segment
-          startNewSegment(segmentID)
-          writeRow(row)
-        } else if (segmentID == currentSegmentID) {
-          // Same segment, continue writing
-          writeRow(row)
-        } else {
-          // New segment detected, flush current and start new
-          val result = flushCurrentSegment()
-          startNewSegment(segmentID)
-          writeRow(row)
-          return result
-        }
-      }
-
-      // No more rows, flush final segment
-      if (currentWriter.isDefined) {
-        flushCurrentSegment()
-      } else {
-        throw new NoSuchElementException("next on empty iterator")
-      }
-    }
-  }
-
-  private def startNewSegment(segmentID: Long): Unit = {
-    currentSegmentID = segmentID
-    currentRowCount = 0
-    currentNullRowCount = 0
-    currentSegmentStartTime = System.currentTimeMillis()
-
-    // Look up partition ID for this segment
-    val partitionID = segmentToPartitionMap.getOrElse(segmentID, {
-      throw new IllegalStateException(s"Partition ID not found for segment $segmentID")
-    })
-
-    // Create writer for this segment
-    val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
-    currentOutputPath = writeOptions("milvus.writer.customPath")
-
-    logger.debug(s"Executor starting segment $segmentID (partition $partitionID) -> $currentOutputPath")
-
-    val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
-    val milvusOption = MilvusOption(optionsMap)
-
-    val batchWrite = new MilvusLoonBatchWrite(targetSchema, milvusOption)
-    val writerFactory = batchWrite.createBatchWriterFactory(null)
-    val writer = writerFactory.createWriter(0, System.currentTimeMillis())
-
-    currentWriter = Some(writer)
-  }
-
-  /**
-   * Write a row to the current segment's writer
-   *
-   * Handles both joined and un-joined rows:
-   * - Joined rows: new field values from backfill data
-   * - Un-joined rows: NULL values for new fields (from left join)
-   */
-  private def writeRow(row: InternalRow): Unit = {
-    currentWriter.foreach { writer =>
-      // Create a new InternalRow with only the target fields (skip segment_id and row_offset)
-      // For un-joined rows, row.get() will return null for new field columns
-      val targetFields = (2 until row.numFields).map(i =>
-        row.get(i, targetSchema.fields(i - 2).dataType)
-      ).toArray
-
-      // Check if this is an un-joined row (all new fields are null)
-      if (targetFields.forall(_ == null)) {
-        currentNullRowCount += 1
-      }
-
-      val targetRow = new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(targetFields)
-      writer.write(targetRow)
-      currentRowCount += 1
-    }
-  }
-
-  private def flushCurrentSegment(): (SegmentBackfillResult, Option[Throwable]) = {
-    val segmentID = currentSegmentID
-    val rowCount = currentRowCount
-    val nullRowCount = currentNullRowCount
-    val outputPath = currentOutputPath
-    val startTime = currentSegmentStartTime
-
-    // Look up partition ID for this segment
-    val partitionID = segmentToPartitionMap.getOrElse(segmentID, {
-      throw new IllegalStateException(s"Partition ID not found for segment $segmentID")
-    })
-
-    currentWriter match {
-      case Some(writer) =>
-        try {
-          // Commit the writer
-          val commitMessage = writer.commit()
-
-          // Extract manifest path from commit message
-          val manifestPaths = commitMessage match {
-            case msg: MilvusLoonCommitMessage => Seq(msg.manifestPath)
-            case _ => Seq.empty
-          }
-
-          val executionTime = System.currentTimeMillis() - startTime
-          val joinedRowCount = rowCount - nullRowCount
-
-          logger.debug(s"Segment $segmentID (partition $partitionID) completed successfully in ${executionTime}ms")
-          logger.debug(s"Segment $segmentID rows: total=$rowCount, joined=$joinedRowCount, un-joined(nulls)=$nullRowCount")
-          logger.debug(s"Segment $segmentID manifest paths: ${manifestPaths.mkString(", ")}")
-
-          // Commit the batch write
-          val optionsMap = new CaseInsensitiveStringMap(
-            config.getS3WriteOptions(collectionID, partitionID, segmentID).asJava
-          )
-          val batchWrite = new MilvusLoonBatchWrite(targetSchema, MilvusOption(optionsMap))
-          batchWrite.commit(Array(commitMessage))
-
-          writer.close()
-          currentWriter = None
-
-          (SegmentBackfillResult(
-            segmentId = segmentID,
-            rowCount = rowCount,
-            manifestPaths = manifestPaths,
-            outputPath = outputPath,
-            executionTimeMs = executionTime
-          ), None)
-
-        } catch {
-          case e: Exception =>
-            val executionTime = System.currentTimeMillis() - startTime
-            logger.error(s"Segment $segmentID (partition $partitionID) failed after ${executionTime}ms", e)
-            writer.abort()
-            writer.close()
-            currentWriter = None
-
-            (SegmentBackfillResult(
-              segmentId = segmentID,
-              rowCount = rowCount,
-              manifestPaths = Seq.empty,
-              outputPath = outputPath,
-              executionTimeMs = executionTime
-            ), Some(e))
-        }
-
-      case None =>
-        throw new IllegalStateException("Attempting to flush segment without active writer")
-    }
-  }
-}
-
-/**
  * Backfill operation for Milvus collections
  *
  * This object provides functionality to backfill new fields into existing Milvus collections
@@ -538,12 +336,6 @@ object MilvusBackfill {
       val preparedDF = joinedDF
         .select((Seq("segment_id", "row_offset") ++ newFieldNames).map(col): _*)
 
-      // Repartition by segment_id to ensure all rows of same segment go to same partition
-      // Sort within partitions to maintain row_offset order
-      val repartitionedDF = preparedDF
-        .repartition(col("segment_id"))
-        .sortWithinPartitions("segment_id", "row_offset")
-
       // Get the schema for new fields only (without segment_id and row_offset)
       val targetSchema = org.apache.spark.sql.types.StructType(
         newFieldNames.map(fieldName =>
@@ -551,30 +343,31 @@ object MilvusBackfill {
         )
       )
 
+      val segmentIds = segmentToPartitionMap.keys.toArray
+      val segmentPartitioner = new SegmentPartitioner(segmentIds)
+
+      // Repartition using custom partitioner, then sort by row_offset within each partition
+      val repartitionedRDD = preparedDF.queryExecution.toRdd
+        .keyBy(_.getLong(0))  // segment_id is at index 0
+        .partitionBy(segmentPartitioner)
+        .values
+        .mapPartitions(iter => iter.toSeq.sortBy(_.getLong(1)).iterator)  // Sort by row_offset
+
       // Broadcast configuration to executors
       val broadcastConfig = spark.sparkContext.broadcast(config)
       val broadcastCollectionID = spark.sparkContext.broadcast(collectionID)
       val broadcastSegmentToPartitionMap = spark.sparkContext.broadcast(segmentToPartitionMap)
       val broadcastTargetSchema = spark.sparkContext.broadcast(targetSchema)
 
-      // Get the underlying RDD[InternalRow] for efficient processing
-      val internalRowRDD = repartitionedDF.queryExecution.toRdd
-
-      // Process each partition (which may contain one or more segments)
-      // Each segment will be written by exactly one FFI writer
-      // Stream processing: create/close writers as segment_id changes
-      val results = internalRowRDD.mapPartitions { iter =>
-        if (!iter.hasNext) {
-          // Empty partition
-          Iterator.empty
-        } else {
-          val cfg = broadcastConfig.value
-          val collID = broadcastCollectionID.value
-          val segToPartMap = broadcastSegmentToPartitionMap.value
-          val schema = broadcastTargetSchema.value
-
-          new SegmentStreamingIterator(iter, cfg, collID, segToPartMap, schema)
-        }
+      val results = repartitionedRDD.mapPartitions { iter =>
+        if (!iter.hasNext) Iterator.empty
+        else processSegmentPartition(
+          iter,
+          broadcastConfig.value,
+          broadcastCollectionID.value,
+          broadcastSegmentToPartitionMap.value,
+          broadcastTargetSchema.value
+        )
       }.collect()
 
       // Cleanup broadcast variables
@@ -622,6 +415,77 @@ object MilvusBackfill {
           message = s"Failed to process segments: ${e.getMessage}",
           cause = Some(e)
         ))
+    }
+  }
+
+  /**
+   * Process a single partition containing exactly one segment
+   * This is called by each Spark executor to write one segment's data
+   */
+  private def processSegmentPartition(
+      iter: Iterator[InternalRow],
+      config: BackfillConfig,
+      collectionID: Long,
+      segmentToPartitionMap: Map[Long, Long],
+      targetSchema: org.apache.spark.sql.types.StructType
+  ): Iterator[(SegmentBackfillResult, Option[Throwable])] = {
+
+    val firstRow = iter.next()
+    val segmentID = firstRow.getLong(0)
+    val partitionID = segmentToPartitionMap(segmentID)
+    val startTime = System.currentTimeMillis()
+
+    // Create writer
+    val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
+    val outputPath = writeOptions("milvus.writer.customPath")
+    val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
+    val batchWrite = new MilvusLoonBatchWrite(targetSchema, MilvusOption(optionsMap))
+    val writer = batchWrite.createBatchWriterFactory(null).createWriter(0, System.currentTimeMillis())
+
+    try {
+      var rowCount = 0L
+      var nullRowCount = 0L
+
+      def writeRow(row: InternalRow): Unit = {
+        val targetFields = (2 until row.numFields).map(i =>
+          row.get(i, targetSchema.fields(i - 2).dataType)
+        ).toArray
+        if (targetFields.forall(_ == null)) nullRowCount += 1
+        writer.write(new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(targetFields))
+        rowCount += 1
+      }
+
+      writeRow(firstRow)
+      iter.foreach(writeRow)
+
+      val commitMessage = writer.commit()
+      val manifestPaths = commitMessage match {
+        case msg: MilvusLoonCommitMessage => Seq(msg.manifestPath)
+        case _ => Seq.empty
+      }
+
+      batchWrite.commit(Array(commitMessage))
+      writer.close()
+
+      Iterator.single((SegmentBackfillResult(
+        segmentId = segmentID,
+        rowCount = rowCount,
+        manifestPaths = manifestPaths,
+        outputPath = outputPath,
+        executionTimeMs = System.currentTimeMillis() - startTime
+      ), None))
+
+    } catch {
+      case e: Exception =>
+        writer.abort()
+        writer.close()
+        Iterator.single((SegmentBackfillResult(
+          segmentId = segmentID,
+          rowCount = 0,
+          manifestPaths = Seq.empty,
+          outputPath = outputPath,
+          executionTimeMs = System.currentTimeMillis() - startTime
+        ), Some(e)))
     }
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.connector.write.DataWriter
 import org.slf4j.LoggerFactory
 
 import com.zilliz.spark.connector.write.{MilvusLoonBatchWrite, MilvusLoonCommitMessage, MilvusLoonWriter}
@@ -11,6 +12,198 @@ import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusO
 
 import scala.collection.JavaConverters._
 
+
+/**
+ * Streaming iterator that processes rows segment-by-segment without buffering
+ *
+ * Creates and closes writers automatically as segment_id changes in the sorted iterator.
+ * Tracks null counts for un-joined rows.
+ */
+private class SegmentStreamingIterator(
+    iter: Iterator[InternalRow],
+    config: BackfillConfig,
+    collectionID: Long,
+    partitionID: Long,
+    targetSchema: org.apache.spark.sql.types.StructType
+) extends Iterator[(SegmentBackfillResult, Option[Throwable])] {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private var currentSegmentID: Long = -1
+  private var currentWriter: Option[DataWriter[InternalRow]] = None
+  private var currentRowCount: Long = 0
+  private var currentNullRowCount: Long = 0
+  private var currentSegmentStartTime: Long = 0
+  private var currentOutputPath: String = ""
+  private var hasNextResult = false
+  private var nextResult: (SegmentBackfillResult, Option[Throwable]) = null
+
+  override def hasNext: Boolean = {
+    if (hasNextResult) {
+      true
+    } else if (iter.hasNext) {
+      true
+    } else {
+      // No more rows, flush final segment if exists
+      if (currentWriter.isDefined) {
+        nextResult = flushCurrentSegment()
+        hasNextResult = true
+        true
+      } else {
+        false
+      }
+    }
+  }
+
+  override def next(): (SegmentBackfillResult, Option[Throwable]) = {
+    if (hasNextResult) {
+      hasNextResult = false
+      nextResult
+    } else {
+      // Process rows until segment changes
+      while (iter.hasNext) {
+        val row = iter.next()
+        val segmentID = row.getLong(0) // segment_id is first column
+
+        if (currentSegmentID == -1) {
+          // First segment
+          startNewSegment(segmentID)
+          writeRow(row)
+        } else if (segmentID == currentSegmentID) {
+          // Same segment, continue writing
+          writeRow(row)
+        } else {
+          // New segment detected, flush current and start new
+          val result = flushCurrentSegment()
+          startNewSegment(segmentID)
+          writeRow(row)
+          return result
+        }
+      }
+
+      // No more rows, flush final segment
+      if (currentWriter.isDefined) {
+        flushCurrentSegment()
+      } else {
+        throw new NoSuchElementException("next on empty iterator")
+      }
+    }
+  }
+
+  private def startNewSegment(segmentID: Long): Unit = {
+    currentSegmentID = segmentID
+    currentRowCount = 0
+    currentNullRowCount = 0
+    currentSegmentStartTime = System.currentTimeMillis()
+
+    // Create writer for this segment
+    val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
+    currentOutputPath = writeOptions("milvus.writer.customPath")
+
+    logger.debug(s"Executor starting segment $segmentID -> $currentOutputPath")
+
+    val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
+    val milvusOption = MilvusOption(optionsMap)
+
+    val batchWrite = new MilvusLoonBatchWrite(targetSchema, milvusOption)
+    val writerFactory = batchWrite.createBatchWriterFactory(null)
+    val writer = writerFactory.createWriter(0, System.currentTimeMillis())
+
+    currentWriter = Some(writer)
+  }
+
+  /**
+   * Write a row to the current segment's writer
+   *
+   * Handles both joined and un-joined rows:
+   * - Joined rows: new field values from backfill data
+   * - Un-joined rows: NULL values for new fields (from left join)
+   */
+  private def writeRow(row: InternalRow): Unit = {
+    currentWriter.foreach { writer =>
+      // Create a new InternalRow with only the target fields (skip segment_id and row_offset)
+      // For un-joined rows, row.get() will return null for new field columns
+      val targetFields = (2 until row.numFields).map(i =>
+        row.get(i, targetSchema.fields(i - 2).dataType)
+      ).toArray
+
+      // Check if this is an un-joined row (all new fields are null)
+      if (targetFields.forall(_ == null)) {
+        currentNullRowCount += 1
+      }
+
+      val targetRow = new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(targetFields)
+      writer.write(targetRow)
+      currentRowCount += 1
+    }
+  }
+
+  private def flushCurrentSegment(): (SegmentBackfillResult, Option[Throwable]) = {
+    val segmentID = currentSegmentID
+    val rowCount = currentRowCount
+    val nullRowCount = currentNullRowCount
+    val outputPath = currentOutputPath
+    val startTime = currentSegmentStartTime
+
+    currentWriter match {
+      case Some(writer) =>
+        try {
+          // Commit the writer
+          val commitMessage = writer.commit()
+
+          // Extract manifest path from commit message
+          val manifestPaths = commitMessage match {
+            case msg: MilvusLoonCommitMessage => Seq(msg.manifestPath)
+            case _ => Seq.empty
+          }
+
+          val executionTime = System.currentTimeMillis() - startTime
+          val joinedRowCount = rowCount - nullRowCount
+
+          logger.debug(s"Segment $segmentID completed successfully in ${executionTime}ms")
+          logger.debug(s"Segment $segmentID rows: total=$rowCount, joined=$joinedRowCount, un-joined(nulls)=$nullRowCount")
+          logger.debug(s"Segment $segmentID manifest paths: ${manifestPaths.mkString(", ")}")
+
+          // Commit the batch write
+          val optionsMap = new CaseInsensitiveStringMap(
+            config.getS3WriteOptions(collectionID, partitionID, segmentID).asJava
+          )
+          val batchWrite = new MilvusLoonBatchWrite(targetSchema, MilvusOption(optionsMap))
+          batchWrite.commit(Array(commitMessage))
+
+          writer.close()
+          currentWriter = None
+
+          (SegmentBackfillResult(
+            segmentId = segmentID,
+            rowCount = rowCount,
+            manifestPaths = manifestPaths,
+            outputPath = outputPath,
+            executionTimeMs = executionTime
+          ), None)
+
+        } catch {
+          case e: Exception =>
+            val executionTime = System.currentTimeMillis() - startTime
+            logger.error(s"Segment $segmentID failed after ${executionTime}ms", e)
+            writer.abort()
+            writer.close()
+            currentWriter = None
+
+            (SegmentBackfillResult(
+              segmentId = segmentID,
+              rowCount = rowCount,
+              manifestPaths = Seq.empty,
+              outputPath = outputPath,
+              executionTimeMs = executionTime
+            ), Some(e))
+        }
+
+      case None =>
+        throw new IllegalStateException("Attempting to flush segment without active writer")
+    }
+  }
+}
 
 /**
  * Backfill operation for Milvus collections
@@ -358,6 +551,7 @@ object MilvusBackfill {
 
       // Process each partition (which may contain one or more segments)
       // Each segment will be written by exactly one FFI writer
+      // Stream processing: create/close writers as segment_id changes
       val results = internalRowRDD.mapPartitions { iter =>
         if (!iter.hasNext) {
           // Empty partition
@@ -368,20 +562,7 @@ object MilvusBackfill {
           val partID = broadcastPartitionID.value
           val schema = broadcastTargetSchema.value
 
-          // Group rows by segment_id within this partition
-          val segmentGroups = groupRowsBySegmentId(iter)
-
-          // Process each segment in this partition
-          segmentGroups.map { case (segmentID, rows) =>
-            processSegmentWithWriter(
-              segmentID = segmentID,
-              rows = rows,
-              collectionID = collID,
-              partitionID = partID,
-              config = cfg,
-              targetSchema = schema
-            )
-          }
+          new SegmentStreamingIterator(iter, cfg, collID, partID, schema)
         }
       }.collect()
 
@@ -433,137 +614,4 @@ object MilvusBackfill {
     }
   }
 
-  /**
-   * Group InternalRows by segment_id
-   * Assumes rows are already sorted by segment_id (from sortWithinPartitions)
-   */
-  private def groupRowsBySegmentId(
-      iter: Iterator[org.apache.spark.sql.catalyst.InternalRow]
-  ): Iterator[(Long, Seq[org.apache.spark.sql.catalyst.InternalRow])] = {
-    if (!iter.hasNext) {
-      return Iterator.empty
-    }
-
-    // Use a mutable buffer to accumulate rows for current segment
-    val buffer = scala.collection.mutable.ListBuffer[(Long, Seq[org.apache.spark.sql.catalyst.InternalRow])]()
-    var currentSegmentID: Long = -1
-    var currentRows = scala.collection.mutable.ListBuffer[org.apache.spark.sql.catalyst.InternalRow]()
-
-    iter.foreach { row =>
-      val segmentID = row.getLong(0) // segment_id is first column
-
-      if (currentSegmentID == -1) {
-        // First row
-        currentSegmentID = segmentID
-        currentRows += row.copy() // Copy to avoid mutation
-      } else if (segmentID == currentSegmentID) {
-        // Same segment, accumulate
-        currentRows += row.copy()
-      } else {
-        // New segment, flush previous
-        buffer += ((currentSegmentID, currentRows.toSeq))
-        currentSegmentID = segmentID
-        currentRows = scala.collection.mutable.ListBuffer(row.copy())
-      }
-    }
-
-    // Flush last segment
-    if (currentRows.nonEmpty) {
-      buffer += ((currentSegmentID, currentRows.toSeq))
-    }
-
-    buffer.iterator
-  }
-
-  /**
-   * Process a single segment using MilvusLoonWriter
-   * Creates one FFI writer per segment for thread safety
-   */
-  private def processSegmentWithWriter(
-      segmentID: Long,
-      rows: Seq[org.apache.spark.sql.catalyst.InternalRow],
-      collectionID: Long,
-      partitionID: Long,
-      config: BackfillConfig,
-      targetSchema: org.apache.spark.sql.types.StructType
-  ): (SegmentBackfillResult, Option[Throwable]) = {
-
-    val segmentStartTime = System.currentTimeMillis()
-
-    try {
-      // Get write options for this segment
-      val writeOptions = config.getS3WriteOptions(collectionID, partitionID, segmentID)
-      val outputPath = writeOptions("milvus.writer.customPath")
-
-      logger.info(s"Executor processing segment $segmentID: ${rows.length} rows -> $outputPath")
-
-      // Create MilvusOption from write options
-      val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
-      val milvusOption = MilvusOption(optionsMap)
-
-      // Create batch write infrastructure
-      val batchWrite = new MilvusLoonBatchWrite(targetSchema, milvusOption)
-      val writerFactory = batchWrite.createBatchWriterFactory(null)
-
-      // Create a single writer for this segment
-      val writer = writerFactory.createWriter(0, System.currentTimeMillis())
-
-      try {
-        // Write all rows for this segment
-        // Extract only the new field columns (skip segment_id and row_offset)
-        rows.foreach { row =>
-          // Create a new InternalRow with only the target fields (columns 2+)
-          val targetRow = new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(
-            (2 until row.numFields).map(i => row.get(i, targetSchema.fields(i - 2).dataType)).toArray
-          )
-          writer.write(targetRow)
-        }
-
-        // Commit the writer
-        val commitMessage = writer.commit()
-
-        // Extract manifest path from commit message
-        val manifestPaths = commitMessage match {
-          case msg: MilvusLoonCommitMessage => Seq(msg.manifestPath)
-          case _ => Seq.empty
-        }
-
-        val segmentExecutionTime = System.currentTimeMillis() - segmentStartTime
-
-        logger.info(s"Segment $segmentID completed successfully in ${segmentExecutionTime}ms")
-        logger.info(s"Segment $segmentID manifest paths: ${manifestPaths.mkString(", ")}")
-
-        // Commit the batch write
-        batchWrite.commit(Array(commitMessage))
-
-        (SegmentBackfillResult(
-          segmentId = segmentID,
-          rowCount = rows.length.toLong,
-          manifestPaths = manifestPaths,
-          outputPath = outputPath,
-          executionTimeMs = segmentExecutionTime
-        ), None)
-
-      } catch {
-        case e: Exception =>
-          writer.abort()
-          throw e
-      } finally {
-        writer.close()
-      }
-
-    } catch {
-      case e: Exception =>
-        val segmentExecutionTime = System.currentTimeMillis() - segmentStartTime
-        logger.error(s"Segment $segmentID failed after ${segmentExecutionTime}ms", e)
-
-        (SegmentBackfillResult(
-          segmentId = segmentID,
-          rowCount = rows.length.toLong,
-          manifestPaths = Seq.empty,
-          outputPath = "",
-          executionTimeMs = segmentExecutionTime
-        ), Some(e))
-    }
-  }
 }

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -1,0 +1,309 @@
+# Backfill API
+
+The Backfill API provides a streamlined way to add new fields to existing Milvus collections by joining original data with new field values and writing per-segment binlog files.
+
+## Quick Start
+
+### 1. Prepare New Field Data
+
+Create a Parquet file with schema `(pk, new_field1, new_field2, ...)`:
+
+```scala
+import org.apache.spark.sql.SparkSession
+
+val spark = SparkSession.builder()
+  .appName("Backfill")
+  .master("local[*]")
+  .getOrCreate()
+
+// Create new field data with primary key
+val newFieldData = Seq(
+  (1L, "value_1", 100),
+  (2L, "value_2", 200),
+  (3L, "value_3", 300)
+).toDF("pk", "new_string_field", "new_int_field")
+
+// Save to Parquet
+val dataPath = "/tmp/new_field_data.parquet"
+newFieldData.write.mode("overwrite").parquet(dataPath)
+```
+
+### 2. Configure and Execute
+
+```scala
+import com.zilliz.spark.connector.operations.backfill._
+
+// Configure backfill
+val config = BackfillConfig(
+  // Milvus connection
+  milvusUri = "http://localhost:19530",
+  milvusToken = "root:Milvus",
+  databaseName = "default",
+  collectionName = "my_collection",
+  
+  // Primary key field ID to read
+  pkFieldToRead = 100,
+  
+  // S3/Minio storage
+  s3Endpoint = "localhost:9000",
+  s3BucketName = "a-bucket",
+  s3AccessKey = "minioadmin",
+  s3SecretKey = "minioadmin",
+  s3UseSSL = false,
+  s3RootPath = "files",
+  s3Region = "us-east-1",
+  
+  // Optional: tuning
+  batchSize = 1024
+)
+
+// Execute backfill
+val result = MilvusBackfill.run(
+  spark = spark,
+  backfillDataPath = dataPath,
+  config = config
+)
+
+// Handle result
+result match {
+  case Right(success) =>
+    println(success.summary)
+    println(s"Segments processed: ${success.segmentsProcessed}")
+    println(s"Total rows: ${success.totalRowsWritten}")
+    println(s"Execution time: ${success.executionTimeSec}s")
+    
+  case Left(error) =>
+    println(s"Backfill failed: ${error.message}")
+    error.cause.foreach(_.printStackTrace())
+}
+```
+
+## Configuration
+
+### Required Parameters
+
+- `milvusUri`: Milvus server URI (e.g., "http://localhost:19530")
+- `collectionName`: Collection name to backfill
+- `pkFieldToRead`: Primary key field ID (e.g., 100)
+- `s3Endpoint`: S3/Minio endpoint (e.g., "localhost:9000")
+- `s3BucketName`: S3 bucket name
+- `s3AccessKey`: S3 access key
+- `s3SecretKey`: S3 secret key
+
+### Optional Parameters
+
+- `milvusToken`: Authentication token (default: "")
+- `databaseName`: Database name (default: "default")
+- `partitionName`: Specific partition to backfill (default: None)
+- `s3UseSSL`: Use SSL for S3 (default: false)
+- `s3RootPath`: Root path in bucket (default: "files")
+- `s3Region`: S3 region (default: "us-east-1")
+- `batchSize`: Write batch size (default: 1024)
+- `customOutputPath`: Custom S3 output path (default: None)
+
+## Error Handling
+
+The API returns `Either[BackfillError, BackfillResult]`:
+
+```scala
+result match {
+  case Right(success) =>
+    // Process successful result
+    
+  case Left(ConnectionError(msg, _)) =>
+    println(s"Connection error: $msg")
+    
+  case Left(SchemaValidationError(msg, _)) =>
+    println(s"Schema error: $msg")
+    
+  case Left(DataReadError(path, msg, _)) =>
+    println(s"Read error at $path: $msg")
+    
+  case Left(WriteError(segmentId, path, msg, _)) =>
+    println(s"Write error for segment $segmentId: $msg")
+    
+  case Left(error) =>
+    println(s"Error: ${error.message}")
+}
+```
+
+## Error Types
+
+- `ConnectionError`: Failed to connect to Milvus or retrieve metadata
+- `SchemaValidationError`: Schema incompatibility between original and new data
+- `DataReadError`: Failed to read new field data or collection data
+- `SegmentProcessingError`: Error processing a specific segment
+- `WriteError`: Failed to write backfill data for a segment
+- `SparkConfigError`: Spark configuration issue
+- `UnexpectedError`: General unexpected error
+
+## Result Structure
+
+```scala
+case class BackfillResult(
+  success: Boolean,
+  segmentsProcessed: Int,
+  totalRowsWritten: Long,
+  manifestPaths: Seq[String],
+  segmentResults: Map[Long, SegmentBackfillResult],
+  executionTimeMs: Long,
+  collectionId: Long,
+  partitionId: Long,
+  newFieldNames: Seq[String]
+)
+```
+
+### Helper Methods
+
+```scala
+// Formatted summary
+success.summary
+
+// Per-segment details
+success.segmentSummary
+
+// Check all segments succeeded
+success.allSegmentsSuccessful
+
+// Execution time in seconds
+success.executionTimeSec
+```
+
+## Output Structure
+
+Backfill data is written to:
+
+```
+s3://{bucket}/{root_path}/insert_log/{collectionID}/{partitionID}/{segmentID}/new_field/
+└── binlog_0/
+    └── task_{taskPartitionId}_{taskId}/
+        └── *.parquet files
+```
+
+By default, the output path follows the Milvus binlog structure. You can customize it using `customOutputPath` parameter.
+
+## Best Practices
+
+1. **Schema Matching**: Ensure `pk` field type in new data matches collection's primary key type (Int64 or VarChar)
+2. **Primary Key Field**: Use `pkFieldToRead` to specify the primary key field ID (typically 100)
+   - This field is used for joining with new data
+   - Only this field (plus segment_id and row_offset) is read from the collection to minimize data transfer
+3. **Batch Size**: Adjust based on data size (default 1024 works for most cases)
+   - Larger batches: faster but more memory usage
+   - Smaller batches: slower but safer for large datasets
+4. **Error Handling**: Always use pattern matching on `Either` result to handle all error cases
+5. **Cleanup**: Remove temporary Parquet files after successful backfill
+6. **Data Preparation**: Save new field data as Parquet for best performance and type safety
+
+## Complete Example
+
+```scala
+import org.apache.spark.sql.SparkSession
+import com.zilliz.spark.connector.operations.backfill._
+
+object BackfillExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("Backfill")
+      .master("local[*]")
+      .getOrCreate()
+
+    try {
+      // Step 1: Prepare new field data
+      val newFieldData = Seq(
+        (1L, "value_1"),
+        (2L, "value_2"),
+        (3L, "value_3")
+      ).toDF("pk", "new_description")
+      
+      val dataPath = "/tmp/new_fields.parquet"
+      newFieldData.write.mode("overwrite").parquet(dataPath)
+
+      // Step 2: Configure
+      val config = BackfillConfig(
+        milvusUri = "http://localhost:19530",
+        milvusToken = "root:Milvus",
+        collectionName = "my_collection",
+        pkFieldToRead = 100,
+        s3Endpoint = "localhost:9000",
+        s3BucketName = "a-bucket",
+        s3AccessKey = "minioadmin",
+        s3SecretKey = "minioadmin"
+      )
+
+      // Step 3: Execute
+      val result = MilvusBackfill.backfill(spark, dataPath, config)
+
+      // Step 4: Handle result
+      result match {
+        case Right(success) =>
+          println("✓ Backfill completed!")
+          println(success.summary)
+          
+        case Left(error) =>
+          println(s"✗ Backfill failed: ${error.message}")
+          System.exit(1)
+      }
+
+    } finally {
+      spark.stop()
+    }
+  }
+}
+```
+
+## Testing
+
+Use the test helper for quick setup:
+
+```scala
+val config = BackfillConfig.forTest(
+  collectionName = "test_collection",
+  pkFieldToRead = 100
+)
+```
+
+## How It Works
+
+The backfill operation follows these steps:
+
+1. **Validate Configuration**: Checks all required parameters are set
+2. **Read New Field Data**: Loads Parquet file with `(pk, new_field1, ...)` schema
+3. **Read Original Collection**: Reads only primary key field + metadata (segment_id, row_offset) from Milvus
+4. **Get Primary Key Name**: Retrieves actual PK field name from Milvus schema (not hardcoded)
+5. **Validate Schema**: Ensures PK types match between original and new data
+6. **Perform Join**: Left joins original data with new field data on primary key
+7. **Retrieve Metadata**: Gets collection ID and partition ID from Milvus
+8. **Process Segments in Parallel**: For each segment:
+   - Filters joined data for that segment
+   - Sorts by row_offset to maintain original order
+   - Writes new field binlog files to S3 using MilvusLoonWriter
+9. **Return Results**: Provides detailed results including manifest paths
+
+## Troubleshooting
+
+### Schema validation error
+- Ensure `pk` column exists in new field data
+- Verify `pk` type matches collection's primary key type (use same type: Long for Int64, String for VarChar)
+- Check that new field data has at least one field besides `pk`
+
+### Connection error
+- Check Milvus server is running and accessible at specified URI
+- Verify Milvus token format is correct: "username:password"
+- Verify S3/Minio endpoint is accessible and credentials are correct
+- Check database and collection names are correct
+
+### Write error
+- Check S3 bucket exists and is writable
+- Verify path permissions and bucket policies
+- Ensure sufficient disk space on executors
+- Check batch size isn't too large for available memory
+
+## API Location
+
+```
+com.zilliz.spark.connector.operations.backfill.MilvusBackfill
+com.zilliz.spark.connector.operations.backfill.BackfillConfig
+com.zilliz.spark.connector.operations.backfill.BackfillResult
+com.zilliz.spark.connector.operations.backfill.BackfillError
+```

--- a/src/main/scala/operations/backfill/SegmentPartitioner.scala
+++ b/src/main/scala/operations/backfill/SegmentPartitioner.scala
@@ -1,0 +1,35 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.Partitioner
+
+/**
+ * Custom partitioner that ensures each segment goes to exactly one partition
+ *
+ * Maps each segment_id to a unique partition index via exact lookup table,
+ * eliminating hash collisions entirely. This guarantees:
+ * - Each partition contains exactly one segment's data
+ * - Each segment's data is in exactly one partition
+ *
+ * @param segmentIds Array of all segment IDs in the collection
+ */
+class SegmentPartitioner(segmentIds: Array[Long]) extends Partitioner {
+
+  // Create exact mapping: segment_id -> partition_index
+  // Sorted to ensure deterministic partition assignment
+  private val segmentToIndex: Map[Long, Int] = segmentIds.sorted.zipWithIndex.toMap
+
+  override def numPartitions: Int = segmentIds.length
+
+  override def getPartition(key: Any): Int = {
+    val segmentId = key.asInstanceOf[Long]
+    segmentToIndex.getOrElse(segmentId,
+      throw new IllegalArgumentException(s"Unknown segment ID: $segmentId. Known segments: ${segmentIds.mkString(", ")}"))
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case h: SegmentPartitioner => h.segmentToIndex == segmentToIndex
+    case _ => false
+  }
+
+  override def hashCode(): Int = segmentToIndex.hashCode()
+}

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -12,12 +12,14 @@ case class MilvusStorageV2InputPartition(
     topK: Option[Int] = None,
     queryVector: Option[Array[Float]] = None,
     metricType: Option[String] = None,
-    vectorColumn: Option[String] = None
+    vectorColumn: Option[String] = None,
+    segmentID: Long = -1L  // Add segment ID tracking for V2
 ) extends InputPartition
 
-// V1 Binlog InputPartition  
+// V1 Binlog InputPartition
 case class MilvusInputPartition(
     fieldFiles: Seq[Map[String, String]],
-    partition: String = ""
+    partition: String = "",
+    segmentID: Long = -1L  // Add segment ID tracking
 ) extends InputPartition
 

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -69,7 +69,7 @@ class MilvusLoonPartitionReader(
   }
 
   // Get Arrow stream
-  private val recordBatchReaderPtr = reader.getRecordBatchReaderScala(null, 1024, 8 * 1024 * 1024)
+  private val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
   private val arrowArrayStream = ArrowArrayStream.wrap(recordBatchReaderPtr)
   private val arrowReader = Data.importArrayStream(allocator, arrowArrayStream)
 

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -178,7 +178,11 @@ object ArrowConverter extends Logging {
 
       case StringType =>
         val str = record.getUTF8String(colIndex)
-        vector.asInstanceOf[VarCharVector].set(rowIndex, str.getBytes)
+        if (str == null) {
+          vector.setNull(rowIndex)
+        } else {
+          vector.asInstanceOf[VarCharVector].set(rowIndex, str.getBytes)
+        }
 
       case ArrayType(FloatType, _) =>
         // FloatVector stored as FixedSizeBinaryVector
@@ -213,7 +217,11 @@ object ArrowConverter extends Logging {
 
       case BinaryType =>
         val bytes = record.getBinary(colIndex)
-        vector.asInstanceOf[VarBinaryVector].set(rowIndex, bytes)
+        if (bytes == null) {
+          vector.setNull(rowIndex)
+        } else {
+          vector.asInstanceOf[VarBinaryVector].set(rowIndex, bytes)
+        }
 
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,43 @@
+# Log4j 2.x configuration for tests
+
+# Root logger level
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = ConsoleAppender
+
+# Console appender configuration
+appender.console.type = Console
+appender.console.name = ConsoleAppender
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+logger.milvus.name = com.zilliz.spark.connector
+logger.milvus.level = info
+logger.milvus.additivity = false
+logger.milvus.appenderRef.stdout.ref = ConsoleAppender
+
+# Reduce Spark noise - only WARN and above
+logger.spark.name = org.apache.spark
+logger.spark.level = warn
+
+logger.sparkproject.name = org.sparkproject
+logger.sparkproject.level = warn
+
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = warn
+
+logger.parquet.name = org.apache.parquet
+logger.parquet.level = warn
+
+logger.parquet2.name = parquet
+logger.parquet2.level = warn
+
+# Reduce other verbose libraries
+logger.jetty.name = org.eclipse.jetty
+logger.jetty.level = warn
+
+logger.netty.name = io.netty
+logger.netty.level = warn
+
+logger.arrow.name = org.apache.arrow
+logger.arrow.level = warn

--- a/src/test/scala/loon/MilvusStorageFFITest.scala
+++ b/src/test/scala/loon/MilvusStorageFFITest.scala
@@ -82,7 +82,7 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
     // Read data using Arrow C Data Interface
     info("Reading data from Milvus storage...")
-    val recordBatchReaderPtr = reader.getRecordBatchReaderScala(null, 1024, 8 * 1024 * 1024)
+    val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
 
     // Wrap the C++ ArrowArrayStream pointer with Arrow Java's ArrowArrayStream
     val allocator = ArrowUtils.getAllocator

--- a/src/test/scala/operations/backfill/MilvusBackfillTest.scala
+++ b/src/test/scala/operations/backfill/MilvusBackfillTest.scala
@@ -62,12 +62,35 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("Use MilvusBackfill API for backfill operation") {
-    
-
-    // Prepare new field data as Parquet file
+    // Create backfill data with NULL values in the MIDDLE to test edge cases
     val totalRecords = batchSize * batchCount
-    val addFieldData = (0 until totalRecords).map { i =>
+
+    // Distribution:
+    // - First 30%: Has backfill data
+    // - Middle 40%: NULL (un-joined) ← Key test: NULL in the middle
+    // - Last 30%: Has backfill data
+    val firstRangeEnd = (totalRecords * 0.3).toInt
+    val nullRangeStart = firstRangeEnd
+    val nullRangeEnd = (totalRecords * 0.7).toInt
+    val lastRangeStart = nullRangeEnd
+
+    val recordsWithData = firstRangeEnd + (totalRecords - lastRangeStart)
+    val expectedNullRecords = nullRangeEnd - nullRangeStart
+
+    info(s"\n=== Test Setup ===")
+    info(s"Total records in collection: $totalRecords")
+    info(s"Backfill data distribution:")
+    info(s"  Records 0-${firstRangeEnd-1}: Has backfill data ($firstRangeEnd rows)")
+    info(s"  Records $nullRangeStart-${nullRangeEnd-1}: NO backfill data - will be NULL ($expectedNullRecords rows)")
+    info(s"  Records $lastRangeStart-${totalRecords-1}: Has backfill data (${totalRecords - lastRangeStart} rows)")
+    info(s"Total records with data: $recordsWithData")
+    info(s"Total records with NULL: $expectedNullRecords")
+
+    // Create backfill data: skip the middle range to create NULL gap
+    val addFieldData = (0 until firstRangeEnd).map { i =>
       (i.toLong, s"api_new_value_$i", i * 2) // pk, new_field1, new_field2
+    } ++ (lastRangeStart until totalRecords).map { i =>
+      (i.toLong, s"api_new_value_$i", i * 2)
     }
 
     val addFieldDF = spark.createDataFrame(addFieldData).toDF("pk", "new_field1", "new_field2")
@@ -113,18 +136,34 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
           info(s"  Total execution time: ${success.executionTimeMs}ms")
 
           info("\n  Per-Segment Results ===")
+          var totalRowsProcessed = 0L
           success.segmentResults.toSeq.sortBy(_._1).foreach { case (segmentId, segResult) =>
             info(s"  Segment $segmentId:")
             info(s"    Rows: ${segResult.rowCount}")
             info(s"    Execution time: ${segResult.executionTimeMs}ms")
             info(s"    Output path: ${segResult.outputPath}")
             info(s"    Manifest paths: ${segResult.manifestPaths.mkString(", ")}")
+            totalRowsProcessed += segResult.rowCount
           }
 
           // Assertions
           assert(success.segmentResults.nonEmpty, "Should process at least one segment")
           assert(success.newFieldNames.contains("new_field1"), "Should contain new_field1")
           assert(success.newFieldNames.contains("new_field2"), "Should contain new_field2")
+
+          // Verify all rows were processed (including those with nulls)
+          info(s"\n=== Null Handling Verification ===")
+          info(s"  Total rows in collection: $totalRecords")
+          info(s"  Total rows processed: $totalRowsProcessed")
+          info(s"  Rows with backfill data (joined): $recordsWithData")
+          info(s"  Expected rows with nulls (un-joined): $expectedNullRecords")
+
+          assert(totalRowsProcessed == totalRecords,
+            s"Should process ALL rows including un-joined ones. Expected: $totalRecords, Got: $totalRowsProcessed")
+
+          info(s"All $totalRecords rows were processed")
+          info(s"This includes $recordsWithData rows with backfill data and $expectedNullRecords rows with NULL values")
+          info(s"NULL gap in middle range ($nullRangeStart-${nullRangeEnd-1}) handled correctly")
 
         case Left(error) =>
           fail(s"Backfill API failed: ${error.message}")

--- a/src/test/scala/operations/backfill/MilvusBackfillTest.scala
+++ b/src/test/scala/operations/backfill/MilvusBackfillTest.scala
@@ -24,7 +24,7 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
   var spark: SparkSession = _
   var milvusClient: MilvusClient = _
 
-  val collectionName = s"backfilltestcollection"
+  val collectionName = s"backfilltestcollection_${System.currentTimeMillis()}"
   val dim = 128
   val batchSize = 10000
   val batchCount = 100

--- a/src/test/scala/operations/backfill/MilvusBackfillTest.scala
+++ b/src/test/scala/operations/backfill/MilvusBackfillTest.scala
@@ -1,0 +1,196 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import scala.util.Random
+
+import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusFieldData, MilvusOption}
+import com.zilliz.spark.connector.loon.Properties
+import io.milvus.grpc.schema.DataType
+
+import java.io.File
+
+/**
+ * Integration test for MilvusBackfill operation
+ *
+ * Prerequisites:
+ * - Milvus 2.6+ running at localhost:19530
+ * - Minio running at localhost:9000
+ */
+class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
+
+  var spark: SparkSession = _
+  var milvusClient: MilvusClient = _
+
+  val collectionName = s"backfilltestcollection"
+  val dim = 128
+  val batchSize = 10000
+  val batchCount = 100
+
+  override def beforeAll(): Unit = {
+    // Initialize Spark
+    spark = SparkSession.builder()
+      .appName("MilvusDataSourceTest")
+      .master("local[*]")
+      .getOrCreate()
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    // Initialize Milvus client
+    milvusClient = MilvusClient(
+      MilvusConnectionParams(
+        uri = "http://localhost:19530",
+        token = "root:Milvus",
+        databaseName = "default"
+      )
+    )
+
+    // Prepare test data
+    prepareTestCollection()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      // Clean up
+      milvusClient.dropCollection("", collectionName)
+    } finally {
+      if (milvusClient != null) milvusClient.close()
+      if (spark != null) spark.stop()
+    }
+  }
+
+  test("Use MilvusBackfill API for backfill operation") {
+    
+
+    // Prepare new field data as Parquet file
+    val totalRecords = batchSize * batchCount
+    val addFieldData = (0 until totalRecords).map { i =>
+      (i.toLong, s"api_new_value_$i", i * 2) // pk, new_field1, new_field2
+    }
+
+    val addFieldDF = spark.createDataFrame(addFieldData).toDF("pk", "new_field1", "new_field2")
+
+    val tempDir = new File(System.getProperty("java.io.tmpdir"))
+    val parquetPath = new File(tempDir, s"new_field_data_${System.currentTimeMillis()}.parquet").getAbsolutePath
+    addFieldDF.write.mode("overwrite").parquet(parquetPath)
+    addFieldDF.show(10, truncate = false)
+
+    try {
+      // Create backfill configuration
+      val config = BackfillConfig(
+        milvusUri = "http://localhost:19530",
+        milvusToken = "root:Milvus",
+        databaseName = "default",
+        collectionName = collectionName,
+        pkFieldToRead = 100,
+        s3Endpoint = "localhost:9000",
+        s3BucketName = "a-bucket",
+        s3AccessKey = "minioadmin",
+        s3SecretKey = "minioadmin",
+        s3UseSSL = false,
+        s3RootPath = "files",
+        s3Region = "us-east-1",
+        batchSize = 512
+      )
+
+      // Execute MilvusBackfill API
+      val result = MilvusBackfill.run(
+        spark,
+        parquetPath,
+        config
+      )
+
+      // Verify result
+      result match {
+        case Right(success) =>
+          info("\n=== Backfill API Result ===")
+          info(s"  Collection ID: ${success.collectionId}")
+          info(s"  Partition ID: ${success.partitionId}")
+          info(s"  Segments processed: ${success.segmentResults.size}")
+          info(s"  New fields: ${success.newFieldNames.mkString(", ")}")
+          info(s"  Total execution time: ${success.executionTimeMs}ms")
+
+          info("\n  Per-Segment Results ===")
+          success.segmentResults.toSeq.sortBy(_._1).foreach { case (segmentId, segResult) =>
+            info(s"  Segment $segmentId:")
+            info(s"    Rows: ${segResult.rowCount}")
+            info(s"    Execution time: ${segResult.executionTimeMs}ms")
+            info(s"    Output path: ${segResult.outputPath}")
+            info(s"    Manifest paths: ${segResult.manifestPaths.mkString(", ")}")
+          }
+
+          // Assertions
+          assert(success.segmentResults.nonEmpty, "Should process at least one segment")
+          assert(success.newFieldNames.contains("new_field1"), "Should contain new_field1")
+          assert(success.newFieldNames.contains("new_field2"), "Should contain new_field2")
+
+        case Left(error) =>
+          fail(s"Backfill API failed: ${error.message}")
+      }
+
+    } finally {
+      // Delete temporary Parquet file
+      val parquetFile = new File(parquetPath)
+      if (parquetFile.exists()) {
+        def deleteRecursively(file: File): Unit = {
+          if (file.isDirectory) {
+            file.listFiles().foreach(deleteRecursively)
+          }
+          file.delete()
+        }
+        deleteRecursively(parquetFile)
+      }
+    }
+  }
+
+  // Helper method to prepare test collection
+  private def prepareTestCollection(): Unit = {
+    milvusClient.dropCollection("", collectionName)
+
+    val fields = List(
+      milvusClient.createCollectionField("id", isPrimary = true, dataType = DataType.Int64, autoID = false),
+      milvusClient.createCollectionField("int64", dataType = DataType.Int64, isClusteringKey = true),
+      milvusClient.createCollectionField("float", dataType = DataType.Float),
+      milvusClient.createCollectionField("varchar", dataType = DataType.VarChar, typeParams = Map("max_length" -> "1024")),
+      milvusClient.createCollectionField("vector", dataType = DataType.FloatVector, typeParams = Map("dim" -> dim.toString))
+    )
+
+    val schema = milvusClient.createCollectionSchema(
+      name = collectionName,
+      fields = fields,
+      description = "Test collection for MilvusBackfill",
+      enableAutoID = false,
+      enableDynamicSchema = false
+    )
+
+    milvusClient.createCollection("", collectionName, schema, shardsNum = 1)
+
+    // Generate and insert test data
+    val random = new Random(42)
+    for (i <- 0 until batchCount) {
+      val idData = (0 until batchSize).map(j => (i * batchSize + j).toLong)
+      val int64Data = (0 until batchSize).map(j => j.toLong)
+      val floatData = (0 until batchSize).map(_ => random.nextFloat())
+      val varcharData = (0 until batchSize).map(j =>
+        s"test_string_${i * batchSize + j}")
+      val vectorData = (0 until batchSize).map(_ =>
+        (0 until dim).map(_ => random.nextFloat()).toSeq)
+
+      val fieldsData = Seq(
+        MilvusFieldData.packInt64FieldData("id", idData),
+        MilvusFieldData.packInt64FieldData("int64", int64Data),
+        MilvusFieldData.packFloatFieldData("float", floatData),
+        MilvusFieldData.packStringFieldData("varchar", varcharData),
+        MilvusFieldData.packFloatVectorFieldData("vector", vectorData, dim)
+      )
+
+      milvusClient.insert("", collectionName, fieldsData = fieldsData, numRows = batchSize)
+    }
+
+    // Flush to ensure data is persisted
+    milvusClient.flush("", Seq(collectionName))
+    Thread.sleep(10000)
+  }
+}


### PR DESCRIPTION
related: https://github.com/zilliztech/spark-milvus/issues/74
Implement a streamlined API to backfill new fields into existing Milvus collections by joining original data with new field values and writing per-segment binlog files.

Key features:
- Dynamic primary key field detection from Milvus schema
- Efficient column pruning (reads only PK + metadata fields)
- Parallel segment processing using Scala parallel collections
- Comprehensive error handling with typed error cases

API structure:
- BackfillConfig: Configuration with required fields validation
- MilvusBackfill.backfill(): Main entry point
- BackfillResult: Detailed result with per-segment statistics
- BackfillError: Typed error hierarchy for error handling