### PR TITLE
feat: add GitHub CI/CD workflows for build and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: spark:4.0.1-scala2.13-java21-python3-ubuntu
+      options: --user root
+
+    steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # 缓存步骤放在安装之前
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: /root/.conan
+          key: conan-${{ hashFiles('milvus-storage/cpp/conanfile.py') }}
+          restore-keys: |
+            conan-
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: /root/.ccache
+          key: ccache-${{ github.sha }}
+          restore-keys: |
+            ccache-
+
+      - name: Cache sbt dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            /root/.sbt
+            /root/.ivy2/cache
+            /root/.cache/coursier
+          key: sbt-${{ hashFiles('build.sbt', 'project/*.sbt', 'project/*.scala') }}
+          restore-keys: |
+            sbt-
+
+      - name: Install build dependencies
+        run: |
+          apt-get install -y g++ gcc make ccache automake autoconf libtool curl wget
+
+      - name: Install CMake
+        run: |
+          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+
+      - name: Install sbt
+        run: |
+          curl -fL https://github.com/sbt/sbt/releases/download/v1.11.1/sbt-1.11.1.tgz | tar xz -C /usr/local
+          ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt
+
+      - name: Install Conan
+        run: |
+          pip3 install conan==1.61.0
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert || true
+
+      - name: Build milvus-storage native library
+        run: |
+          cd milvus-storage/cpp
+          make build USE_JNI=True WITH_UT=False USE_ASAN=False
+
+      - name: Copy native libraries
+        run: |
+          mkdir -p milvus-storage/java/native src/main/resources/native
+          cp milvus-storage/cpp/build/Release/libmilvus-storage.so milvus-storage/java/native/
+          cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so milvus-storage/java/native/
+          cp milvus-storage/cpp/build/Release/libmilvus-storage.so src/main/resources/native/
+          cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so src/main/resources/native/
+
+      - name: Publish milvus-storage Java binding locally
+        run: |
+          cd milvus-storage/java
+          sbt publishLocal
+
+      - name: Compile
+        run: sbt compile
+
+      - name: Run unit tests
+        run: |
+          sbt 'testOnly \
+            com.zilliz.spark.connector.MilvusOptionTest \
+            com.zilliz.spark.connector.MilvusS3OptionTest \
+            com.zilliz.spark.connector.DataTypeUtilTest \
+            com.zilliz.spark.connector.filter.VectorBruteForceSearchTest \
+            com.zilliz.spark.connector.operations.backfill.BackfillConfigTest \
+            com.zilliz.spark.connector.loon.PropertiesTest \
+            serde.SchemaUtilTest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,17 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+            cmake_arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            cmake_arch: aarch64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     container:
       image: spark:4.0.1-scala2.13-java21-python3-ubuntu
       options: --user root
@@ -30,7 +39,7 @@ jobs:
         run: |
           echo "commit=$(git -C milvus-storage rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      # 缓存 native library 编译产物
+      # 缓存 native library 编译产物 (按架构区分)
       - name: Cache native library build
         id: cache-native
         uses: actions/cache@v4
@@ -38,7 +47,7 @@ jobs:
           path: |
             milvus-storage/cpp/build
             milvus-storage/java/native
-          key: native-${{ steps.milvus-storage.outputs.commit }}
+          key: native-${{ matrix.arch }}-${{ steps.milvus-storage.outputs.commit }}
 
       # 以下缓存仅在需要编译时使用
       - name: Cache Conan packages
@@ -46,18 +55,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /root/.conan
-          key: conan-${{ steps.milvus-storage.outputs.commit }}
+          key: conan-${{ matrix.arch }}-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
-            conan-
+            conan-${{ matrix.arch }}-
 
       - name: Cache ccache
         if: steps.cache-native.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: /root/.ccache
-          key: ccache-${{ steps.milvus-storage.outputs.commit }}
+          key: ccache-${{ matrix.arch }}-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
-            ccache-
+            ccache-${{ matrix.arch }}-
 
       - name: Cache sbt dependencies
         uses: actions/cache@v4
@@ -66,9 +75,9 @@ jobs:
             /root/.sbt
             /root/.ivy2/cache
             /root/.cache/coursier
-          key: sbt-${{ hashFiles('build.sbt', 'project/*.sbt', 'project/*.scala') }}
+          key: sbt-${{ matrix.arch }}-${{ hashFiles('build.sbt', 'project/*.sbt', 'project/*.scala') }}
           restore-keys: |
