### PR TITLE
Fix: Propagate Hadoop S3 configuration to Executors

### DIFF
--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -264,6 +264,7 @@ case class MilvusS3Option(
       // Credentials priority: AK/SK options > spark.hadoop.* > DefaultAWSCredentialsProviderChain
       if (notEmpty(s3AccessKey) && notEmpty(s3SecretKey)) {
         // Priority 1: Use explicit AK/SK credentials when provided via options
+        println(s"MilvusS3Option: Initializing S3 FileSystem using explicit AccessKey/SecretKey. Endpoint: $s3Endpoint")
         conf.set(
           "fs.s3a.aws.credentials.provider",
           "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider,com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
@@ -272,25 +273,18 @@ case class MilvusS3Option(
         conf.set("fs.s3a.secret.key", s3SecretKey)
       } else if (sparkHadoopS3Conf.nonEmpty) {
         // Priority 2: Use Spark's hadoop configuration (spark.hadoop.fs.s3a.*)
-        // This allows users to configure AssumedRoleCredentialProvider via spark.hadoop.*
+        println(s"MilvusS3Option: Initializing S3 FileSystem using Spark Hadoop Configuration (fs.s3a.*). Endpoint: $s3Endpoint")
         sparkHadoopS3Conf.foreach { case (key, value) =>
           conf.set(key, value)
         }
-        // Set default provider if not configured in spark.hadoop.*
-        if (conf.get("fs.s3a.aws.credentials.provider") == null) {
-          conf.set(
-            "fs.s3a.aws.credentials.provider",
-            "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
-          )
-        }
       } else {
         // Priority 3: Use DefaultAWSCredentialsProviderChain for IAM role / env vars
+        println(s"MilvusS3Option: No specific credentials provided. Initializing S3 FileSystem using DefaultAWSCredentialsProviderChain. Endpoint: $s3Endpoint")
         conf.set(
           "fs.s3a.aws.credentials.provider",
           "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
         )
       }
-
       conf.set("fs.s3a.connection.ssl.enabled", s3UseSSL.toString)
 
       // Performance optimization settings

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -18,7 +18,7 @@ class MilvusPartitionReaderFactory(
 ) extends PartitionReaderFactory with Logging {
 
   // Reconstruct CaseInsensitiveStringMap for V1 reader
-  @transient private lazy val readerOptions = {
+  private val readerOptions = {
     import scala.jdk.CollectionConverters._
     import java.util.HashMap
     val javaMap = new HashMap[String, String]()


### PR DESCRIPTION
This change fixes an issue where the Hadoop S3 configuration (specifically fs.s3a.aws.credentials.provider) was lost during serialization to executors because readerOptions was marked @transient lazy. It also improves logging and fallback logic for S3A credential providers.