### PR TITLE
enhance: support snapshot-only backfill with correct field IDs and fix data corruption

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "spark-connector",
     assembly / parallelExecution := true,
+    assembly / assemblyPackageScala / assembleArtifact := false,
     Test / parallelExecution := true,
     Compile / compile / parallelExecution := true,
     version := s"${gitBranch}-${arch}-SNAPSHOT",
@@ -143,8 +144,8 @@ lazy val root = (project in file("."))
     ),
 
     // Add milvus-storage JNI library as unmanaged dependency
-    Compile / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni-test_2.13-0.1.0-SNAPSHOT.jar",
-    Test / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni-test_2.13-0.1.0-SNAPSHOT.jar",
+    Compile / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni_2.13-0.1.0-SNAPSHOT.jar",
+    Test / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni_2.13-0.1.0-SNAPSHOT.jar",
 
     libraryDependencies ++= Seq(
       munit % Test,

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -115,6 +115,8 @@ object MilvusOption {
 
   // Writer config
   val WriterCustomPath = "milvus.writer.customPath"
+  val WriterCommitType = "milvus.writer.commitType"  // "addfield" for backfill, default "addfiles"
+  val WriterFieldIds = "milvus.writer.fieldIds"      // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
 
   // Snapshot-based reading options (for offline/client-free mode)
   val SnapshotMode = "milvus.snapshot.mode"                 // "true" to enable snapshot mode

--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -1,5 +1,8 @@
 package com.zilliz.spark.connector.operations.backfill
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
 /**
  * Result of backfilling a single segment
  */
@@ -56,29 +59,32 @@ case class BackfillResult(
    * Serialize this result to a JSON string
    */
   def toJson: String = {
-    val segmentsJson = segmentResults.toSeq.sortBy(_._1).map { case (segId, r) =>
-      val manifestPathsJson = r.manifestPaths.map(p => s""""${escapeJson(p)}"""").mkString("[", ", ", "]")
-      s"""    "$segId": {"version": ${r.committedVersion}, "rowCount": ${r.rowCount}, "executionTimeMs": ${r.executionTimeMs}, "outputPath": "${escapeJson(r.outputPath)}", "manifestPaths": $manifestPathsJson}"""
-    }.mkString(",\n")
+    val mapper = new ObjectMapper()
+    mapper.registerModule(DefaultScalaModule)
 
-    val newFieldNamesJson = newFieldNames.map(n => s""""${escapeJson(n)}"""").mkString("[", ", ", "]")
+    val segments = segmentResults.toSeq.sortBy(_._1).map { case (segId, r) =>
+      segId.toString -> Map(
+        "version" -> r.committedVersion,
+        "rowCount" -> r.rowCount,
+        "executionTimeMs" -> r.executionTimeMs,
+        "outputPath" -> r.outputPath,
+        "manifestPaths" -> r.manifestPaths
+      )
+    }.toMap
 
-    s"""{
-       |  "success": $success,
-       |  "collectionId": $collectionId,
-       |  "partitionId": $partitionId,
-       |  "segmentsProcessed": $segmentsProcessed,
-       |  "totalRowsWritten": $totalRowsWritten,
-       |  "executionTimeMs": $executionTimeMs,
-       |  "newFieldNames": $newFieldNamesJson,
-       |  "segments": {
-       |$segmentsJson
-       |  }
-       |}""".stripMargin
+    val result = Map(
+      "success" -> success,
+      "collectionId" -> collectionId,
+      "partitionId" -> partitionId,
+      "segmentsProcessed" -> segmentsProcessed,
+      "totalRowsWritten" -> totalRowsWritten,
+      "executionTimeMs" -> executionTimeMs,
+      "newFieldNames" -> newFieldNames,
+      "segments" -> segments
+    )
+
+    mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result)
   }
-
-  private def escapeJson(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
 
   /**
    * Check if all segments were processed successfully

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -132,8 +132,18 @@ object MilvusBackfill {
           Map.empty
       }
 
-      // Filter to only the new fields being backfilled
-      val newFieldNameToId = newFieldNames.flatMap(n => fieldNameToId.get(n).map(n -> _)).toMap
+      // Filter to only the new fields being backfilled, fail fast if any field is missing from snapshot schema
+      val newFieldNameToId = if (fieldNameToId.nonEmpty) {
+        val missing = newFieldNames.filterNot(fieldNameToId.contains)
+        if (missing.nonEmpty) {
+          return Left(SchemaValidationError(
+            s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
+            s"Available fields: ${fieldNameToId.keys.mkString(", ")}"))
+        }
+        newFieldNames.map(n => n -> fieldNameToId(n)).toMap
+      } else {
+        Map.empty[String, Long]
+      }
 
       // Process each segment
       val segmentResults = processSegments(
@@ -651,18 +661,20 @@ object MilvusBackfill {
       val segId = item.segmentID
       MilvusSnapshotReader.parseManifestContent(item.manifest) match {
         case Right(mc) =>
-          segmentBasePathMap += (segId -> mc.basePath)
           // Extract partition ID from basePath: .../insert_log/{col_id}/{part_id}/{seg_id}
           val parts = mc.basePath.split("/")
           val insertLogIdx = parts.indexOf("insert_log")
           if (insertLogIdx >= 0 && insertLogIdx + 2 < parts.length) {
             try {
               val partitionId = parts(insertLogIdx + 2).toLong
+              segmentBasePathMap += (segId -> mc.basePath)
               segmentToPartitionMap += (segId -> partitionId)
             } catch {
               case _: NumberFormatException =>
-                logger.warn(s"Failed to parse partition ID from basePath: ${mc.basePath}")
+                logger.warn(s"Skipping segment $segId: failed to parse partition ID from basePath: ${mc.basePath}")
             }
+          } else {
+            logger.warn(s"Skipping segment $segId: basePath does not contain expected insert_log structure: ${mc.basePath}")
           }
         case Left(e) =>
           logger.warn(s"Failed to parse manifest for segment $segId: ${e.getMessage}")

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -50,7 +50,10 @@ object MilvusBackfill {
     }
 
     // Step 1: Try to load snapshot metadata
-    val snapshotMetadataOpt = loadSnapshotMetadata(spark, snapshotPath, config)
+    val snapshotMetadataOpt = loadSnapshotMetadata(spark, snapshotPath, config) match {
+      case Left(error) => return Left(error)
+      case Right(opt) => opt
+    }
 
     // Step 2: Create Milvus client only if no snapshot is available
     var client: MilvusClient = null
@@ -128,22 +131,19 @@ object MilvusBackfill {
         case Some(metadata) =>
           MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
         case None =>
-          // TODO: get from Milvus client when needed
-          Map.empty
+          return Left(SchemaValidationError(
+            "ADDFIELD backfill requires field ID mapping from snapshot. " +
+            "Please provide a snapshot path to resolve correct field IDs."))
       }
 
       // Filter to only the new fields being backfilled, fail fast if any field is missing from snapshot schema
-      val newFieldNameToId = if (fieldNameToId.nonEmpty) {
-        val missing = newFieldNames.filterNot(fieldNameToId.contains)
-        if (missing.nonEmpty) {
-          return Left(SchemaValidationError(
-            s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
-            s"Available fields: ${fieldNameToId.keys.mkString(", ")}"))
-        }
-        newFieldNames.map(n => n -> fieldNameToId(n)).toMap
-      } else {
-        Map.empty[String, Long]
+      val missing = newFieldNames.filterNot(fieldNameToId.contains)
+      if (missing.nonEmpty) {
+        return Left(SchemaValidationError(
+          s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
+          s"Available fields: ${fieldNameToId.keys.mkString(", ")}"))
       }
+      val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
 
       // Process each segment
       val segmentResults = processSegments(
@@ -623,24 +623,27 @@ object MilvusBackfill {
 
   /**
    * Load and parse snapshot metadata from file.
-   * Returns None if snapshot path is empty or parsing fails.
+   * Returns None if snapshot path is empty.
+   * Returns Left(error) if snapshot path is provided but parsing fails.
    */
   private def loadSnapshotMetadata(
       spark: SparkSession,
       snapshotPath: String,
       config: BackfillConfig
-  ): Option[SnapshotMetadata] = {
-    if (snapshotPath == null || snapshotPath.isEmpty) return None
+  ): Either[BackfillError, Option[SnapshotMetadata]] = {
+    if (snapshotPath == null || snapshotPath.isEmpty) return Right(None)
 
     readSnapshotJson(spark, snapshotPath, config) match {
       case Right(json) if json.nonEmpty =>
         MilvusSnapshotReader.parseSnapshotMetadata(json) match {
-          case Right(metadata) => Some(metadata)
+          case Right(metadata) => Right(Some(metadata))
           case Left(e) =>
-            logger.warn(s"Failed to parse snapshot metadata: ${e.getMessage}")
-            None
+            Left(SchemaValidationError(s"Failed to parse snapshot metadata: ${e.getMessage}"))
         }
-      case _ => None
+      case Right(_) =>
+        Left(SchemaValidationError(s"Snapshot file is empty: $snapshotPath"))
+      case Left(e) =>
+        Left(SchemaValidationError(s"Failed to read snapshot file: ${e.getMessage}"))
     }
   }
 
@@ -697,7 +700,7 @@ object MilvusBackfill {
       val fs = hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
       val out = fs.create(hadoopPath, true)
       try {
-        out.writeBytes(result.toJson)
+        out.write(result.toJson.getBytes(java.nio.charset.StandardCharsets.UTF_8))
       } finally {
         out.close()
       }

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -13,5 +13,6 @@ case class MilvusStorageV2InputPartition(
     queryVector: Option[Array[Float]] = None,
     metricType: Option[String] = None,
     vectorColumn: Option[String] = None,
-    segmentID: Long = -1L
+    segmentID: Long = -1L,
+    readVersion: Long = -1L  // -1 = LATEST, >0 = specific manifest version from snapshot
 ) extends InputPartition

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -43,7 +43,8 @@ class MilvusPartitionReaderFactory(
           p.queryVector,
           p.metricType,
           p.vectorColumn,
-          pushedFilters
+          pushedFilters,
+          p.readVersion
         )
 
         // If the expected schema includes system/metadata fields, wrap the reader to add them

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -224,7 +224,7 @@ case class ManifestContent(
  * Storage V2 manifest item
  */
 case class StorageV2ManifestItem(
-    @JsonProperty("segmentID") rawSegmentID: Option[JsonNode] = None,  // Can be Long or String from JSON
+    @JsonProperty("segmentID") @JsonAlias(Array("segment_id")) rawSegmentID: Option[JsonNode] = None,  // Can be Long or String from JSON
     @JsonProperty("manifest") manifest: String = "",
     @JsonProperty("segmentIDLong") rawSegmentIDLong: Option[JsonNode] = None  // For serialization (using JsonNode to handle Int/Long)
 ) {

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -270,7 +270,7 @@ object ArrowConverter extends Logging {
       sparkSchema: StructType
   ): Unit = {
     sparkSchema.fields.zipWithIndex.foreach { case (field, colIndex) =>
-      val vector = root.getVector(field.name)
+      val vector = root.getVector(colIndex)
       sparkValueToArrowValue(vector, rowIndex, record, colIndex, field.dataType)
     }
   }


### PR DESCRIPTION
- Enable snapshot-only mode: extract collectionID, partition mapping, and segment base paths from snapshot manifests without requiring a live Milvus connection
- Write new fields with correct Milvus field IDs from snapshot schema; use numeric field ID as Arrow column name per milvus-storage convention
- Pin manifest reads to snapshot version (ver) for point-in-time consistency
- Fix UnsafeRow reuse corruption: .copy() before keyBy/partitionBy to prevent ExternalSorter from referencing the same mutable buffer
- Fix Arrow C Data zero-copy corruption: create new VectorSchemaRoot per flush, keep exported roots alive until C++ writer closes
- Use index-based Arrow vector lookup to support numeric field ID column names
- Return committedVersion from transaction commit; support ADDFIELD commit type
- Update milvus-storage submodule and align JNI JAR artifact name

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>