-            sbt-
+            sbt-${{ matrix.arch }}-
 
       - name: Install build dependencies
         if: steps.cache-native.outputs.cache-hit != 'true'
@@ -78,12 +87,12 @@ jobs:
       - name: Install CMake
         if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
-          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-${{ matrix.cmake_arch }}.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 
       - name: Install sbt
         run: |
           curl -fL https://github.com/sbt/sbt/releases/download/v1.11.1/sbt-1.11.1.tgz | tar xz -C /usr/local
-          ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt
+          ln -sf /usr/local/sbt/bin/sbt /usr/local/bin/sbt
 
       - name: Install Conan
         if: steps.cache-native.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [ci-workflows]  # for testing cache
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,20 +25,35 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Get milvus-storage commit ID
+        id: milvus-storage
+        run: |
+          echo "commit=$(git -C milvus-storage rev-parse HEAD)" >> $GITHUB_OUTPUT
+
       # 缓存步骤放在安装之前
       - name: Cache Conan packages
         uses: actions/cache@v4
         with:
           path: /root/.conan
-          key: conan-${{ hashFiles('milvus-storage/cpp/conanfile.py') }}
+          key: conan-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
             conan-
 
+      - name: Cache native library build
+        id: cache-native
+        uses: actions/cache@v4
+        with:
+          path: |
+            milvus-storage/cpp/build
+            milvus-storage/java/native
+          key: native-${{ steps.milvus-storage.outputs.commit }}
+
       - name: Cache ccache
+        if: steps.cache-native.outputs.cache-hit != 'true'
         uses: actions/cache@v4
         with:
           path: /root/.ccache
-          key: ccache-${{ github.sha }}
+          key: ccache-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
             ccache-
 
@@ -54,10 +69,12 @@ jobs:
             sbt-
 
       - name: Install build dependencies
+        if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
           apt-get install -y g++ gcc make ccache automake autoconf libtool curl wget
 
       - name: Install CMake
+        if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
           wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 
@@ -67,6 +84,7 @@ jobs:
           ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt
 
       - name: Install Conan
+        if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
           pip3 install conan==1.61.0
           conan profile new default --detect || true
@@ -74,6 +92,7 @@ jobs:
           conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert || true
 
       - name: Build milvus-storage native library
+        if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
           cd milvus-storage/cpp
           make build USE_JNI=True WITH_UT=False USE_ASAN=False

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,7 @@ jobs:
         run: |
           echo "commit=$(git -C milvus-storage rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      # 缓存步骤放在安装之前
-      - name: Cache Conan packages
-        uses: actions/cache@v4
-        with:
-          path: /root/.conan
-          key: conan-${{ steps.milvus-storage.outputs.commit }}
-          restore-keys: |
-            conan-
-
+      # 缓存 native library 编译产物
       - name: Cache native library build
         id: cache-native
         uses: actions/cache@v4
@@ -47,6 +39,16 @@ jobs:
             milvus-storage/cpp/build
             milvus-storage/java/native
           key: native-${{ steps.milvus-storage.outputs.commit }}
+
+      # 以下缓存仅在需要编译时使用
+      - name: Cache Conan packages
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: /root/.conan
+          key: conan-${{ steps.milvus-storage.outputs.commit }}
+          restore-keys: |
+            conan-
 
       - name: Cache ccache
         if: steps.cache-native.outputs.cache-hit != 'true'
@@ -96,14 +98,15 @@ jobs:
         run: |
           cd milvus-storage/cpp
           make build USE_JNI=True WITH_UT=False USE_ASAN=False
+          mkdir -p ../java/native
+          cp build/Release/libmilvus-storage.so ../java/native/
+          cp build/Release/libmilvus-storage-jni.so ../java/native/
 
       - name: Copy native libraries
         run: |
-          mkdir -p milvus-storage/java/native src/main/resources/native
-          cp milvus-storage/cpp/build/Release/libmilvus-storage.so milvus-storage/java/native/
-          cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so milvus-storage/java/native/
-          cp milvus-storage/cpp/build/Release/libmilvus-storage.so src/main/resources/native/
-          cp milvus-storage/cpp/build/Release/libmilvus-storage-jni.so src/main/resources/native/
+          mkdir -p src/main/resources/native
+          cp milvus-storage/java/native/libmilvus-storage.so src/main/resources/native/
+          cp milvus-storage/java/native/libmilvus-storage-jni.so src/main/resources/native/
 
       - name: Publish milvus-storage Java binding locally
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,10 @@ on:
 
 jobs:
   build-and-test:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            arch: amd64
