### PR TITLE
feat: add Docker build support with dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ note.md
 build/
 src/main/resources/native/libmilvus-storage.so
 src/main/resources/native/libmilvus-storage-jni.so
+.sbt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,141 @@
+# syntax=docker/dockerfile:1.4
+# Build spark-milvus connector with milvus-storage native libraries
+
+# Build arguments
+ARG GIT_BRANCH=unknown
+
+# Stage 1: Build milvus-storage native libraries and Java binding
+FROM spark:4.0.1-scala2.13-java21-python3-ubuntu AS builder
+
+ARG GIT_BRANCH
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Install dependencies for building milvus-storage
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates wget curl git g++ gcc make ccache gdb \
+    python3 python3-pip \
+    zip unzip \
+    automake autoconf libtool \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/aclocal-1.16 /usr/bin/aclocal-1.15 \
+    && ln -sf /usr/bin/automake-1.16 /usr/bin/automake-1.15
+
+# Install CMake (architecture-aware, same pattern as milvus-storage)
+RUN wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-$(uname -m).tar.gz" | tar --strip-components=1 -xz -C /usr/local
+
+# Install Conan
+RUN pip3 install conan==1.61.0
+
+# Setup Conan profile and remote (handle existing profile from cache)
+RUN conan profile new default --detect || true \
+    && conan profile update settings.compiler.libcxx=libstdc++11 default
+RUN conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert || true
+
+# Set ccache configuration
+ENV CCACHE_DIR=/root/.ccache
+ENV PATH=/usr/lib/ccache:$PATH
+
+# Install SDKMAN and Java/Scala/sbt
+ENV SDKMAN_DIR=/root/.sdkman
+RUN curl -s "https://get.sdkman.io" | bash
+RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && \
+    sdk install java 17.0.14-zulu && \
+    sdk install scala 2.13.16 && \
+    sdk install sbt 1.11.1"
+
+ENV JAVA_HOME=/root/.sdkman/candidates/java/current
+ENV SCALA_HOME=/root/.sdkman/candidates/scala/current
+ENV SBT_HOME=/root/.sdkman/candidates/sbt/current
+ENV PATH=$JAVA_HOME/bin:$SCALA_HOME/bin:$SBT_HOME/bin:$PATH
+
+WORKDIR /workspace
+
+COPY . .
+
+# Initialize git submodules
+RUN git config --global --add safe.directory /workspace && \
+    git config --global --add safe.directory /workspace/milvus-proto && \
+    git config --global --add safe.directory /workspace/milvus-storage && \
+    git submodule update --init --recursive
+
+# ARM64 workaround: crc32c has -Werror but produces warnings on ARM64
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        for compiler in g++ gcc c++; do \
+            [ -f "/usr/bin/$compiler" ] && \
+            mv /usr/bin/$compiler /usr/bin/${compiler}.real && \
+            printf '#!/bin/bash\nexec /usr/bin/%s.real "${@//-Werror/}"\n' "$compiler" > /usr/bin/$compiler && \
+            chmod +x /usr/bin/$compiler; \
+        done; \
+    fi
+
+# Build milvus-storage native library using its Makefile (with cache)
+RUN --mount=type=cache,target=/root/.conan \
+    --mount=type=cache,target=/root/.ccache \
+    cd milvus-storage/cpp && make build USE_JNI=True WITH_UT=False
+
+# Copy native libs
+RUN mkdir -p milvus-storage/java/native src/main/resources/native && \
+    cp milvus-storage/cpp/build/Release/libmilvus-storage.so milvus-storage/java/native/ && \
+    cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so milvus-storage/java/native/ && \
+    cp milvus-storage/cpp/build/Release/libmilvus-storage.so src/main/resources/native/ && \
+    cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so src/main/resources/native/
+
+# Build milvus-storage Java binding (with cache)
+RUN --mount=type=cache,target=/root/.ivy2 \
+    --mount=type=cache,target=/root/.sbt \
+    cd milvus-storage/java && bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publishLocal"
+
+# Build spark-milvus connector (with cache)
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV SBT_OPTS="-Xmx4g -Xms2g"
+RUN --mount=type=cache,target=/root/.ivy2 \
+    --mount=type=cache,target=/root/.sbt \
+    bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt package"
+
+# Stage 2: Final image (only copy artifacts and publish)
+FROM spark:4.0.1-scala2.13-java21-python3-ubuntu AS final
+
+ARG GIT_BRANCH
+ENV GIT_BRANCH=${GIT_BRANCH}
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl zip unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV SDKMAN_DIR=/root/.sdkman
+RUN curl -s "https://get.sdkman.io" | bash
+RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && \
+    sdk install java 17.0.14-zulu && \
+    sdk install scala 2.13.16 && \
+    sdk install sbt 1.11.1"
+
+ENV JAVA_HOME=/root/.sdkman/candidates/java/current
+ENV SCALA_HOME=/root/.sdkman/candidates/scala/current
+ENV SBT_HOME=/root/.sdkman/candidates/sbt/current
+ENV PATH=$JAVA_HOME/bin:$SCALA_HOME/bin:$SBT_HOME/bin:$PATH
+
+WORKDIR /workspace
+
+# Copy only necessary files for sbt publish (not entire workspace)
+COPY --from=builder /workspace/build.sbt /workspace/build.sbt
+COPY --from=builder /workspace/project/ /workspace/project/
+COPY --from=builder /workspace/target/ /workspace/target/
+COPY --from=builder /root/.ivy2/local /root/.ivy2/local
+
+ARG PUBLISH_TO_CENTRAL=true
+ENV SBT_OPTS="-Xmx4g -Xms2g"
+RUN --mount=type=cache,target=/root/.sbt \
+    if [ "$PUBLISH_TO_CENTRAL" = "true" ]; then \
+        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish"; \
+    fi
+
+CMD ["/bin/bash"]

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,9 @@ import scala.sys.process.Process
 import scala.io.Source
 
 import xerial.sbt.Sonatype._
