### PR TITLE
fix: simplify snapshot manifest handling by passing basePath to datas…

### DIFF
--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -92,8 +92,9 @@ case class BackfillConfig(
    */
   def getS3WriteOptions(collectionId: Long, partitionId: Long, segmentId: Long): Map[String, String] = {
     // TODO: this should be changed to field id based on the collection schema once Milvus snapshot feature is ready
+    // Note: bucket name is configured separately via fs.bucket_name, so outputPath should NOT include bucket
     val outputPath = customOutputPath.getOrElse(
-      s"$s3BucketName/$s3RootPath/insert_log/$collectionId/$partitionId/$segmentId/new_field"
+      s"$s3RootPath/insert_log/$collectionId/$partitionId/$segmentId/new_field"
     )
 
     Map(

--- a/src/test/scala/operations/backfill/MilvusBackfillTest.scala
+++ b/src/test/scala/operations/backfill/MilvusBackfillTest.scala
@@ -32,7 +32,7 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
   val snapshotName = s"backfill_snapshot_${System.currentTimeMillis()}"
   val dim = 128
   val batchSize = 10000
-  val batchCount = 100
+  val batchCount = 10
   val s3Bucket = "a-bucket"
 
   // Jackson mapper for JSON parsing


### PR DESCRIPTION
…ource

  - Change manifest handling to pass basePath instead of full manifest content, letting the FFI reader load manifests directly from storage
  - Fix S3 output path in BackfillConfig to exclude bucket name (configured separately via fs.bucket_name)
  - Add StorageV2ManifestItem companion object with factory method for Long segmentID serialization
  - Extract segmentID from manifest path in MilvusDataSource when not explicitly provided
  - Remove verbose logging statements throughout MilvusBackfill
  - Reduce test batchCount from 100 to 10 for faster test execution
  
  related: https://github.com/zilliztech/spark-milvus/issues/74