### PR TITLE
feat: support AssumeRole and spark.hadoop.* S3 credentials configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ ARG PUBLISH_TO_CENTRAL=true
 ENV SBT_OPTS="-Xmx4g -Xms2g"
 RUN --mount=type=cache,target=/root/.sbt \
     if [ "$PUBLISH_TO_CENTRAL" = "true" ]; then \
-        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish"; \
+        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish sonatypeBundleRelease"; \
     fi
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,11 +120,15 @@ COPY --from=builder /workspace/project/ /workspace/project/
 COPY --from=builder /workspace/target/ /workspace/target/
 COPY --from=builder /root/.ivy2/local /root/.ivy2/local
 
-ARG PUBLISH_TO_CENTRAL=true
+ARG PUBLISH_TO_NEXUS=true
+ARG NEXUS_USER=""
+ARG NEXUS_PASSWORD=""
+ENV NEXUS_USER=${NEXUS_USER}
+ENV NEXUS_PASSWORD=${NEXUS_PASSWORD}
 ENV SBT_OPTS="-Xmx4g -Xms2g"
 RUN --mount=type=cache,target=/root/.sbt \
-    if [ "$PUBLISH_TO_CENTRAL" = "true" ]; then \
-        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish sonatypeCentralUpload"; \
+    if [ "$PUBLISH_TO_NEXUS" = "true" ]; then \
+        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish"; \
     fi
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,7 @@ ARG PUBLISH_TO_CENTRAL=true
 ENV SBT_OPTS="-Xmx4g -Xms2g"
 RUN --mount=type=cache,target=/root/.sbt \
     if [ "$PUBLISH_TO_CENTRAL" = "true" ]; then \
-        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish sonatypeBundleRelease"; \
+        bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publish sonatypeCentralUpload"; \
     fi
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,12 +78,12 @@ RUN --mount=type=cache,target=/root/.ivy2 \
     --mount=type=cache,target=/root/.sbt \
     cd milvus-storage/java && bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt publishLocal"
 
-# Build spark-milvus connector (with cache)
+# Build spark-milvus connector with assembly JAR (with cache)
 ENV GIT_BRANCH=${GIT_BRANCH}
 ENV SBT_OPTS="-Xmx4g -Xms2g"
 RUN --mount=type=cache,target=/root/.ivy2 \
     --mount=type=cache,target=/root/.sbt \
-    bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt package"
+    bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sbt assembly"
 
 # Stage 2: Final image (only copy artifacts and publish)
 FROM spark:4.0.1-scala2.13-java21-python3-ubuntu AS final

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val root = (project in file("."))
     assembly / parallelExecution := true,
     Test / parallelExecution := true,
     Compile / compile / parallelExecution := true,
-    version := s"${gitBranch}-${arch}-SNAPSHOT",
+    version := s"${gitBranch}-${arch}",  // Release version (no SNAPSHOT)
     organization := "com.zilliz",
 
     // Disable Scaladoc and sources jar for publish (not needed, speeds up build)

--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,9 @@ lazy val root = (project in file("."))
     version := s"${gitBranch}-${arch}",  // Release version (no SNAPSHOT)
     organization := "com.zilliz",
 
-    // Disable Scaladoc and sources jar for publish (not needed, speeds up build)
-    Compile / packageDoc / publishArtifact := false,
-    Compile / packageSrc / publishArtifact := false,
+    // Enable Scaladoc and sources jar for Maven Central publishing (required)
+    Compile / packageDoc / publishArtifact := true,
+    Compile / packageSrc / publishArtifact := true,
 
     // Fork JVM for run and tests to properly load native libraries
     run / fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -39,12 +39,8 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishMavenStyle := true
 
-ThisBuild / publishTo := {
-  val centralSnapshots =
-    "https://central.sonatype.com/repository/maven-snapshots/"
-  if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
-  else localStaging.value
-}
+// For Sonatype Central, use sonatypeCentralHost and let sbt-sonatype handle publishing
+ThisBuild / publishTo := sonatypeCentralHost
 
 ThisBuild / licenses := List(
   "Server Side Public License v1" -> new URL(

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val root = (project in file("."))
     assembly / parallelExecution := true,
     Test / parallelExecution := true,
     Compile / compile / parallelExecution := true,
-    version := s"${gitBranch}-${arch}",  // Release version (no SNAPSHOT)
+    version := s"0.1.0-${gitBranch}-${arch}",  // Release version with semver prefix
     organization := "com.zilliz",
 
     // Enable sources jar for Maven Central publishing (required)

--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,11 @@ lazy val root = (project in file("."))
     version := s"${gitBranch}-${arch}",  // Release version (no SNAPSHOT)
     organization := "com.zilliz",
 
-    // Enable Scaladoc and sources jar for Maven Central publishing (required)
-    Compile / packageDoc / publishArtifact := true,
+    // Enable sources jar for Maven Central publishing (required)
     Compile / packageSrc / publishArtifact := true,
+    // Generate empty javadoc JAR (Scaladoc fails on generated protobuf code)
+    Compile / packageDoc / publishArtifact := true,
+    Compile / doc / sources := Seq.empty,
 
     // Fork JVM for run and tests to properly load native libraries
     run / fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,8 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishMavenStyle := true
 
-// For Sonatype Central, use sonatypeCentralHost and let sbt-sonatype handle publishing
-ThisBuild / publishTo := sonatypeCentralHost
+// For Sonatype Central, use sonatypePublishToBundle for bundle publishing
+ThisBuild / publishTo := sonatypePublishToBundle.value
 
 ThisBuild / licenses := List(
   "Server Side Public License v1" -> new URL(


### PR DESCRIPTION
## Summary
- Add support for `spark.hadoop.fs.s3a.*` configuration to enable AssumedRoleCredentialProvider
- Extract fs.s3a.* configs from SparkSession's hadoopConfiguration at initialization
- Only set default credentials provider when not already configured via spark.hadoop.*
- Change default AK/SK to empty string to support IAM role and environment variables

## Usage

### Via spark.hadoop.* (AssumeRole)
```yaml
spark.hadoop.fs.s3a.aws.credentials.provider: "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider"
spark.hadoop.fs.s3a.assumed.role.arn: "arn:aws:iam::xxx:role/spark-data-role"
spark.hadoop.fs.s3a.assumed.role.credentials.provider: "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
```

### Via options (AK/SK)
```python
spark.read.format("milvus")
    .option("s3.user", "access-key")
    .option("s3.password", "secret-key")
    .load()
```

### Via environment variables / IAM role
```python
# No s3.user/s3.password needed, uses DefaultAWSCredentialsProviderChain
spark.read.format("milvus")
    .option("s3.fs", "s3a://")
    .load()
```

## Test plan
- [ ] Test with explicit AK/SK via options
- [ ] Test with spark.hadoop.* AssumedRoleCredentialProvider configuration
- [ ] Test with empty credentials (DefaultAWSCredentialsProviderChain)