### PR TITLE
enhance: add exponential backoff retry for insert rate limit

### DIFF
--- a/src/main/scala/Exception.scala
+++ b/src/main/scala/Exception.scala
@@ -7,3 +7,5 @@ case class DataTypeException(message: String) extends Exception(message)
 case class MilvusConnectionException(message: String) extends Exception(message)
 
 case class MilvusRpcException(message: String) extends Exception(message)
+
+case class MilvusRateLimitException(message: String) extends Exception(message)

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -175,7 +175,9 @@ class MilvusClient(params: MilvusConnectionParams) {
   }
 
   def checkStatus(api: String, status: Status): Try[Status] = {
-    if (status.code != 0 || status.errorCode != ErrorCode.Success) {
+    if (status.code == 8 || status.reason.contains("rate limit exceeded")) {
+      Failure(new MilvusRateLimitException(s"Failed to $api: ${status.reason}"))
+    } else if (status.code != 0 || status.errorCode != ErrorCode.Success) {
       Failure(new Exception(s"Failed to $api: ${status.reason}"))
     } else {
       Success(status)

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -175,12 +175,18 @@ class MilvusClient(params: MilvusConnectionParams) {
   }
 
   def checkStatus(api: String, status: Status): Try[Status] = {
-    if (status.code == 8 || status.reason.contains("rate limit exceeded")) {
-      Failure(new MilvusRateLimitException(s"Failed to $api: ${status.reason}"))
-    } else if (status.code != 0 || status.errorCode != ErrorCode.Success) {
-      Failure(new Exception(s"Failed to $api: ${status.reason}"))
+    // Success path first: avoids misclassifying success responses whose reason
+    // may coincidentally contain rate-limit-like text.
+    if (status.code == 0 && status.errorCode == ErrorCode.Success) {
+      return Success(status)
+    }
+    // Failure path: classify rate limit vs other errors.
+    val reason = Option(status.reason).getOrElse("")
+    if (status.code == MilvusClient.RateLimitErrorCode ||
+        reason.toLowerCase.contains(MilvusClient.RateLimitReasonMarker)) {
+      Failure(new MilvusRateLimitException(s"Failed to $api: $reason"))
     } else {
-      Success(status)
+      Failure(new Exception(s"Failed to $api: $reason"))
     }
   }
 
@@ -796,6 +802,11 @@ class MilvusClient(params: MilvusConnectionParams) {
 object MilvusClient {
   val baseUrl = "/v2/vectordb"
   val segmentsUrl = s"$baseUrl/segments/describe"
+
+  // Milvus ErrServiceRateLimit (also matches gRPC RESOURCE_EXHAUSTED numeric value).
+  val RateLimitErrorCode: Int = 8
+  // Case-insensitive reason marker used as a fallback when error code is not set.
+  val RateLimitReasonMarker: String = "rate limit exceeded"
 
   val mapper: ObjectMapper with ScalaObjectMapper = {
     val m = new ObjectMapper() with ScalaObjectMapper

--- a/src/main/scala/write/MilvusInsertDataWriter.scala
+++ b/src/main/scala/write/MilvusInsertDataWriter.scala
@@ -60,18 +60,11 @@ case class MilvusInsertDataWriter(
   private var totalSize = 0
   private var currentHandledBuffer = Seq.empty[FieldData]
 
-  private val maxRateLimitRetries = 10
-  private val initialRateLimitDelay = 500L
-  private val maxRateLimitDelay = 10000L
-
   private def flushBuffer(
       retries: Int = milvusOption.retryCount,
-      rateLimitRetries: Int = maxRateLimitRetries,
-      rateLimitDelay: Long = initialRateLimitDelay
+      rateLimitRetries: Int = MilvusInsertDataWriter.MaxRateLimitRetries,
+      rateLimitDelay: Long = MilvusInsertDataWriter.InitialRateLimitDelay
   ): Unit = {
-    if (retries <= 0 && rateLimitRetries <= 0) {
-      throw new MilvusRpcException("Flush buffer failed")
-    }
     if (currentHandledBuffer.isEmpty) {
       currentHandledBuffer = MilvusInsertDataWriter.getInsertFieldsData(
         collectionSchema.get,
@@ -80,7 +73,7 @@ case class MilvusInsertDataWriter(
     }
 
     try {
-      val insertResult = milvusClient.insert(
+      milvusClient.insert(
         milvusOption.databaseName,
         milvusOption.collectionName,
         if (milvusOption.partitionName.isEmpty) None
@@ -88,31 +81,36 @@ case class MilvusInsertDataWriter(
         currentHandledBuffer,
         numRows = currentSizeInBuffer
       ) match {
-        case Success(status) =>
+        case Success(_) =>
           currentHandledBuffer = Seq.empty[FieldData]
           currentSizeInBuffer = 0
         case Failure(e) =>
           throw e
       }
     } catch {
-      case e: MilvusRateLimitException =>
-        if (rateLimitRetries <= 0) {
-          throw new MilvusRpcException(s"Flush buffer failed after rate limit retries: ${e.getMessage}")
-        }
-        logWarning(
-          s"Rate limit hit, backing off ${rateLimitDelay}ms, remaining retries: ${rateLimitRetries}, error: ${e.getMessage}"
-        )
-        Thread.sleep(rateLimitDelay)
-        flushBuffer(retries, rateLimitRetries - 1, Math.min(rateLimitDelay * 2, maxRateLimitDelay))
       case e: Exception =>
-        if (retries <= 0) {
-          throw new MilvusRpcException(s"Flush buffer failed: ${e.getMessage}")
+        MilvusInsertDataWriter.decideRetry(
+          error = e,
+          retries = retries,
+          rateLimitRetries = rateLimitRetries,
+          rateLimitDelay = rateLimitDelay,
+          retryInterval = milvusOption.retryInterval
+        ) match {
+          case MilvusInsertDataWriter.Abort(err) =>
+            throw err
+          case MilvusInsertDataWriter.Retry(nextRetries, nextRateLimitRetries, sleepMs, nextRateLimitDelay, isRateLimit) =>
+            if (isRateLimit) {
+              logWarning(
+                s"Rate limit hit, backing off ${sleepMs}ms, remaining retries: ${nextRateLimitRetries}, error: ${e.getMessage}"
+              )
+            } else {
+              logWarning(
+                s"Flush buffer failed, retries: ${nextRetries}, error: ${e.getMessage}"
+              )
+            }
+            Thread.sleep(sleepMs)
+            flushBuffer(nextRetries, nextRateLimitRetries, nextRateLimitDelay)
         }
-        logWarning(
-          s"Flush buffer failed, retries: ${retries}, error: ${e.getMessage}"
-        )
-        Thread.sleep(milvusOption.retryInterval)
-        flushBuffer(retries - 1, rateLimitRetries, rateLimitDelay)
     }
   }
 
@@ -156,6 +154,74 @@ case class MilvusInsertDataWriter(
 }
 
 object MilvusInsertDataWriter {
+  // Retry policy constants (exposed for tests).
+  val MaxRateLimitRetries: Int = 10
+  val InitialRateLimitDelay: Long = 500L
+  val MaxRateLimitDelay: Long = 10000L
+
+  /** Outcome of [[decideRetry]]. Either we retry with updated counters, or we abort. */
+  sealed trait RetryDecision
+  final case class Retry(
+      retries: Int,
+      rateLimitRetries: Int,
+      sleepMs: Long,
+      nextRateLimitDelay: Long,
+      isRateLimit: Boolean
+  ) extends RetryDecision
+  final case class Abort(error: Throwable) extends RetryDecision
+
+  /**
+   * Classify a flush error and decide whether to retry.
+   *
+   *  - [[MilvusRateLimitException]] (app-layer error code 8 from Milvus) consumes
+   *    a rate-limit retry and doubles the backoff up to [[MaxRateLimitDelay]].
+   *  - Any other exception (including transport-layer RESOURCE_EXHAUSTED which
+   *    surfaces as a non-rate-limit gRPC failure because it is in the gRPC
+   *    interceptor's non-retryable set) consumes a generic retry and uses the
+   *    caller-provided [[retryInterval]].
+   *  - The two counters are independent: a generic failure does not consume a
+   *    rate-limit retry, and vice versa.
+   *  - [[rateLimitDelay]] is NOT reset by generic errors; it only resets when a
+   *    new flushBuffer invocation starts with a fresh batch. This is intentional
+   *    so that a burst of rate limits followed by an unrelated error does not
+   *    fall back to a tiny 500ms backoff on the next rate-limit hit.
+   */
+  def decideRetry(
+      error: Throwable,
+      retries: Int,
+      rateLimitRetries: Int,
+      rateLimitDelay: Long,
+      retryInterval: Long,
+      maxRateLimitDelay: Long = MaxRateLimitDelay
+  ): RetryDecision = error match {
+    case _: MilvusRateLimitException =>
+      if (rateLimitRetries <= 0) {
+        Abort(new MilvusRpcException(
+          s"Flush buffer failed after rate limit retries: ${error.getMessage}"
+        ))
+      } else {
+        Retry(
+          retries = retries,
+          rateLimitRetries = rateLimitRetries - 1,
+          sleepMs = rateLimitDelay,
+          nextRateLimitDelay = Math.min(rateLimitDelay * 2, maxRateLimitDelay),
+          isRateLimit = true
+        )
+      }
+    case _ =>
+      if (retries <= 0) {
+        Abort(new MilvusRpcException(s"Flush buffer failed: ${error.getMessage}"))
+      } else {
+        Retry(
+          retries = retries - 1,
+          rateLimitRetries = rateLimitRetries,
+          sleepMs = retryInterval,
+          nextRateLimitDelay = rateLimitDelay, // not reset across generic errors
+          isRateLimit = false
+        )
+      }
+  }
+
   def newDataBuffer(
       schema: CollectionSchema
   ): Map[String, Any] = {

--- a/src/main/scala/write/MilvusInsertDataWriter.scala
+++ b/src/main/scala/write/MilvusInsertDataWriter.scala
@@ -19,6 +19,7 @@ import com.zilliz.spark.connector.{
   MilvusClient,
   MilvusFieldData,
   MilvusOption,
+  MilvusRateLimitException,
   MilvusRpcException,
   MilvusSchemaUtil
 }
@@ -59,8 +60,16 @@ case class MilvusInsertDataWriter(
   private var totalSize = 0
   private var currentHandledBuffer = Seq.empty[FieldData]
 
-  private def flushBuffer(retries: Int = milvusOption.retryCount): Unit = {
-    if (retries <= 0) {
+  private val maxRateLimitRetries = 10
+  private val initialRateLimitDelay = 500L
+  private val maxRateLimitDelay = 10000L
+
+  private def flushBuffer(
+      retries: Int = milvusOption.retryCount,
+      rateLimitRetries: Int = maxRateLimitRetries,
+      rateLimitDelay: Long = initialRateLimitDelay
+  ): Unit = {
+    if (retries <= 0 && rateLimitRetries <= 0) {
       throw new MilvusRpcException("Flush buffer failed")
     }
     if (currentHandledBuffer.isEmpty) {
@@ -86,12 +95,24 @@ case class MilvusInsertDataWriter(
           throw e
       }
     } catch {
+      case e: MilvusRateLimitException =>
+        if (rateLimitRetries <= 0) {
+          throw new MilvusRpcException(s"Flush buffer failed after rate limit retries: ${e.getMessage}")
+        }
+        logWarning(
+          s"Rate limit hit, backing off ${rateLimitDelay}ms, remaining retries: ${rateLimitRetries}, error: ${e.getMessage}"
+        )
+        Thread.sleep(rateLimitDelay)
+        flushBuffer(retries, rateLimitRetries - 1, Math.min(rateLimitDelay * 2, maxRateLimitDelay))
       case e: Exception =>
+        if (retries <= 0) {
+          throw new MilvusRpcException(s"Flush buffer failed: ${e.getMessage}")
+        }
         logWarning(
           s"Flush buffer failed, retries: ${retries}, error: ${e.getMessage}"
         )
         Thread.sleep(milvusOption.retryInterval)
-        flushBuffer(retries - 1)
+        flushBuffer(retries - 1, rateLimitRetries, rateLimitDelay)
     }
   }
 

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -1,0 +1,85 @@
+package com.zilliz.spark.connector
+
+import io.milvus.grpc.common.{ErrorCode, Status}
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.util.{Failure, Success}
+
+/**
+ * Unit tests for MilvusClient.checkStatus classification logic.
+ *
+ * Covers the review feedback on ordering, NPE safety, success-path
+ * misclassification, case-insensitive reason matching, and the named
+ * rate-limit error code constant.
+ */
+class MilvusClientCheckStatusTest extends AnyFunSuite {
+
+  private val client = new MilvusClient(
+    MilvusConnectionParams(
+      uri = "http://localhost:19530",
+      token = "",
+      databaseName = "default"
+    )
+  )
+
+  test("success status returns Success regardless of reason content") {
+    // A coincidental reason containing 'rate limit exceeded' must not flip a
+    // success into a failure.
+    val ok = Status(code = 0, errorCode = ErrorCode.Success, reason = "rate limit exceeded")
+    assert(client.checkStatus("insert", ok).isInstanceOf[Success[_]])
+  }
+
+  test("success status with empty reason returns Success") {
+    val ok = Status(code = 0, errorCode = ErrorCode.Success, reason = "")
+    assert(client.checkStatus("insert", ok).isInstanceOf[Success[_]])
+  }
+
+  test("code == RateLimitErrorCode returns MilvusRateLimitException") {
+    val status = Status(
+      code = MilvusClient.RateLimitErrorCode,
+      errorCode = ErrorCode.UnexpectedError,
+      reason = "request is rejected by grpc RateLimiter middleware"
+    )
+    client.checkStatus("insert", status) match {
+      case Failure(_: MilvusRateLimitException) => succeed
+      case other => fail(s"expected MilvusRateLimitException, got $other")
+    }
+  }
+
+  test("case-insensitive reason matching classifies as rate limit") {
+    val status = Status(
+      code = 99,
+      errorCode = ErrorCode.UnexpectedError,
+      reason = "Rate Limit Exceeded [rate=6.29e+06]"
+    )
+    client.checkStatus("insert", status) match {
+      case Failure(_: MilvusRateLimitException) => succeed
+      case other => fail(s"expected MilvusRateLimitException, got $other")
+    }
+  }
+
+  test("null reason does not NPE and falls through to generic failure") {
+    // scalapb proto case classes default reason to "", but defensively handle null.
+    val status = Status(code = 5, errorCode = ErrorCode.UnexpectedError, reason = null)
+    client.checkStatus("insert", status) match {
+      case Failure(e: MilvusRateLimitException) => fail(s"unexpected rate-limit classification: $e")
+      case Failure(_) => succeed
+      case Success(_) => fail("expected Failure")
+    }
+  }
+
+  test("non-rate-limit failure returns generic Exception") {
+    val status = Status(code = 1, errorCode = ErrorCode.UnexpectedError, reason = "schema mismatch")
+    client.checkStatus("insert", status) match {
+      case Failure(_: MilvusRateLimitException) => fail("should not be classified as rate limit")
+      case Failure(_) => succeed
+      case Success(_) => fail("expected Failure")
+    }
+  }
+
+  test("errorCode != Success with code 0 returns Failure") {
+    // Defensive: code=0 but errorCode flags a real failure.
+    val status = Status(code = 0, errorCode = ErrorCode.UnexpectedError, reason = "something broke")
+    assert(client.checkStatus("insert", status).isFailure)
+  }
+}

--- a/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
+++ b/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
@@ -1,0 +1,230 @@
+package com.zilliz.spark.connector.write
+
+import com.zilliz.spark.connector.{MilvusRateLimitException, MilvusRpcException}
+import com.zilliz.spark.connector.write.MilvusInsertDataWriter.{Abort, Retry, decideRetry}
+import io.grpc.StatusRuntimeException
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for MilvusInsertDataWriter retry decision logic.
+ *
+ * Covers the review feedback on:
+ *   - app-layer rate limit classification (MilvusRateLimitException)
+ *   - transport-layer RESOURCE_EXHAUSTED path (gRPC failure surfacing as a
+ *     generic exception, since the connector's GrpcRetryInterceptor marks
+ *     RESOURCE_EXHAUSTED as non-retryable)
+ *   - rateLimitDelay not being reset across alternating generic/rate-limit paths
+ *   - independent interaction of the two counters (retries / rateLimitRetries)
+ */
+class MilvusInsertDataWriterRetryTest extends AnyFunSuite {
+
+  private val retryInterval = 1000L
+  private val initialDelay = 500L
+  private val maxDelay = 10000L
+
+  // ---------- app-layer rate limit classification ----------
+
+  test("rate limit error consumes a rate-limit retry and doubles backoff") {
+    val decision = decideRetry(
+      error = new MilvusRateLimitException("app layer"),
+      retries = 3,
+      rateLimitRetries = 10,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval,
+      maxRateLimitDelay = maxDelay
+    )
+    decision match {
+      case Retry(3, 9, 500L, 1000L, true) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("exponential backoff progression caps at maxRateLimitDelay") {
+    // 500 -> 1000 -> 2000 -> 4000 -> 8000 -> 10000 (capped) -> 10000
+    val progression = List(500L, 1000L, 2000L, 4000L, 8000L, 10000L)
+    val next = progression.tail :+ 10000L
+    progression.zip(next).foreach { case (current, expected) =>
+      decideRetry(
+        error = new MilvusRateLimitException("app layer"),
+        retries = 3,
+        rateLimitRetries = 10,
+        rateLimitDelay = current,
+        retryInterval = retryInterval,
+        maxRateLimitDelay = maxDelay
+      ) match {
+        case Retry(_, _, _, nextDelay, true) =>
+          assert(nextDelay == expected, s"from $current expected $expected but got $nextDelay")
+        case other => fail(s"unexpected: $other")
+      }
+    }
+  }
+
+  test("rate limit with exhausted rateLimitRetries aborts") {
+    decideRetry(
+      error = new MilvusRateLimitException("app layer"),
+      retries = 3,
+      rateLimitRetries = 0,
+      rateLimitDelay = 8000L,
+      retryInterval = retryInterval
+    ) match {
+      case Abort(err: MilvusRpcException) =>
+        assert(err.getMessage.contains("rate limit retries"))
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  // ---------- transport-layer RESOURCE_EXHAUSTED path ----------
+
+  test("transport-layer RESOURCE_EXHAUSTED is handled as a generic retry") {
+    // The connector's GrpcRetryInterceptor marks RESOURCE_EXHAUSTED as
+    // non-retryable at the transport layer, so it propagates up as a
+    // StatusRuntimeException wrapped inside a non-MilvusRateLimitException.
+    // decideRetry must NOT classify this as a rate-limit retry; it should
+    // consume a generic retry slot.
+    val transportError = new StatusRuntimeException(io.grpc.Status.RESOURCE_EXHAUSTED)
+    decideRetry(
+      error = transportError,
+      retries = 3,
+      rateLimitRetries = 10,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(2, 10, 1000L, 500L, false) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("generic exception consumes a generic retry and sleeps retryInterval") {
+    decideRetry(
+      error = new RuntimeException("schema mismatch"),
+      retries = 3,
+      rateLimitRetries = 10,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(2, 10, 1000L, 500L, false) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("generic exception with exhausted retries aborts") {
+    decideRetry(
+      error = new RuntimeException("schema mismatch"),
+      retries = 0,
+      rateLimitRetries = 10,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Abort(err: MilvusRpcException) =>
+        assert(!err.getMessage.contains("rate limit retries"))
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  // ---------- rateLimitDelay non-reset behavior ----------
+
+  test("generic error preserves the escalated rateLimitDelay") {
+    // Scenario: a rate-limit sequence has escalated delay to 4000ms, then
+    // a generic error occurs. The next rate-limit hit should continue from
+    // 4000ms (doubling to 8000ms), not fall back to the initial 500ms.
+    decideRetry(
+      error = new RuntimeException("transient"),
+      retries = 3,
+      rateLimitRetries = 8,
+      rateLimitDelay = 4000L,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(_, _, _, nextRateLimitDelay, _) =>
+        assert(nextRateLimitDelay == 4000L, "generic error must not reset rateLimitDelay")
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("alternating sequence preserves rate-limit delay escalation") {
+    // RL(500) -> RL(1000) -> G -> G -> RL should double from 2000 to 4000
+    val step1 = decideRetry(
+      new MilvusRateLimitException("rl"), 3, 10, 500L, retryInterval
+    ).asInstanceOf[Retry]
+    assert(step1.nextRateLimitDelay == 1000L)
+
+    val step2 = decideRetry(
+      new MilvusRateLimitException("rl"),
+      step1.retries, step1.rateLimitRetries, step1.nextRateLimitDelay, retryInterval
+    ).asInstanceOf[Retry]
+    assert(step2.nextRateLimitDelay == 2000L)
+
+    val step3 = decideRetry(
+      new RuntimeException("g"),
+      step2.retries, step2.rateLimitRetries, step2.nextRateLimitDelay, retryInterval
+    ).asInstanceOf[Retry]
+    assert(step3.nextRateLimitDelay == 2000L, "generic error preserves delay")
+
+    val step4 = decideRetry(
+      new RuntimeException("g"),
+      step3.retries, step3.rateLimitRetries, step3.nextRateLimitDelay, retryInterval
+    ).asInstanceOf[Retry]
+    assert(step4.nextRateLimitDelay == 2000L)
+
+    val step5 = decideRetry(
+      new MilvusRateLimitException("rl"),
+      step4.retries, step4.rateLimitRetries, step4.nextRateLimitDelay, retryInterval
+    ).asInstanceOf[Retry]
+    assert(step5.nextRateLimitDelay == 4000L, "rate-limit resumes doubling from escalated delay")
+  }
+
+  // ---------- independent counter interactions ----------
+
+  test("generic error does not consume a rate-limit retry") {
+    decideRetry(
+      error = new RuntimeException("g"),
+      retries = 3,
+      rateLimitRetries = 5,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(2, 5, _, _, false) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("rate-limit error does not consume a generic retry") {
+    decideRetry(
+      error = new MilvusRateLimitException("rl"),
+      retries = 3,
+      rateLimitRetries = 5,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(3, 4, _, _, true) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("exhausted generic retries still allow rate-limit retries") {
+    // With retries=0 and rateLimitRetries=5, a rate-limit error should
+    // still be retried (the two counters are independent).
+    decideRetry(
+      error = new MilvusRateLimitException("rl"),
+      retries = 0,
+      rateLimitRetries = 5,
+      rateLimitDelay = initialDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(0, 4, _, _, true) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+
+  test("exhausted rate-limit retries still allow generic retries") {
+    decideRetry(
+      error = new RuntimeException("g"),
+      retries = 3,
+      rateLimitRetries = 0,
+      rateLimitDelay = maxDelay,
+      retryInterval = retryInterval
+    ) match {
+      case Retry(2, 0, _, _, false) => succeed
+      case other => fail(s"unexpected: $other")
+    }
+  }
+}


### PR DESCRIPTION
  Spark partitions flush concurrently and can exceed per-Proxy insert rate limit.
  Add MilvusRateLimitException with dedicated retry path: 10 attempts, exponential
  backoff 500ms -> 10s cap, independent from general error retries.