-            cmake_arch: x86_64
-          - os: ubuntu-24.04-arm
-            arch: arm64
-            cmake_arch: aarch64
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    # TODO: Add ARM64 support after milvus-storage updates google-cloud-cpp dependency
+    # ARM64 build fails due to crc32c/1.1.1 compilation error with newer GCC
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     container:
       image: spark:4.0.1-scala2.13-java21-python3-ubuntu
       options: --user root
@@ -57,8 +50,7 @@ jobs:
           path: /root/.conan
           key: conan-${{ matrix.arch }}-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
-            conan-${{ matrix.arch }}-
-
+            conan-
       - name: Cache ccache
         if: steps.cache-native.outputs.cache-hit != 'true'
         uses: actions/cache@v4
@@ -66,8 +58,7 @@ jobs:
           path: /root/.ccache
           key: ccache-${{ matrix.arch }}-${{ steps.milvus-storage.outputs.commit }}
           restore-keys: |
-            ccache-${{ matrix.arch }}-
-
+            ccache-
       - name: Cache sbt dependencies
         uses: actions/cache@v4
         with:
@@ -77,8 +68,7 @@ jobs:
             /root/.cache/coursier
           key: sbt-${{ matrix.arch }}-${{ hashFiles('build.sbt', 'project/*.sbt', 'project/*.scala') }}
           restore-keys: |
-            sbt-${{ matrix.arch }}-
-
+            sbt-
       - name: Install build dependencies
         if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
@@ -87,7 +77,7 @@ jobs:
       - name: Install CMake
         if: steps.cache-native.outputs.cache-hit != 'true'
         run: |
-          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-${{ matrix.cmake_arch }}.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
 
       - name: Install sbt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,4 +172,5 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
           VERSION=${{ github.event.release.tag_name }}