+import xerial.sbt.Sonatype.sonatypeCentralHost
+
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 import Dependencies._
 
 // Load Sonatype Central credentials
@@ -61,14 +64,22 @@ ThisBuild / scmInfo := Some(
     "scm:git@github.com:zilliztech/milvus-spark-connector.git"
   )
 )
-ThisBuild / developers := List(
-  Developer(
-    id = "simfg",
-    name = "SimFG",
-    email = "bang.fu@zilliz.com",
-    url = url("https://github.com/SimFG")
+ThisBuild / developers := List()
+
+lazy val arch = System.getProperty("os.arch") match {
+  case "amd64" | "x86_64" => "amd64"
+  case "aarch64" | "arm64" => "arm64"
+  case other => other
+}
+
+// Get git branch name from env var (for Docker builds) or git command, sanitize for Maven version
+lazy val gitBranch = {
+  val branch = sys.env.getOrElse("GIT_BRANCH",
+    scala.util.Try(Process("git rev-parse --abbrev-ref HEAD").!!.trim).getOrElse("unknown")
   )
-)
+  // Replace invalid characters for Maven version (only alphanumeric, dash, dot, underscore allowed)
+  branch.replaceAll("[^a-zA-Z0-9._-]", "-")
+}
 
 lazy val root = (project in file("."))
   .settings(
@@ -76,8 +87,12 @@ lazy val root = (project in file("."))
     assembly / parallelExecution := true,
     Test / parallelExecution := true,
     Compile / compile / parallelExecution := true,
-    version := "0.2.1-SNAPSHOT",
+    version := s"${gitBranch}-${arch}-SNAPSHOT",
     organization := "com.zilliz",
+
+    // Disable Scaladoc and sources jar for publish (not needed, speeds up build)
+    Compile / packageDoc / publishArtifact := false,
+    Compile / packageSrc / publishArtifact := false,
 
     // Fork JVM for run and tests to properly load native libraries
     run / fork := true,

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.10")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.17")
 
 // format: on


### PR DESCRIPTION
- Add multi-stage Dockerfile for building spark-milvus with milvus-storage native library
- Support ARM64 and x86 architectures
- Enable BuildKit cache for faster builds
- Use dynamic version naming: {branch}-{arch}-SNAPSHOT
- Get branch name from GIT_BRANCH env var (for Docker builds) or git command
- Increase JVM heap to 4GB for sbt assembly
- Disable Scaladoc/sources jar to speed up publish
- Optimize Stage 2 to copy only necessary files