-          sbt "set version := \"${VERSION#v}\"" publishSigned sonatypeCentralRelease
+          # Use semicolons to ensure version setting is in same session
+          sbt "; set version := \"${VERSION#v}\"; publishSigned; sonatypeBundleRelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: builder
+          load: true
+          tags: spark-milvus-release:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run unit tests
+        run: |
+          docker run --rm spark-milvus-release:latest bash -c "
+            source \$SDKMAN_DIR/bin/sdkman-init.sh && \
+            sbt 'testOnly \
+              com.zilliz.spark.connector.MilvusOptionTest \
+              com.zilliz.spark.connector.MilvusS3OptionTest \
+              com.zilliz.spark.connector.DataTypeUtilTest \
+              com.zilliz.spark.connector.filter.VectorBruteForceSearchTest \
+              com.zilliz.spark.connector.operations.backfill.BackfillConfigTest \
+              com.zilliz.spark.connector.loon.PropertiesTest \
+              serde.SchemaUtilTest'
+          "
+
+      - name: Build assembly JAR
+        run: |
+          mkdir -p dist
+          docker run --rm -v $(pwd)/dist:/dist spark-milvus-release:latest bash -c "
+            source \$SDKMAN_DIR/bin/sdkman-init.sh && \
+            sbt assembly && \
+            cp target/scala-2.13/*.jar /dist/
+          "
+
+      - name: Extract native libraries
+        run: |
+          docker create --name extract spark-milvus-release:latest
+          docker cp extract:/workspace/src/main/resources/native/ ./dist/native/ || true
+          docker rm extract
+
+      - name: Create release archive
+        run: |
+          cd dist
+          VERSION=${{ github.event.release.tag_name }}
+          tar -czvf spark-milvus-${VERSION}.tar.gz *.jar native/
+          zip -r spark-milvus-${VERSION}.zip *.jar native/
+
+      - name: Upload release assets to GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/spark-milvus-*.tar.gz
+            dist/spark-milvus-*.zip
+            dist/*.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Maven Central
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: |
+          # Create Sonatype credentials file
+          mkdir -p ~/.sbt
+          cat > ~/.sbt/sonatype_central_credentials << EOF
+          host=central.sonatype.com
+          user=$SONATYPE_USERNAME
+          password=$SONATYPE_PASSWORD
+          EOF
+
+          # Import GPG key for signing
+          echo "$PGP_SECRET" | base64 -d | gpg --batch --import
+
+          # Publish to Maven Central
+          docker run --rm \
+            -v ~/.sbt:/root/.sbt \
+            -v ~/.gnupg:/root/.gnupg \
+            -e PGP_PASSPHRASE="$PGP_PASSPHRASE" \
+            spark-milvus-release:latest bash -c "
+              source \$SDKMAN_DIR/bin/sdkman-init.sh && \
+              sbt 'set version := \"${{ github.event.release.tag_name }}\"' publishSigned sonatypeCentralRelease
+            "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,5 +172,5 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
           VERSION=${{ github.event.release.tag_name }}
-          # Use semicolons to ensure version setting is in same session
-          sbt "; set version := \"${VERSION#v}\"; publishSigned; sonatypeBundleRelease"
+          # Use sonatypeCentralUpload for Sonatype Central Portal
+          sbt "; set version := \"${VERSION#v}\"; publishSigned; sonatypeCentralUpload"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,63 +7,135 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
+    container:
+      image: spark:4.0.1-scala2.13-java21-python3-ubuntu
+      options: --user root
 
     permissions:
       contents: write
 
     steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git gnupg
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Get milvus-storage commit ID
+        id: milvus-storage
+        run: |
+          echo "commit=$(git -C milvus-storage rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build Docker image
-        uses: docker/build-push-action@v5
+      # 复用 CI 的 native library 缓存
+      - name: Cache native library build
+        id: cache-native
+        uses: actions/cache@v4
         with:
-          context: .
-          target: builder
-          load: true
-          tags: spark-milvus-release:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          path: |
+            milvus-storage/cpp/build
+            milvus-storage/java/native
+          key: native-${{ steps.milvus-storage.outputs.commit }}
+
+      - name: Cache Conan packages
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: /root/.conan
+          key: conan-${{ steps.milvus-storage.outputs.commit }}
+          restore-keys: |
+            conan-
+
+      - name: Cache ccache
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        uses: actions/cache@v4
+        with:
+          path: /root/.ccache
+          key: ccache-${{ steps.milvus-storage.outputs.commit }}
+          restore-keys: |
+            ccache-
+
+      - name: Cache sbt dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            /root/.sbt
+            /root/.ivy2/cache
+            /root/.cache/coursier
+          key: sbt-${{ hashFiles('build.sbt', 'project/*.sbt', 'project/*.scala') }}
+          restore-keys: |
+            sbt-
+
+      - name: Install build dependencies
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        run: |
+          apt-get install -y g++ gcc make ccache automake autoconf libtool curl wget
+
+      - name: Install CMake
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        run: |
+          wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-x86_64.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+
+      - name: Install sbt
+        run: |
+          curl -fL https://github.com/sbt/sbt/releases/download/v1.11.1/sbt-1.11.1.tgz | tar xz -C /usr/local
+          ln -sf /usr/local/sbt/bin/sbt /usr/local/bin/sbt
+
+      - name: Install Conan
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        run: |
+          pip3 install conan==1.61.0
+          conan profile new default --detect || true
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+          conan remote add default-conan-local https://milvus01.jfrog.io/artifactory/api/conan/default-conan-local --insert || true
+
+      - name: Build milvus-storage native library
+        if: steps.cache-native.outputs.cache-hit != 'true'
+        run: |
+          cd milvus-storage/cpp
+          make build USE_JNI=True WITH_UT=False USE_ASAN=False
+          mkdir -p ../java/native
+          cp build/Release/libmilvus-storage.so ../java/native/
+          cp build/Release/libmilvus-storage-jni.so ../java/native/
+
+      - name: Copy native libraries
+        run: |
+          mkdir -p src/main/resources/native
+          cp milvus-storage/java/native/libmilvus-storage.so src/main/resources/native/
+          cp milvus-storage/java/native/libmilvus-storage-jni.so src/main/resources/native/
+
+      - name: Publish milvus-storage Java binding locally
+        run: |
+          cd milvus-storage/java
+          sbt publishLocal
 
       - name: Run unit tests
         run: |
-          docker run --rm spark-milvus-release:latest bash -c "
-            source \$SDKMAN_DIR/bin/sdkman-init.sh && \
-            sbt 'testOnly \
-              com.zilliz.spark.connector.MilvusOptionTest \
-              com.zilliz.spark.connector.MilvusS3OptionTest \
-              com.zilliz.spark.connector.DataTypeUtilTest \
-              com.zilliz.spark.connector.filter.VectorBruteForceSearchTest \
-              com.zilliz.spark.connector.operations.backfill.BackfillConfigTest \
-              com.zilliz.spark.connector.loon.PropertiesTest \
-              serde.SchemaUtilTest'
-          "
+          sbt 'testOnly \
+            com.zilliz.spark.connector.MilvusOptionTest \
+            com.zilliz.spark.connector.MilvusS3OptionTest \
+            com.zilliz.spark.connector.DataTypeUtilTest \
+            com.zilliz.spark.connector.filter.VectorBruteForceSearchTest \
+            com.zilliz.spark.connector.operations.backfill.BackfillConfigTest \
+            com.zilliz.spark.connector.loon.PropertiesTest \
+            serde.SchemaUtilTest'
 
       - name: Build assembly JAR
         run: |
-          mkdir -p dist
-          docker run --rm -v $(pwd)/dist:/dist spark-milvus-release:latest bash -c "
-            source \$SDKMAN_DIR/bin/sdkman-init.sh && \
-            sbt assembly && \
-            cp target/scala-2.13/*.jar /dist/
-          "
-
-      - name: Extract native libraries
-        run: |
-          docker create --name extract spark-milvus-release:latest
-          docker cp extract:/workspace/src/main/resources/native/ ./dist/native/ || true
-          docker rm extract
+          VERSION=${{ github.event.release.tag_name }}
+          sbt "set version := \"${VERSION#v}\"" assembly
 
       - name: Create release archive
         run: |
-          cd dist
           VERSION=${{ github.event.release.tag_name }}
+          mkdir -p dist
+          cp target/scala-2.13/*.jar dist/
+          cp -r src/main/resources/native dist/
+          cd dist
           tar -czvf spark-milvus-${VERSION}.tar.gz *.jar native/
           zip -r spark-milvus-${VERSION}.zip *.jar native/
 
@@ -77,30 +149,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to Maven Central
+      - name: Setup GPG for signing
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: |
+          echo "$PGP_SECRET" | base64 -d | gpg --batch --import
+
+      - name: Setup Sonatype credentials
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: |
-          # Create Sonatype credentials file
-          mkdir -p ~/.sbt
-          cat > ~/.sbt/sonatype_central_credentials << EOF
+          mkdir -p /root/.sbt
+          cat > /root/.sbt/sonatype_central_credentials << EOF
           host=central.sonatype.com
           user=$SONATYPE_USERNAME
           password=$SONATYPE_PASSWORD
           EOF
 
-          # Import GPG key for signing
-          echo "$PGP_SECRET" | base64 -d | gpg --batch --import
-
-          # Publish to Maven Central
-          docker run --rm \
-            -v ~/.sbt:/root/.sbt \
-            -v ~/.gnupg:/root/.gnupg \
-            -e PGP_PASSPHRASE="$PGP_PASSPHRASE" \
-            spark-milvus-release:latest bash -c "
-              source \$SDKMAN_DIR/bin/sdkman-init.sh && \
-              sbt 'set version := \"${{ github.event.release.tag_name }}\"' publishSigned sonatypeCentralRelease
-            "
+      - name: Publish to Maven Central
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          VERSION=${{ github.event.release.tag_name }}
+          sbt "set version := \"${VERSION#v}\"" publishSigned sonatypeCentralRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Git
         run: |
           apt-get update
-          apt-get install -y git gnupg
+          apt-get install -y git gnupg zip
 
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add CI workflow triggered on PR to main branch
- Add Release workflow triggered on GitHub release publish

## CI Workflow (`ci.yml`)

- Uses `spark:4.0.1-scala2.13-java21-python3-ubuntu` container
- Builds milvus-storage native library
- Runs 114 unit tests
- Caches Conan, ccache, and sbt dependencies for faster builds

## Release Workflow (`release.yml`)

- Builds Docker image for release
- Runs unit tests
- Creates assembly JAR with native libraries
- Uploads to GitHub Release page (tar.gz, zip, jar)
- Publishes to Maven Central via Sonatype

## Test plan

- [x] Local Docker build successful
- [x] All 114 unit tests pass
- [ ] CI workflow runs on this PR