### PR TITLE
feat: support running on Spark Operator with IAM/IRSA and dual-bucket credentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,6 +147,25 @@ lazy val root = (project in file("."))
     Compile / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni_2.13-0.1.0-SNAPSHOT.jar",
     Test / unmanagedJars += baseDirectory.value / "milvus-storage" / "java" / "target" / "scala-2.13" / "milvus-storage-jni_2.13-0.1.0-SNAPSHOT.jar",
 
+    // 老 log binding (slf4j-log4j12 / reload4j / log4j 1.x) 与 spark 的 log4j2 冲突，
+    // 全局排除掉。
+    excludeDependencies ++= Seq(
+      ExclusionRule("org.slf4j", "slf4j-log4j12"),
+      ExclusionRule("org.slf4j", "slf4j-reload4j"),
+      ExclusionRule("log4j", "log4j"),
+      ExclusionRule("ch.qos.reload4j", "reload4j")
+    ),
+    // 在 assembly 阶段过滤掉 slf4j-api jar：
+    // 编译时仍可用（来自传递依赖），但不进 fat jar，运行时由 spark 镜像
+    // /opt/spark/jars/slf4j-api-2.x.jar 提供，避免 userClassPathFirst=true 时
+    // Logger 被加载两份触发 LinkageError
+    assembly / assemblyExcludedJars := {
+      val cp = (assembly / fullClasspath).value
+      cp.filter { f =>
+        val n = f.data.getName
+        n.startsWith("slf4j-api-")
+      }
+    },
     libraryDependencies ++= Seq(
       munit % Test,
       scalaTest % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,12 +39,15 @@ object Dependencies {
     "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided,test" excludeAll(
       ExclusionRule(organization = "org.apache.arrow")
     )
+  // Hadoop / Parquet 已由 Spark 发行版（镜像 /opt/spark/jars）提供，
+  // 标 provided 避免被 sbt assembly 打入 fat jar，否则与运行时 classpath 冲突
+  // 引发 "X not a subtype of Y" 类加载错误（特别是开 userClassPathFirst 时）
   lazy val parquetHadoop =
-    "org.apache.parquet" % "parquet-hadoop" % parquetVersion
+    "org.apache.parquet" % "parquet-hadoop" % parquetVersion % "provided,test"
   lazy val hadoopCommon =
-    "org.apache.hadoop" % "hadoop-common" % hadoopVersion exclude ("javax.activation", "activation")
+    "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "provided,test" exclude ("javax.activation", "activation")
   lazy val hadoopAws =
-    "org.apache.hadoop" % "hadoop-aws" % hadoopVersion exclude("software.amazon.awssdk", "bundle")
+    "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "provided,test" exclude("software.amazon.awssdk", "bundle")
   lazy val awsSdkS3 =
     "software.amazon.awssdk" % "s3" % "2.30.38" // doc: https://javadoc.io/doc/software.amazon.awssdk/s3/2.30.38/index.html
   lazy val awsSdkS3Transfer = 

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -1,17 +1,17 @@
 package com.zilliz.spark.connector.loon
 
 import java.{util => ju}
-import io.milvus.storage.MilvusStorageProperties
-import com.zilliz.spark.connector.MilvusOption
 
-/**
- * Utilities for creating MilvusStorageProperties from S3 configuration
- */
+import com.zilliz.spark.connector.MilvusOption
+import io.milvus.storage.MilvusStorageProperties
+
+/** Utilities for creating MilvusStorageProperties from S3 configuration
+  */
 object Properties {
 
-  /**
-   * Filesystem configuration constants for Storage V2 (matching milvus-storage C++ API)
-   */
+  /** Filesystem configuration constants for Storage V2 (matching milvus-storage
+    * C++ API)
+    */
   object FsConfig {
     val FsAddress = "fs.address"
     val FsBucketName = "fs.bucket_name"
@@ -33,31 +33,54 @@ object Properties {
     val FsUseCustomPartUpload = "fs.use_custom_part_upload"
   }
 
-  /**
-   * Create MilvusStorageProperties from MilvusOption
-   * Builds properties for Storage V2 FFI from filesystem configuration in MilvusOption
-   *
-   * @param milvusOption MilvusOption containing filesystem configuration
-   * @return MilvusStorageProperties for milvus-storage native library
-   */
+  /** Create MilvusStorageProperties from MilvusOption Builds properties for
+    * Storage V2 FFI from filesystem configuration in MilvusOption
+    *
+    * @param milvusOption
+    *   MilvusOption containing filesystem configuration
+    * @return
+    *   MilvusStorageProperties for milvus-storage native library
+    */
   def fromMilvusOption(milvusOption: MilvusOption): MilvusStorageProperties = {
     val props = new MilvusStorageProperties()
     val propsMap = new ju.HashMap[String, String]()
 
     // Extract filesystem configuration with defaults
-    val endpoint = milvusOption.options.getOrElse(FsConfig.FsAddress,"localhost:9000")
-    val bucket = milvusOption.options.getOrElse(FsConfig.FsBucketName, "a-bucket")
+    val endpoint =
+      milvusOption.options.getOrElse(FsConfig.FsAddress, "localhost:9000")
+    val bucket =
+      milvusOption.options.getOrElse(FsConfig.FsBucketName, "a-bucket")
     val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
-    val accessKey = milvusOption.options.getOrElse(FsConfig.FsAccessKeyId, "minioadmin")
-    val secretKey = milvusOption.options.getOrElse(FsConfig.FsAccessKeyValue, "minioadmin")
+    // When use_iam=true the FFI must consult the AWS default credentials
+    // chain (env vars / web identity / instance profile). Falling back to
+    // hard-coded "minioadmin" defaults under IRSA produces signed requests
+    // with bogus keys, which fail with InvalidAccessKeyId. Only inject the
+    // dev/test default when we are clearly *not* in IAM mode.
+    val useIamFlag = milvusOption.options
+      .get(FsConfig.FsUseIam)
+      .exists(_.equalsIgnoreCase("true"))
+    val accessKey =
+      milvusOption.options.getOrElse(
+        FsConfig.FsAccessKeyId,
+        if (useIamFlag) "" else "minioadmin"
+      )
+    val secretKey =
+      milvusOption.options.getOrElse(
+        FsConfig.FsAccessKeyValue,
+        if (useIamFlag) "" else "minioadmin"
+      )
     val useSsl = milvusOption.options.getOrElse(FsConfig.FsUseSSL, "false")
-    val storageType = milvusOption.options.getOrElse(FsConfig.FsStorageType, "remote")
+    val storageType =
+      milvusOption.options.getOrElse(FsConfig.FsStorageType, "remote")
     val region = milvusOption.options.getOrElse(FsConfig.FsRegion, "us-west-2")
 
     // Set required properties
     propsMap.put(FsConfig.FsStorageType, storageType)
-    propsMap.put(FsConfig.FsAccessKeyId, accessKey)
-    propsMap.put(FsConfig.FsAccessKeyValue, secretKey)
+    // Only forward AK/SK to the FFI when we actually have static credentials.
+    // Empty values under IAM mode would otherwise overwrite whatever the
+    // default credentials chain resolves.
+    if (accessKey.nonEmpty) propsMap.put(FsConfig.FsAccessKeyId, accessKey)
+    if (secretKey.nonEmpty) propsMap.put(FsConfig.FsAccessKeyValue, secretKey)
     propsMap.put(FsConfig.FsBucketName, bucket)
     propsMap.put(FsConfig.FsRootPath, rootPath)
     propsMap.put(FsConfig.FsUseSSL, useSsl)
@@ -65,20 +88,42 @@ object Properties {
     propsMap.put(FsConfig.FsRegion, region)
 
     // Set optional properties if present
-    milvusOption.options.get(FsConfig.FsCloudProvider).foreach(propsMap.put(FsConfig.FsCloudProvider, _))
-    milvusOption.options.get(FsConfig.FsIamEndpoint).foreach(propsMap.put(FsConfig.FsIamEndpoint, _))
-    milvusOption.options.get(FsConfig.FsLogLevel).foreach(propsMap.put(FsConfig.FsLogLevel, _))
-    milvusOption.options.get(FsConfig.FsSslCaCert).foreach(propsMap.put(FsConfig.FsSslCaCert, _))
-    milvusOption.options.get(FsConfig.FsUseIam).foreach(propsMap.put(FsConfig.FsUseIam, _))
-    milvusOption.options.get(FsConfig.FsUseVirtualHost).foreach(propsMap.put(FsConfig.FsUseVirtualHost, _))
-    milvusOption.options.get(FsConfig.FsRequestTimeoutMs).foreach(propsMap.put(FsConfig.FsRequestTimeoutMs, _))
-    milvusOption.options.get(FsConfig.FsGcpNativeWithoutAuth).foreach(propsMap.put(FsConfig.FsGcpNativeWithoutAuth, _))
-    milvusOption.options.get(FsConfig.FsGcpCredentialJson).foreach(propsMap.put(FsConfig.FsGcpCredentialJson, _))
-    milvusOption.options.get(FsConfig.FsUseCustomPartUpload).foreach(propsMap.put(FsConfig.FsUseCustomPartUpload, _))
+    milvusOption.options
+      .get(FsConfig.FsCloudProvider)
+      .foreach(propsMap.put(FsConfig.FsCloudProvider, _))
+    milvusOption.options
+      .get(FsConfig.FsIamEndpoint)
+      .foreach(propsMap.put(FsConfig.FsIamEndpoint, _))
+    milvusOption.options
+      .get(FsConfig.FsLogLevel)
+      .foreach(propsMap.put(FsConfig.FsLogLevel, _))
+    milvusOption.options
+      .get(FsConfig.FsSslCaCert)
+      .foreach(propsMap.put(FsConfig.FsSslCaCert, _))
+    milvusOption.options
+      .get(FsConfig.FsUseIam)
+      .foreach(propsMap.put(FsConfig.FsUseIam, _))
+    milvusOption.options
+      .get(FsConfig.FsUseVirtualHost)
+      .foreach(propsMap.put(FsConfig.FsUseVirtualHost, _))
+    milvusOption.options
+      .get(FsConfig.FsRequestTimeoutMs)
+      .foreach(propsMap.put(FsConfig.FsRequestTimeoutMs, _))
+    milvusOption.options
+      .get(FsConfig.FsGcpNativeWithoutAuth)
+      .foreach(propsMap.put(FsConfig.FsGcpNativeWithoutAuth, _))
+    milvusOption.options
+      .get(FsConfig.FsGcpCredentialJson)
+      .foreach(propsMap.put(FsConfig.FsGcpCredentialJson, _))
+    milvusOption.options
+      .get(FsConfig.FsUseCustomPartUpload)
+      .foreach(propsMap.put(FsConfig.FsUseCustomPartUpload, _))
 
     props.create(propsMap)
     if (!props.isValid) {
-      throw new IllegalStateException("Failed to create MilvusStorageProperties")
+      throw new IllegalStateException(
+        "Failed to create MilvusStorageProperties"
+      )
     }
     props
   }

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -101,6 +101,37 @@ object BackfillApp {
     }
   }
 
+  // Boolean flags do not consume the next token.
+  private[backfill] val BoolFlags: Set[String] = Set(
+    "s3-use-ssl",
+    "use-iam",
+    "source-s3-use-ssl",
+    "source-use-iam"
+  )
+
+  // All accepted CLI keys. Validating against this whitelist surfaces typos
+  // (e.g. `--s3access-key` instead of `--s3-access-key`) at parse time
+  // instead of silently absorbing them and producing a confusing failure
+  // later inside the AWS default provider chain.
+  private[backfill] val KvFlags: Set[String] = Set(
+    "parquet",
+    "snapshot",
+    "s3-endpoint",
+    "s3-bucket",
+    "s3-access-key",
+    "s3-secret-key",
+    "s3-root-path",
+    "s3-region",
+    "source-s3-endpoint",
+    "source-s3-access-key",
+    "source-s3-secret-key",
+    "source-s3-region",
+    "batch-size",
+    "output-result"
+  )
+
+  private[backfill] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
+
   private[backfill] def parseArgs(args: Array[String]): Map[String, String] = {
     var map = Map.empty[String, String]
     var i = 0
@@ -108,9 +139,14 @@ object BackfillApp {
       args(i) match {
         case flag if flag.startsWith("--") =>
           val key = flag.stripPrefix("--")
-          if (
-            key == "s3-use-ssl" || key == "use-iam" || key == "source-s3-use-ssl" || key == "source-use-iam"
-          ) {
+          if (!KnownFlags.contains(key)) {
+            throw new IllegalArgumentException(
+              s"Unknown argument: $flag. Known flags: ${KnownFlags.toSeq.sorted
+                  .map("--" + _)
+                  .mkString(", ")}"
+            )
+          }
+          if (BoolFlags.contains(key)) {
             map += (key -> "true")
             i += 1
           } else if (i + 1 < args.length) {

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -1,0 +1,120 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.SparkSession
+
+/** Spark application entry point for running backfill via spark-submit.
+  *
+  * Usage: spark-submit --class
+  * com.zilliz.spark.connector.operations.backfill.BackfillApp \
+  * spark-connector-assembly.jar \ --parquet <path> --snapshot <path> \
+  * --s3-endpoint <endpoint> --s3-bucket <bucket> \ --s3-access-key <key>
+  * --s3-secret-key <secret> \ [--s3-root-path <path>] [--s3-region <region>]
+  * [--s3-use-ssl] \ [--batch-size <n>] [--output-result <path>]
+  */
+object BackfillApp {
+
+  def main(args: Array[String]): Unit = {
+    val parsed = parseArgs(args)
+
+    val parquetPath = parsed.getOrElse(
+      "parquet",
+      throw new IllegalArgumentException("--parquet is required")
+    )
+    val snapshotPath = parsed.getOrElse(
+      "snapshot",
+      throw new IllegalArgumentException("--snapshot is required")
+    )
+    val s3Endpoint = parsed.getOrElse(
+      "s3-endpoint",
+      throw new IllegalArgumentException("--s3-endpoint is required")
+    )
+    val s3Bucket = parsed.getOrElse(
+      "s3-bucket",
+      throw new IllegalArgumentException("--s3-bucket is required")
+    )
+    // Optional in IAM/IRSA mode — when both empty, automatically enable use_iam so that
+    // both Milvus FFI and Spark Hadoop S3A defer to the default credentials chain
+    // (env vars, instance profile, web identity token, etc.).
+    val s3AccessKey = parsed.getOrElse("s3-access-key", "")
+    val s3SecretKey = parsed.getOrElse("s3-secret-key", "")
+    val useIam =
+      parsed.contains("use-iam") || (s3AccessKey.isEmpty && s3SecretKey.isEmpty)
+
+    // Optional separate credentials for the backfill input (parquet) bucket.
+    // When unset, the main s3-* credentials above are reused.
+    val sourceUseIamFlag =
+      if (parsed.contains("source-use-iam")) Some(true)
+      else if (
+        parsed.contains("source-s3-access-key") || parsed.contains(
+          "source-s3-secret-key"
+        )
+      ) Some(false)
+      else None
+
+    val config = BackfillConfig(
+      s3Endpoint = s3Endpoint,
+      s3BucketName = s3Bucket,
+      s3AccessKey = s3AccessKey,
+      s3SecretKey = s3SecretKey,
+      s3UseSSL = parsed.contains("s3-use-ssl"),
+      s3RootPath = parsed.getOrElse("s3-root-path", "files"),
+      s3Region = parsed.getOrElse("s3-region", "us-east-1"),
+      s3UseIam = useIam,
+      sourceS3Endpoint = parsed.get("source-s3-endpoint"),
+      sourceS3AccessKey = parsed.get("source-s3-access-key"),
+      sourceS3SecretKey = parsed.get("source-s3-secret-key"),
+      sourceS3UseSSL =
+        if (parsed.contains("source-s3-use-ssl")) Some(true) else None,
+      sourceS3UseIam = sourceUseIamFlag,
+      sourceS3Region = parsed.get("source-s3-region"),
+      batchSize = parsed.getOrElse("batch-size", "1024").toInt
+    )
+
+    val spark = SparkSession.builder
+      .appName("MilvusBackfill")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    try {
+      MilvusBackfill.run(spark, parquetPath, snapshotPath, config) match {
+        case Right(result) =>
+          println(result.summary)
+          println(result.segmentSummary)
+          parsed.get("output-result").foreach { outputPath =>
+            MilvusBackfill.writeResultJson(spark, result, outputPath)
+            println(s"Result JSON written to: $outputPath")
+          }
+        case Left(error) =>
+          System.err.println(s"Backfill FAILED: ${error.message}")
+          System.exit(1)
+      }
+    } finally {
+      spark.stop()
+    }
+  }
+
+  private def parseArgs(args: Array[String]): Map[String, String] = {
+    var map = Map.empty[String, String]
+    var i = 0
+    while (i < args.length) {
+      args(i) match {
+        case flag if flag.startsWith("--") =>
+          val key = flag.stripPrefix("--")
+          if (
+            key == "s3-use-ssl" || key == "use-iam" || key == "source-s3-use-ssl" || key == "source-use-iam"
+          ) {
+            map += (key -> "true")
+            i += 1
+          } else if (i + 1 < args.length) {
+            map += (key -> args(i + 1))
+            i += 2
+          } else {
+            throw new IllegalArgumentException(s"Missing value for $flag")
+          }
+        case other =>
+          throw new IllegalArgumentException(s"Unexpected argument: $other")
+      }
+    }
+    map
+  }
+}

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -81,8 +81,16 @@ object BackfillApp {
           println(result.summary)
           println(result.segmentSummary)
           parsed.get("output-result").foreach { outputPath =>
-            MilvusBackfill.writeResultJson(spark, result, outputPath)
-            println(s"Result JSON written to: $outputPath")
+            MilvusBackfill
+              .writeResultJson(spark, result, outputPath, config) match {
+              case Right(_) =>
+                println(s"Result JSON written to: $outputPath")
+              case Left(err) =>
+                System.err.println(
+                  s"Backfill succeeded but writing result JSON FAILED: ${err.message}"
+                )
+                System.exit(2)
+            }
           }
         case Left(error) =>
           System.err.println(s"Backfill FAILED: ${error.message}")
@@ -93,7 +101,7 @@ object BackfillApp {
     }
   }
 
-  private def parseArgs(args: Array[String]): Map[String, String] = {
+  private[backfill] def parseArgs(args: Array[String]): Map[String, String] = {
     var map = Map.empty[String, String]
     var i = 0
     while (i < args.length) {

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -133,11 +133,18 @@ case class BackfillConfig(
       "fs.address" -> s3Endpoint,
       "fs.bucket_name" -> s3BucketName,
       "fs.root_path" -> s3RootPath,
-      "fs.access_key_id" -> s3AccessKey,
-      "fs.access_key_value" -> s3SecretKey,
       "fs.use_ssl" -> s3UseSSL.toString,
       "fs.use_iam" -> s3UseIam.toString
     )
+    // Only inject static credentials when NOT in IAM mode. Under IRSA the FFI
+    // must consult the AWS default credentials chain — passing fake AK/SK
+    // (or the "minioadmin" defaults from Properties.scala) breaks signing.
+    if (!s3UseIam) {
+      options = options ++ Map(
+        "fs.access_key_id" -> s3AccessKey,
+        "fs.access_key_value" -> s3SecretKey
+      )
+    }
 
     // Add optional configurations
     partitionName.foreach(p =>
@@ -174,8 +181,6 @@ case class BackfillConfig(
       "fs.address" -> s3Endpoint,
       "fs.bucket_name" -> s3BucketName,
       "fs.root_path" -> s3RootPath,
-      "fs.access_key_id" -> s3AccessKey,
-      "fs.access_key_value" -> s3SecretKey,
       "fs.use_ssl" -> s3UseSSL.toString,
       "fs.use_iam" -> s3UseIam.toString,
       "fs.region" -> s3Region,
@@ -184,6 +189,15 @@ case class BackfillConfig(
       "milvus.writer.commitType" -> "addfield",
       "milvus.insertMaxBatchSize" -> batchSize.toString
     )
+    // See getMilvusReadOptions: skip static credentials in IAM mode so the
+    // FFI defers to the AWS default credentials chain instead of signing
+    // with placeholder keys.
+    if (!s3UseIam) {
+      opts = opts ++ Map(
+        "fs.access_key_id" -> s3AccessKey,
+        "fs.access_key_value" -> s3SecretKey
+      )
+    }
     // Pass field name -> field ID mapping for correct column naming
     if (fieldNameToId.nonEmpty) {
       opts = opts + ("milvus.writer.fieldIds" -> fieldNameToId

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -1,23 +1,36 @@
 package com.zilliz.spark.connector.operations.backfill
 
-/**
- * Configuration for backfill operation
- *
- * @param milvusUri Milvus server URI (e.g., "http://localhost:19530")
- * @param milvusToken Authentication token in format "username:password"
- * @param databaseName Milvus database name
- * @param collectionName Milvus collection name to backfill
- * @param partitionName Optional specific partition name to backfill
- * @param s3Endpoint S3/Minio endpoint (e.g., "localhost:9000")
- * @param s3BucketName S3 bucket name
- * @param s3AccessKey S3 access key ID
- * @param s3SecretKey S3 secret access key
- * @param s3UseSSL Whether to use SSL for S3 connections
- * @param s3RootPath Root path in S3 bucket
- * @param s3Region S3 region
- * @param batchSize Batch size for writing data
- * @param customOutputPath Optional custom output path override
- */
+/** Configuration for backfill operation
+  *
+  * @param milvusUri
+  *   Milvus server URI (e.g., "http://localhost:19530")
+  * @param milvusToken
+  *   Authentication token in format "username:password"
+  * @param databaseName
+  *   Milvus database name
+  * @param collectionName
+  *   Milvus collection name to backfill
+  * @param partitionName
+  *   Optional specific partition name to backfill
+  * @param s3Endpoint
+  *   S3/Minio endpoint (e.g., "localhost:9000")
+  * @param s3BucketName
+  *   S3 bucket name
+  * @param s3AccessKey
+  *   S3 access key ID
+  * @param s3SecretKey
+  *   S3 secret access key
+  * @param s3UseSSL
+  *   Whether to use SSL for S3 connections
+  * @param s3RootPath
+  *   Root path in S3 bucket
+  * @param s3Region
+  *   S3 region
+  * @param batchSize
+  *   Batch size for writing data
+  * @param customOutputPath
+  *   Optional custom output path override
+  */
 case class BackfillConfig(
     // Milvus connection (optional for snapshot-only mode)
     milvusUri: String = "",
@@ -34,45 +47,63 @@ case class BackfillConfig(
     s3UseSSL: Boolean = false,
     s3RootPath: String = "files",
     s3Region: String = "us-east-1",
+    // When true, both Milvus FFI and Spark Hadoop S3A use the default credentials
+    // chain (env / web identity / instance profile) instead of static AK/SK.
+    s3UseIam: Boolean = false,
+
+    // Optional separate credentials for the backfill *input* parquet bucket.
+    // When set, these are used (via Hadoop per-bucket S3A config) to read the
+    // backfill data parquet, while the main s3* fields above continue to be
+    // used for snapshot reads and segment writes (Milvus storage bucket).
+    // Leave as None to reuse the main credentials for both buckets.
+    sourceS3Endpoint: Option[String] = None,
+    sourceS3AccessKey: Option[String] = None,
+    sourceS3SecretKey: Option[String] = None,
+    sourceS3UseSSL: Option[Boolean] = None,
+    sourceS3UseIam: Option[Boolean] = None,
+    sourceS3Region: Option[String] = None,
 
     // Writer configuration
     batchSize: Int = 1024,
     customOutputPath: Option[String] = None
 ) {
-  /**
-   * Validate S3 and writer configuration (always required)
-   */
+
+  /** Validate S3 and writer configuration (always required)
+    */
   def validate(): Either[String, Unit] = {
     if (s3Endpoint.isEmpty) {
       Left("s3Endpoint cannot be empty")
     } else if (s3BucketName.isEmpty) {
       Left("s3BucketName cannot be empty")
-    } else if (s3AccessKey.isEmpty) {
-      Left("s3AccessKey cannot be empty")
-    } else if (s3SecretKey.isEmpty) {
-      Left("s3SecretKey cannot be empty")
     } else if (batchSize <= 0) {
       Left("batchSize must be positive")
     } else {
+      // s3AccessKey/s3SecretKey may be empty in IAM/IRSA mode — the SDK
+      // falls back to the default AWS credentials chain.
       Right(())
     }
   }
 
-  /**
-   * Validate that Milvus client connection config is present (required when no snapshot)
-   */
+  /** Validate that Milvus client connection config is present (required when no
+    * snapshot)
+    */
   def validateForClientMode(): Either[String, Unit] = {
     validate().flatMap { _ =>
-      if (milvusUri.isEmpty) Left("milvusUri cannot be empty (required when no snapshot is provided)")
-      else if (collectionName.isEmpty) Left("collectionName cannot be empty (required when no snapshot is provided)")
+      if (milvusUri.isEmpty)
+        Left(
+          "milvusUri cannot be empty (required when no snapshot is provided)"
+        )
+      else if (collectionName.isEmpty)
+        Left(
+          "collectionName cannot be empty (required when no snapshot is provided)"
+        )
       else Right(())
     }
   }
 
-  /**
-   * Get Milvus read options as a Map for DataSource
-   * Only reads the primary key field to minimize data transfer for join operation
-   */
+  /** Get Milvus read options as a Map for DataSource Only reads the primary key
+    * field to minimize data transfer for join operation
+    */
   def getMilvusReadOptions: Map[String, String] = {
     var options = Map(
       "milvus.uri" -> milvusUri,
@@ -85,31 +116,40 @@ case class BackfillConfig(
       "fs.root_path" -> s3RootPath,
       "fs.access_key_id" -> s3AccessKey,
       "fs.access_key_value" -> s3SecretKey,
-      "fs.use_ssl" -> s3UseSSL.toString
+      "fs.use_ssl" -> s3UseSSL.toString,
+      "fs.use_iam" -> s3UseIam.toString
     )
 
     // Add optional configurations
-    partitionName.foreach(p => options = options + ("milvus.partition.name" -> p))
+    partitionName.foreach(p =>
+      options = options + ("milvus.partition.name" -> p)
+    )
 
     options
   }
 
-  /**
-   * Get S3 write options as a Map for MilvusLoonWriter
-   */
-  def getS3WriteOptions(collectionId: Long, partitionId: Long, segmentId: Long,
-                         fieldNameToId: Map[String, Long] = Map.empty): Map[String, String] = {
+  /** Get S3 write options as a Map for MilvusLoonWriter
+    */
+  def getS3WriteOptions(
+      collectionId: Long,
+      partitionId: Long,
+      segmentId: Long,
+      fieldNameToId: Map[String, Long] = Map.empty
+  ): Map[String, String] = {
     val outputPath = customOutputPath.getOrElse(
       s"$s3RootPath/insert_log/$collectionId/$partitionId/$segmentId"
     )
     getS3WriteOptionsForBasePath(outputPath, segmentId, fieldNameToId)
   }
 
-  /**
-   * Get S3 write options using a specific segment base path (e.g., from manifest)
-   */
-  def getS3WriteOptionsForBasePath(segmentBasePath: String, segmentId: Long,
-                                    fieldNameToId: Map[String, Long] = Map.empty): Map[String, String] = {
+  /** Get S3 write options using a specific segment base path (e.g., from
+    * manifest)
+    */
+  def getS3WriteOptionsForBasePath(
+      segmentBasePath: String,
+      segmentId: Long,
+      fieldNameToId: Map[String, Long] = Map.empty
+  ): Map[String, String] = {
     var opts = Map(
       "fs.storage_type" -> "remote",
       "fs.address" -> s3Endpoint,
@@ -118,6 +158,7 @@ case class BackfillConfig(
       "fs.access_key_id" -> s3AccessKey,
       "fs.access_key_value" -> s3SecretKey,
       "fs.use_ssl" -> s3UseSSL.toString,
+      "fs.use_iam" -> s3UseIam.toString,
       "fs.region" -> s3Region,
       "milvus.collection.name" -> s"segment_${segmentId}_backfill",
       "milvus.writer.customPath" -> segmentBasePath,
@@ -126,16 +167,18 @@ case class BackfillConfig(
     )
     // Pass field name -> field ID mapping for correct column naming
     if (fieldNameToId.nonEmpty) {
-      opts = opts + ("milvus.writer.fieldIds" -> fieldNameToId.map { case (k, v) => s"$k:$v" }.mkString(","))
+      opts = opts + ("milvus.writer.fieldIds" -> fieldNameToId
+        .map { case (k, v) => s"$k:$v" }
+        .mkString(","))
     }
     opts
   }
 }
 
 object BackfillConfig {
-  /**
-   * Create a minimal config for testing
-   */
+
+  /** Create a minimal config for testing
+    */
   def forTest(
       collectionName: String,
       milvusUri: String = "http://localhost:19530",

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -77,10 +77,29 @@ case class BackfillConfig(
       Left("s3BucketName cannot be empty")
     } else if (batchSize <= 0) {
       Left("batchSize must be positive")
+    } else if (!s3UseIam && (s3AccessKey.isEmpty || s3SecretKey.isEmpty)) {
+      // Hard invariant: must use IAM or supply both AK and SK. Half-set
+      // static credentials are never valid — they would silently fall back
+      // to the default provider chain and mask config mistakes.
+      Left(
+        "s3AccessKey and s3SecretKey must both be set unless s3UseIam=true"
+      )
     } else {
-      // s3AccessKey/s3SecretKey may be empty in IAM/IRSA mode — the SDK
-      // falls back to the default AWS credentials chain.
-      Right(())
+      // Same invariant for the source (input parquet) bucket. Any field
+      // left as None falls back to the main credentials, which we already
+      // validated above, so we only fail when an asymmetric override would
+      // produce half-set static credentials.
+      val srcUseIam = sourceS3UseIam.getOrElse(s3UseIam)
+      val srcAk = sourceS3AccessKey.getOrElse(s3AccessKey)
+      val srcSk = sourceS3SecretKey.getOrElse(s3SecretKey)
+      if (!srcUseIam && (srcAk.isEmpty || srcSk.isEmpty)) {
+        Left(
+          "source bucket: sourceS3AccessKey and sourceS3SecretKey must both " +
+            "be set unless sourceS3UseIam=true (or fall back to main)"
+        )
+      } else {
+        Right(())
+      }
     }
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1,39 +1,55 @@
 package com.zilliz.spark.connector.operations.backfill
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.apache.spark.sql.connector.write.DataWriter
-import org.slf4j.LoggerFactory
-
-import com.zilliz.spark.connector.write.{MilvusLoonBatchWrite, MilvusLoonCommitMessage, MilvusLoonWriter}
-import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusOption}
-import com.zilliz.spark.connector.read.{MilvusSnapshotReader, SnapshotMetadata, StorageV2ManifestItem}
-
-import org.apache.hadoop.fs.Path
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.DataWriter
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.slf4j.LoggerFactory
 
-/**
- * Backfill operation for Milvus collections
- *
- * This object provides functionality to backfill new fields into existing Milvus collections
- * by reading the original data, joining with new field data, and writing per-segment binlog files.
- */
+import com.zilliz.spark.connector.{
+  MilvusClient,
+  MilvusConnectionParams,
+  MilvusOption
+}
+import com.zilliz.spark.connector.read.{
+  MilvusSnapshotReader,
+  SnapshotMetadata,
+  StorageV2ManifestItem
+}
+import com.zilliz.spark.connector.write.{
+  MilvusLoonBatchWrite,
+  MilvusLoonCommitMessage,
+  MilvusLoonWriter
+}
+
+/** Backfill operation for Milvus collections
+  *
+  * This object provides functionality to backfill new fields into existing
+  * Milvus collections by reading the original data, joining with new field
+  * data, and writing per-segment binlog files.
+  */
 object MilvusBackfill {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  /**
-   * Backfill new fields into a Milvus collection
-   *
-   * @param spark SparkSession
-   * @param backfillDataPath Path to Parquet file containing new field data with schema (pk, new_field1, new_field2, ...)
-   * @param snapshotPath Path to Milvus snapshot metadata JSON file
-   * @param config Backfill configuration
-   * @return Either error or successful result
-   */
+  /** Backfill new fields into a Milvus collection
+    *
+    * @param spark
+    *   SparkSession
+    * @param backfillDataPath
+    *   Path to Parquet file containing new field data with schema (pk,
+    *   new_field1, new_field2, ...)
+    * @param snapshotPath
+    *   Path to Milvus snapshot metadata JSON file
+    * @param config
+    *   Backfill configuration
+    * @return
+    *   Either error or successful result
+    */
   def run(
       spark: SparkSession,
       backfillDataPath: String,
@@ -45,22 +61,28 @@ object MilvusBackfill {
 
     // Validate S3/writer configuration (always required)
     config.validate() match {
-      case Left(error) => return Left(SchemaValidationError(s"Invalid configuration: $error"))
+      case Left(error) =>
+        return Left(SchemaValidationError(s"Invalid configuration: $error"))
       case Right(_) => // Continue
     }
 
     // Step 1: Try to load snapshot metadata
-    val snapshotMetadataOpt = loadSnapshotMetadata(spark, snapshotPath, config) match {
-      case Left(error) => return Left(error)
-      case Right(opt) => opt
-    }
+    val snapshotMetadataOpt =
+      loadSnapshotMetadata(spark, snapshotPath, config) match {
+        case Left(error) => return Left(error)
+        case Right(opt)  => opt
+      }
 
     // Step 2: Create Milvus client only if no snapshot is available
     var client: MilvusClient = null
     if (snapshotMetadataOpt.isEmpty) {
       config.validateForClientMode() match {
-        case Left(error) => return Left(SchemaValidationError(
-          s"No snapshot provided and invalid client configuration: $error"))
+        case Left(error) =>
+          return Left(
+            SchemaValidationError(
+              s"No snapshot provided and invalid client configuration: $error"
+            )
+          )
         case Right(_) =>
       }
       client = MilvusClient(
@@ -76,49 +98,68 @@ object MilvusBackfill {
       // Step 3: Get PK field info
       val (pkName, pkFieldId) = snapshotMetadataOpt match {
         case Some(metadata) =>
-          val pkField = metadata.collection.schema.fields.find(_.isPrimaryKey.getOrElse(false))
-            .getOrElse(return Left(SchemaValidationError("No primary key field found in snapshot schema")))
+          val pkField = metadata.collection.schema.fields
+            .find(_.isPrimaryKey.getOrElse(false))
+            .getOrElse(
+              return Left(
+                SchemaValidationError(
+                  "No primary key field found in snapshot schema"
+                )
+              )
+            )
           (pkField.name, pkField.getFieldIDAsLong)
         case None =>
           client.getPkField(config.databaseName, config.collectionName) match {
             case scala.util.Success((name, id)) => (name, id)
-            case scala.util.Failure(e) => return Left(ConnectionError(
-              message = s"Failed to get PK field: ${e.getMessage}", cause = Some(e)))
+            case scala.util.Failure(e) =>
+              return Left(
+                ConnectionError(
+                  message = s"Failed to get PK field: ${e.getMessage}",
+                  cause = Some(e)
+                )
+              )
           }
       }
 
       // Read backfill data from Parquet
-      val backfillDF = readBackfillData(spark, backfillDataPath) match {
+      val backfillDF = readBackfillData(spark, backfillDataPath, config) match {
         case Left(error) => return Left(error)
-        case Right(df) => df
+        case Right(df)   => df
       }
 
       // Read original collection data with segment metadata
-      val originalDF = readCollectionWithMetadata(spark, config, pkFieldId, snapshotMetadataOpt) match {
+      val originalDF = readCollectionWithMetadata(
+        spark,
+        config,
+        pkFieldId,
+        snapshotMetadataOpt
+      ) match {
         case Left(error) => return Left(error)
-        case Right(df) => df
+        case Right(df)   => df
       }
 
       // Validate schema compatibility
       validateSchemaCompatibility(originalDF, backfillDF, pkName) match {
         case Left(error) => return Left(error)
-        case Right(_) => // Continue
+        case Right(_)    => // Continue
       }
 
       // Perform Sort Merge Join
       val joinedDF = performJoin(originalDF, backfillDF, pkName)
 
       // Step 4: Get collection metadata (collectionID, segment-to-partition mapping, base paths)
-      val (collectionID, segmentToPartitionMap, segmentBasePathMap) = snapshotMetadataOpt match {
-        case Some(metadata) =>
-          extractMetadataFromSnapshot(metadata)
-        case None =>
-          val (colId, segPartMap) = retrieveMilvusMetadata(config, client) match {
-            case Left(error) => return Left(error)
-            case Right(metadata) => metadata
-          }
-          (colId, segPartMap, Map.empty[Long, String])
-      }
+      val (collectionID, segmentToPartitionMap, segmentBasePathMap) =
+        snapshotMetadataOpt match {
+          case Some(metadata) =>
+            extractMetadataFromSnapshot(metadata)
+          case None =>
+            val (colId, segPartMap) =
+              retrieveMilvusMetadata(config, client) match {
+                case Left(error)     => return Left(error)
+                case Right(metadata) => metadata
+              }
+            (colId, segPartMap, Map.empty[Long, String])
+        }
 
       // Extract new field names
       val newFieldNames = backfillDF.schema.fields
@@ -131,17 +172,23 @@ object MilvusBackfill {
         case Some(metadata) =>
           MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
         case None =>
-          return Left(SchemaValidationError(
-            "ADDFIELD backfill requires field ID mapping from snapshot. " +
-            "Please provide a snapshot path to resolve correct field IDs."))
+          return Left(
+            SchemaValidationError(
+              "ADDFIELD backfill requires field ID mapping from snapshot. " +
+                "Please provide a snapshot path to resolve correct field IDs."
+            )
+          )
       }
 
       // Filter to only the new fields being backfilled, fail fast if any field is missing from snapshot schema
       val missing = newFieldNames.filterNot(fieldNameToId.contains)
       if (missing.nonEmpty) {
-        return Left(SchemaValidationError(
-          s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
-          s"Available fields: ${fieldNameToId.keys.mkString(", ")}"))
+        return Left(
+          SchemaValidationError(
+            s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
+              s"Available fields: ${fieldNameToId.keys.mkString(", ")}"
+          )
+        )
       }
       val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
 
@@ -156,7 +203,7 @@ object MilvusBackfill {
         newFieldNames,
         newFieldNameToId
       ) match {
-        case Left(error) => return Left(error)
+        case Left(error)    => return Left(error)
         case Right(results) => results
       }
 
@@ -191,51 +238,63 @@ object MilvusBackfill {
     }
   }
 
-  /**
-   * Read backfill data from Parquet file
-   */
+  /** Read backfill data from Parquet file
+    */
   private def readBackfillData(
       spark: SparkSession,
-      path: String
+      path: String,
+      config: BackfillConfig
   ): Either[BackfillError, DataFrame] = {
     try {
+      // Ensure Hadoop S3A is configured for the source bucket (may differ
+      // from the Milvus storage bucket) before reading the parquet.
+      configureHadoopS3ForPath(spark, path, config, isSource = true)
       val df = spark.read.parquet(path)
 
       // Validate that it has a 'pk' column
       if (!df.columns.contains("pk")) {
-        return Left(DataReadError(
-          path = path,
-          message = "Backfill data must contain a 'pk' column"
-        ))
+        return Left(
+          DataReadError(
+            path = path,
+            message = "Backfill data must contain a 'pk' column"
+          )
+        )
       }
 
       // Validate that it has at least one other column
       if (df.columns.length < 2) {
-        return Left(DataReadError(
-          path = path,
-          message = "New field data must contain at least one field besides 'pk'"
-        ))
+        return Left(
+          DataReadError(
+            path = path,
+            message =
+              "New field data must contain at least one field besides 'pk'"
+          )
+        )
       }
 
       Right(df)
     } catch {
       case e: Exception =>
         logger.error(s"Failed to read Parquet file from $path", e)
-        Left(DataReadError(
-          path = path,
-          message = s"Failed to read Parquet file: ${e.getMessage}",
-          cause = Some(e)
-        ))
+        Left(
+          DataReadError(
+            path = path,
+            message = s"Failed to read Parquet file: ${e.getMessage}",
+            cause = Some(e)
+          )
+        )
     }
   }
 
-  /**
-   * Read collection data with segment_id and row_offset metadata
-   * segment_id and row_offset are used to match with the original sequence of rows for each segment
-   *
-   * @param pkFieldId Primary key field ID to read only PK field
-   * @param snapshotMetadata Optional snapshot metadata for offline reading (no client connection)
-   */
+  /** Read collection data with segment_id and row_offset metadata segment_id
+    * and row_offset are used to match with the original sequence of rows for
+    * each segment
+    *
+    * @param pkFieldId
+    *   Primary key field ID to read only PK field
+    * @param snapshotMetadata
+    *   Optional snapshot metadata for offline reading (no client connection)
+    */
   private def readCollectionWithMetadata(
       spark: SparkSession,
       config: BackfillConfig,
@@ -253,24 +312,32 @@ object MilvusBackfill {
 
         // Override connection options for snapshot mode (no client needed)
         options = options + ("milvus.uri" -> "dummy://snapshot-mode")
-        options = options + ("milvus.collection.name" -> metadata.collection.schema.name)
+        options =
+          options + ("milvus.collection.name" -> metadata.collection.schema.name)
 
         // Add snapshot collection ID
-        options = options + (MilvusOption.SnapshotCollectionId -> metadata.snapshotInfo.collectionId.toString)
+        options =
+          options + (MilvusOption.SnapshotCollectionId -> metadata.snapshotInfo.collectionId.toString)
 
         // Add snapshot partition IDs
-        options = options + (MilvusOption.SnapshotPartitionIds -> metadata.snapshotInfo.partitionIds.mkString(","))
+        options =
+          options + (MilvusOption.SnapshotPartitionIds -> metadata.snapshotInfo.partitionIds
+            .mkString(","))
 
         // Convert snapshot schema to protobuf bytes and pass as Base64
-        val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(metadata.collection.schema)
-        val schemaBytesBase64 = java.util.Base64.getEncoder.encodeToString(schemaBytes)
-        options = options + (MilvusOption.SnapshotSchemaBytes -> schemaBytesBase64)
+        val schemaBytes =
+          MilvusSnapshotReader.toProtobufSchemaBytes(metadata.collection.schema)
+        val schemaBytesBase64 =
+          java.util.Base64.getEncoder.encodeToString(schemaBytes)
+        options =
+          options + (MilvusOption.SnapshotSchemaBytes -> schemaBytesBase64)
 
         metadata.storageV2ManifestList.foreach { manifestList =>
           // Pass original manifest JSON (containing both ver and base_path) so that
           // the DataSource can extract readVersion and lock reads to snapshot version
           if (manifestList.nonEmpty) {
-            val manifestJson = MilvusSnapshotReader.serializeManifestList(manifestList)
+            val manifestJson =
+              MilvusSnapshotReader.serializeManifestList(manifestList)
             options = options + (MilvusOption.SnapshotManifests -> manifestJson)
           } else {
             logger.warn("No valid manifests found in snapshot")
@@ -283,17 +350,25 @@ object MilvusBackfill {
         case Some(metadata) =>
           // For snapshot mode, only include the PK field we need to read (not all user fields)
           // FFI reader will only read the columns specified in the schema
-          val pkField = metadata.collection.schema.fields.find(_.getFieldIDAsLong == pkFieldId)
+          val pkField = metadata.collection.schema.fields
+            .find(_.getFieldIDAsLong == pkFieldId)
           val pkSchema = pkField match {
             case Some(field) =>
               // Create schema with only the PK field
               import org.apache.spark.sql.types._
               val pkFieldType = MilvusSnapshotReader.fieldToSparkType(field)
-              StructType(Seq(StructField(field.name, pkFieldType, nullable = true)))
+              StructType(
+                Seq(StructField(field.name, pkFieldType, nullable = true))
+              )
             case None =>
               // Fallback: use full schema if PK field not found
-              logger.warn(s"PK field with ID $pkFieldId not found in snapshot schema, using full schema")
-              MilvusSnapshotReader.toSparkSchema(metadata.collection.schema, includeSystemFields = false)
+              logger.warn(
+                s"PK field with ID $pkFieldId not found in snapshot schema, using full schema"
+              )
+              MilvusSnapshotReader.toSparkSchema(
+                metadata.collection.schema,
+                includeSystemFields = false
+              )
           }
 
           // Add extra columns for segment tracking
@@ -301,44 +376,56 @@ object MilvusBackfill {
             .add("segment_id", org.apache.spark.sql.types.LongType, false)
             .add("row_offset", org.apache.spark.sql.types.LongType, false)
 
-          logger.info(s"Reading with schema: ${fullSchema.fieldNames.mkString(", ")}")
+          logger.info(
+            s"Reading with schema: ${fullSchema.fieldNames.mkString(", ")}"
+          )
 
           spark.read
             .schema(fullSchema)
-            .format("milvus")
+            .format("com.zilliz.spark.connector.sources.MilvusDataSource")
             .options(options)
             .load()
 
         case None =>
           // Client-based mode (existing behavior)
           spark.read
-            .format("milvus")
+            .format("com.zilliz.spark.connector.sources.MilvusDataSource")
             .options(options)
             .load()
       }
 
       // Validate that segment_id and row_offset are present
-      if (!df.columns.contains("segment_id") || !df.columns.contains("row_offset")) {
-        return Left(ConnectionError(
-          message = "Failed to read collection data with segment_id and row_offset. " +
-            "Ensure milvus.extra.columns is set correctly."
-        ))
+      if (
+        !df.columns.contains("segment_id") || !df.columns.contains("row_offset")
+      ) {
+        return Left(
+          ConnectionError(
+            message =
+              "Failed to read collection data with segment_id and row_offset. " +
+                "Ensure milvus.extra.columns is set correctly."
+          )
+        )
       }
 
       Right(df)
     } catch {
       case e: Exception =>
-        logger.error(s"Failed to read Milvus collection ${config.collectionName}", e)
-        Left(ConnectionError(
-          message = s"Failed to read Milvus collection ${config.collectionName}: ${e.getMessage}",
-          cause = Some(e)
-        ))
+        logger.error(
+          s"Failed to read Milvus collection ${config.collectionName}",
+          e
+        )
+        Left(
+          ConnectionError(
+            message =
+              s"Failed to read Milvus collection ${config.collectionName}: ${e.getMessage}",
+            cause = Some(e)
+          )
+        )
     }
   }
 
-  /**
-   * Validate schema compatibility between original and new field data
-   */
+  /** Validate schema compatibility between original and new field data
+    */
   private def validateSchemaCompatibility(
       originalDF: DataFrame,
       backfillDF: DataFrame,
@@ -346,24 +433,32 @@ object MilvusBackfill {
   ): Either[BackfillError, Unit] = {
     try {
       // Find the primary key field in original data
-      val pkField = originalDF.schema.fields.find(_.name == pkName)
+      val pkField = originalDF.schema.fields
+        .find(_.name == pkName)
         .getOrElse {
-          return Left(SchemaValidationError(
-            s"Original collection data must have primary key field '$pkName'"
-          ))
+          return Left(
+            SchemaValidationError(
+              s"Original collection data must have primary key field '$pkName'"
+            )
+          )
         }
 
       // Find the pk field in new field data
-      val newPkField = backfillDF.schema.fields.find(_.name == "pk")
+      val newPkField = backfillDF.schema.fields
+        .find(_.name == "pk")
         .getOrElse {
-          return Left(SchemaValidationError("New field data must have 'pk' field"))
+          return Left(
+            SchemaValidationError("New field data must have 'pk' field")
+          )
         }
 
       // Validate types match
       if (pkField.dataType != newPkField.dataType) {
-        return Left(SchemaValidationError(
-          s"Primary key type mismatch: original=${pkField.dataType}, new=${newPkField.dataType}"
-        ))
+        return Left(
+          SchemaValidationError(
+            s"Primary key type mismatch: original=${pkField.dataType}, new=${newPkField.dataType}"
+          )
+        )
       }
 
       Right(())
@@ -371,15 +466,16 @@ object MilvusBackfill {
     } catch {
       case e: Exception =>
         logger.error("Failed to validate schema compatibility", e)
-        Left(SchemaValidationError(
-          s"Failed to validate schema compatibility: ${e.getMessage}"
-        ))
+        Left(
+          SchemaValidationError(
+            s"Failed to validate schema compatibility: ${e.getMessage}"
+          )
+        )
     }
   }
 
-  /**
-   * Perform left join between original and new field data
-   */
+  /** Perform left join between original and new field data
+    */
   private def performJoin(
       originalDF: DataFrame,
       backfillDF: DataFrame,
@@ -388,26 +484,32 @@ object MilvusBackfill {
     originalDF.join(backfillDF, originalDF(pkName) === backfillDF("pk"), "left")
   }
 
-  /**
-   * Retrieve Milvus metadata (collection ID and segment-to-partition mapping)
-   * Supports multi-partition collections by tracking partition ID for each segment
-   */
+  /** Retrieve Milvus metadata (collection ID and segment-to-partition mapping)
+    * Supports multi-partition collections by tracking partition ID for each
+    * segment
+    */
   private def retrieveMilvusMetadata(
       config: BackfillConfig,
       client: MilvusClient
   ): Either[BackfillError, (Long, Map[Long, Long])] = {
     try {
-      val segments = client.getSegments(config.databaseName, config.collectionName)
+      val segments = client
+        .getSegments(config.databaseName, config.collectionName)
         .getOrElse {
-          return Left(ConnectionError(
-            message = s"No segments found for collection ${config.collectionName}"
-          ))
+          return Left(
+            ConnectionError(
+              message =
+                s"No segments found for collection ${config.collectionName}"
+            )
+          )
         }
 
       if (segments.isEmpty) {
-        return Left(ConnectionError(
-          message = s"Collection ${config.collectionName} has no segments"
-        ))
+        return Left(
+          ConnectionError(
+            message = s"Collection ${config.collectionName} has no segments"
+          )
+        )
       }
 
       val collectionID = segments.head.collectionID
@@ -421,19 +523,23 @@ object MilvusBackfill {
 
     } catch {
       case e: Exception =>
-        logger.error(s"Failed to retrieve Milvus metadata for collection ${config.collectionName}", e)
-        Left(ConnectionError(
-          message = s"Failed to retrieve Milvus metadata: ${e.getMessage}",
-          cause = Some(e)
-        ))
+        logger.error(
+          s"Failed to retrieve Milvus metadata for collection ${config.collectionName}",
+          e
+        )
+        Left(
+          ConnectionError(
+            message = s"Failed to retrieve Milvus metadata: ${e.getMessage}",
+            cause = Some(e)
+          )
+        )
     }
   }
 
-  /**
-   * Process each segment separately by distributing to Spark executors
-   * Each segment is processed by exactly one FFI writer on a single executor
-   * Supports multi-partition collections by tracking partition ID per segment
-   */
+  /** Process each segment separately by distributing to Spark executors Each
+    * segment is processed by exactly one FFI writer on a single executor
+    * Supports multi-partition collections by tracking partition ID per segment
+    */
   private def processSegments(
       spark: SparkSession,
       joinedDF: DataFrame,
@@ -466,32 +572,39 @@ object MilvusBackfill {
       // ExternalSorter stores references to the same mutable buffer, causing all
       // rows to contain the last row's data.
       val repartitionedRDD = preparedDF.queryExecution.toRdd
-        .map(_.copy())  // Materialize each row to avoid UnsafeRow reuse
-        .keyBy(_.getLong(0))  // segment_id is at index 0
+        .map(_.copy()) // Materialize each row to avoid UnsafeRow reuse
+        .keyBy(_.getLong(0)) // segment_id is at index 0
         .partitionBy(segmentPartitioner)
         .values
-        .mapPartitions(iter => iter.toSeq.sortBy(_.getLong(1)).iterator)  // Sort by row_offset
+        .mapPartitions(iter =>
+          iter.toSeq.sortBy(_.getLong(1)).iterator
+        ) // Sort by row_offset
 
       // Broadcast configuration to executors
       val broadcastConfig = spark.sparkContext.broadcast(config)
       val broadcastCollectionID = spark.sparkContext.broadcast(collectionID)
-      val broadcastSegmentToPartitionMap = spark.sparkContext.broadcast(segmentToPartitionMap)
-      val broadcastSegmentBasePathMap = spark.sparkContext.broadcast(segmentBasePathMap)
+      val broadcastSegmentToPartitionMap =
+        spark.sparkContext.broadcast(segmentToPartitionMap)
+      val broadcastSegmentBasePathMap =
+        spark.sparkContext.broadcast(segmentBasePathMap)
       val broadcastTargetSchema = spark.sparkContext.broadcast(targetSchema)
       val broadcastFieldNameToId = spark.sparkContext.broadcast(fieldNameToId)
 
-      val results = repartitionedRDD.mapPartitions { iter =>
-        if (!iter.hasNext) Iterator.empty
-        else processSegmentPartition(
-          iter,
-          broadcastConfig.value,
-          broadcastCollectionID.value,
-          broadcastSegmentToPartitionMap.value,
-          broadcastSegmentBasePathMap.value,
-          broadcastTargetSchema.value,
-          broadcastFieldNameToId.value
-        )
-      }.collect()
+      val results = repartitionedRDD
+        .mapPartitions { iter =>
+          if (!iter.hasNext) Iterator.empty
+          else
+            processSegmentPartition(
+              iter,
+              broadcastConfig.value,
+              broadcastCollectionID.value,
+              broadcastSegmentToPartitionMap.value,
+              broadcastSegmentBasePathMap.value,
+              broadcastTargetSchema.value,
+              broadcastFieldNameToId.value
+            )
+        }
+        .collect()
 
       // Cleanup broadcast variables
       broadcastConfig.unpersist()
@@ -506,12 +619,15 @@ object MilvusBackfill {
       if (failures.nonEmpty) {
         val firstFailure = failures.head
         val error = firstFailure._2.get
-        return Left(WriteError(
-          segmentId = firstFailure._1.segmentId,
-          outputPath = firstFailure._1.outputPath,
-          message = s"Failed to write ${failures.length} segment(s): ${error.getMessage}",
-          cause = Some(error)
-        ))
+        return Left(
+          WriteError(
+            segmentId = firstFailure._1.segmentId,
+            outputPath = firstFailure._1.outputPath,
+            message =
+              s"Failed to write ${failures.length} segment(s): ${error.getMessage}",
+            cause = Some(error)
+          )
+        )
       }
 
       // Extract successful results
@@ -535,18 +651,19 @@ object MilvusBackfill {
     } catch {
       case e: Exception =>
         logger.error("Failed to process segments", e)
-        Left(SegmentProcessingError(
-          segmentId = -1,
-          message = s"Failed to process segments: ${e.getMessage}",
-          cause = Some(e)
-        ))
+        Left(
+          SegmentProcessingError(
+            segmentId = -1,
+            message = s"Failed to process segments: ${e.getMessage}",
+            cause = Some(e)
+          )
+        )
     }
   }
 
-  /**
-   * Process a single partition containing exactly one segment
-   * This is called by each Spark executor to write one segment's data
-   */
+  /** Process a single partition containing exactly one segment This is called
+    * by each Spark executor to write one segment's data
+    */
   private def processSegmentPartition(
       iter: Iterator[InternalRow],
       config: BackfillConfig,
@@ -564,25 +681,39 @@ object MilvusBackfill {
 
     // Create writer — use manifest basePath if available, otherwise generate path
     val writeOptions = segmentBasePathMap.get(segmentID) match {
-      case Some(basePath) => config.getS3WriteOptionsForBasePath(basePath, segmentID, fieldNameToId)
-      case None => config.getS3WriteOptions(collectionID, partitionID, segmentID, fieldNameToId)
+      case Some(basePath) =>
+        config.getS3WriteOptionsForBasePath(basePath, segmentID, fieldNameToId)
+      case None =>
+        config.getS3WriteOptions(
+          collectionID,
+          partitionID,
+          segmentID,
+          fieldNameToId
+        )
     }
     val outputPath = writeOptions("milvus.writer.customPath")
 
     val optionsMap = new CaseInsensitiveStringMap(writeOptions.asJava)
-    val batchWrite = new MilvusLoonBatchWrite(targetSchema, MilvusOption(optionsMap))
-    val writer = batchWrite.createBatchWriterFactory(null).createWriter(0, System.currentTimeMillis())
+    val batchWrite =
+      new MilvusLoonBatchWrite(targetSchema, MilvusOption(optionsMap))
+    val writer = batchWrite
+      .createBatchWriterFactory(null)
+      .createWriter(0, System.currentTimeMillis())
 
     try {
       var rowCount = 0L
       var nullRowCount = 0L
 
       def writeRow(row: InternalRow): Unit = {
-        val targetFields = (2 until row.numFields).map(i =>
-          row.get(i, targetSchema.fields(i - 2).dataType)
-        ).toArray
+        val targetFields = (2 until row.numFields)
+          .map(i => row.get(i, targetSchema.fields(i - 2).dataType))
+          .toArray
         if (targetFields.forall(_ == null)) nullRowCount += 1
-        writer.write(new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(targetFields))
+        writer.write(
+          new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(
+            targetFields
+          )
+        )
         rowCount += 1
       }
 
@@ -591,41 +722,51 @@ object MilvusBackfill {
 
       val commitMessage = writer.commit()
       val (manifestPaths, committedVersion) = commitMessage match {
-        case msg: MilvusLoonCommitMessage => (Seq(msg.manifestPath), msg.committedVersion)
+        case msg: MilvusLoonCommitMessage =>
+          (Seq(msg.manifestPath), msg.committedVersion)
         case _ => (Seq.empty[String], -1L)
       }
 
       batchWrite.commit(Array(commitMessage))
       writer.close()
 
-      Iterator.single((SegmentBackfillResult(
-        segmentId = segmentID,
-        rowCount = rowCount,
-        manifestPaths = manifestPaths,
-        outputPath = outputPath,
-        executionTimeMs = System.currentTimeMillis() - startTime,
-        committedVersion = committedVersion
-      ), None))
+      Iterator.single(
+        (
+          SegmentBackfillResult(
+            segmentId = segmentID,
+            rowCount = rowCount,
+            manifestPaths = manifestPaths,
+            outputPath = outputPath,
+            executionTimeMs = System.currentTimeMillis() - startTime,
+            committedVersion = committedVersion
+          ),
+          None
+        )
+      )
 
     } catch {
       case e: Exception =>
         writer.abort()
         writer.close()
-        Iterator.single((SegmentBackfillResult(
-          segmentId = segmentID,
-          rowCount = 0,
-          manifestPaths = Seq.empty,
-          outputPath = outputPath,
-          executionTimeMs = System.currentTimeMillis() - startTime
-        ), Some(e)))
+        Iterator.single(
+          (
+            SegmentBackfillResult(
+              segmentId = segmentID,
+              rowCount = 0,
+              manifestPaths = Seq.empty,
+              outputPath = outputPath,
+              executionTimeMs = System.currentTimeMillis() - startTime
+            ),
+            Some(e)
+          )
+        )
     }
   }
 
-  /**
-   * Load and parse snapshot metadata from file.
-   * Returns None if snapshot path is empty.
-   * Returns Left(error) if snapshot path is provided but parsing fails.
-   */
+  /** Load and parse snapshot metadata from file. Returns None if snapshot path
+    * is empty. Returns Left(error) if snapshot path is provided but parsing
+    * fails.
+    */
   private def loadSnapshotMetadata(
       spark: SparkSession,
       snapshotPath: String,
@@ -638,19 +779,26 @@ object MilvusBackfill {
         MilvusSnapshotReader.parseSnapshotMetadata(json) match {
           case Right(metadata) => Right(Some(metadata))
           case Left(e) =>
-            Left(SchemaValidationError(s"Failed to parse snapshot metadata: ${e.getMessage}"))
+            Left(
+              SchemaValidationError(
+                s"Failed to parse snapshot metadata: ${e.getMessage}"
+              )
+            )
         }
       case Right(_) =>
         Left(SchemaValidationError(s"Snapshot file is empty: $snapshotPath"))
       case Left(e) =>
-        Left(SchemaValidationError(s"Failed to read snapshot file: ${e.getMessage}"))
+        Left(
+          SchemaValidationError(s"Failed to read snapshot file: ${e.message}")
+        )
     }
   }
 
-  /**
-   * Extract collection metadata from snapshot: collectionID, segment-to-partition mapping, segment base paths.
-   * Partition IDs are derived from manifest basePaths: {rootPath}/insert_log/{col_id}/{part_id}/{seg_id}
-   */
+  /** Extract collection metadata from snapshot: collectionID,
+    * segment-to-partition mapping, segment base paths. Partition IDs are
+    * derived from manifest basePaths:
+    * {rootPath}/insert_log/{col_id}/{part_id}/{seg_id}
+    */
   private def extractMetadataFromSnapshot(
       metadata: SnapshotMetadata
   ): (Long, Map[Long, Long], Map[Long, String]) = {
@@ -674,47 +822,147 @@ object MilvusBackfill {
               segmentToPartitionMap += (segId -> partitionId)
             } catch {
               case _: NumberFormatException =>
-                logger.warn(s"Skipping segment $segId: failed to parse partition ID from basePath: ${mc.basePath}")
+                logger.warn(
+                  s"Skipping segment $segId: failed to parse partition ID from basePath: ${mc.basePath}"
+                )
             }
           } else {
-            logger.warn(s"Skipping segment $segId: basePath does not contain expected insert_log structure: ${mc.basePath}")
+            logger.warn(
+              s"Skipping segment $segId: basePath does not contain expected insert_log structure: ${mc.basePath}"
+            )
           }
         case Left(e) =>
-          logger.warn(s"Failed to parse manifest for segment $segId: ${e.getMessage}")
+          logger.warn(
+            s"Failed to parse manifest for segment $segId: ${e.getMessage}"
+          )
       }
     }
 
-    logger.info(s"Extracted from snapshot: collectionID=$collectionID, " +
-      s"segments=${segmentBasePathMap.keys.mkString(",")}")
+    logger.info(
+      s"Extracted from snapshot: collectionID=$collectionID, " +
+        s"segments=${segmentBasePathMap.keys.mkString(",")}"
+    )
 
     (collectionID, segmentToPartitionMap, segmentBasePathMap)
   }
 
-  /**
-   * Write backfill result JSON to the given output path (S3 or local).
-   * Uses Spark's Hadoop FileSystem API for portability.
-   */
-  def writeResultJson(spark: SparkSession, result: BackfillResult, outputPath: String): Unit = {
+  /** Write backfill result JSON to the given output path (S3 or local). Uses
+    * Spark's Hadoop FileSystem API for portability.
+    */
+  def writeResultJson(
+      spark: SparkSession,
+      result: BackfillResult,
+      outputPath: String
+  ): Unit = {
     try {
       val hadoopPath = new Path(outputPath)
       val fs = hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
       val out = fs.create(hadoopPath, true)
       try {
-        out.write(result.toJson.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        out.write(
+          result.toJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        )
       } finally {
         out.close()
       }
       logger.info(s"Backfill result JSON written to: $outputPath")
     } catch {
       case e: Exception =>
-        logger.error(s"Failed to write result JSON to $outputPath: ${e.getMessage}", e)
+        logger.error(
+          s"Failed to write result JSON to $outputPath: ${e.getMessage}",
+          e
+        )
     }
   }
 
-  /**
-   * Read snapshot JSON content from S3 or local file system.
-   * Returns the JSON string.
-   */
+  /** Configure Hadoop S3A credentials for the bucket referenced by `path`.
+    *
+    * Uses per-bucket keys (`fs.s3a.bucket.<bucket>.*`) so that the backfill
+    * *source* bucket and the Milvus storage bucket (snapshot / segments) can
+    * each use their own endpoint and credentials within the same Spark session.
+    * No-op for non-S3 paths.
+    *
+    * @param isSource
+    *   true when configuring the backfill input bucket — in that case we
+    *   consult the `sourceS3*` overrides and fall back to the main credentials
+    *   when a particular field is unset.
+    */
+  private def configureHadoopS3ForPath(
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = {
+    if (path == null) return
+    if (!(path.startsWith("s3://") || path.startsWith("s3a://"))) return
+
+    // Extract bucket name from s3(a)://bucket/key
+    val withoutScheme = path.stripPrefix("s3a://").stripPrefix("s3://")
+    val bucket = {
+      val slash = withoutScheme.indexOf('/')
+      if (slash < 0) withoutScheme else withoutScheme.substring(0, slash)
+    }
+    if (bucket.isEmpty) return
+
+    // Resolve the effective credentials for this bucket. For the source bucket
+    // any unset override falls back to the main credentials, preserving the
+    // existing single-bucket behavior.
+    val endpoint =
+      if (isSource) config.sourceS3Endpoint.getOrElse(config.s3Endpoint)
+      else config.s3Endpoint
+    val accessKey =
+      if (isSource) config.sourceS3AccessKey.getOrElse(config.s3AccessKey)
+      else config.s3AccessKey
+    val secretKey =
+      if (isSource) config.sourceS3SecretKey.getOrElse(config.s3SecretKey)
+      else config.s3SecretKey
+    val useSSL =
+      if (isSource) config.sourceS3UseSSL.getOrElse(config.s3UseSSL)
+      else config.s3UseSSL
+    val useIam =
+      if (isSource) config.sourceS3UseIam.getOrElse(config.s3UseIam)
+      else config.s3UseIam
+
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    val prefix = s"fs.s3a.bucket.$bucket"
+
+    // Endpoint + path style + SSL are safe to set in both IAM and static modes
+    if (endpoint != null && endpoint.nonEmpty) {
+      hadoopConf.set(s"$prefix.endpoint", endpoint)
+    }
+    hadoopConf.set(s"$prefix.path.style.access", "true")
+    hadoopConf.set(
+      s"$prefix.connection.ssl.enabled",
+      if (useSSL) "true" else "false"
+    )
+
+    if (useIam) {
+      // Defer credential resolution to the default AWS provider chain for
+      // this bucket (env vars, instance profile, IRSA web identity, etc.).
+      hadoopConf.set(
+        s"$prefix.aws.credentials.provider",
+        "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+      )
+    } else {
+      hadoopConf.set(s"$prefix.access.key", accessKey)
+      hadoopConf.set(s"$prefix.secret.key", secretKey)
+      // Force the simple static-credentials provider for this bucket so it
+      // doesn't get shadowed by a globally configured provider chain.
+      hadoopConf.set(
+        s"$prefix.aws.credentials.provider",
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    }
+
+    logger.info(
+      s"Configured Hadoop S3A for bucket '$bucket' " +
+        s"(endpoint=$endpoint, useIam=$useIam, isSource=$isSource)"
+    )
+  }
+
+  /** Read snapshot JSON content from S3 or local file system. Returns the JSON
+    * string.
+    */
   private def readSnapshotJson(
       spark: SparkSession,
       snapshotPath: String,
@@ -726,7 +974,9 @@ object MilvusBackfill {
 
     try {
       // Check if it's an S3 path
-      if (snapshotPath.startsWith("s3://") || snapshotPath.startsWith("s3a://")) {
+      if (
+        snapshotPath.startsWith("s3://") || snapshotPath.startsWith("s3a://")
+      ) {
 
         // Construct full S3 path (ensure s3a:// scheme for Hadoop)
         val s3Path = if (snapshotPath.startsWith("s3://")) {
@@ -735,13 +985,10 @@ object MilvusBackfill {
           snapshotPath
         }
 
-        // Configure S3 settings in Spark's Hadoop Configuration
-        val hadoopConf = spark.sparkContext.hadoopConfiguration
-        hadoopConf.set("fs.s3a.endpoint", config.s3Endpoint)
-        hadoopConf.set("fs.s3a.access.key", config.s3AccessKey)
-        hadoopConf.set("fs.s3a.secret.key", config.s3SecretKey)
-        hadoopConf.set("fs.s3a.path.style.access", "true")
-        hadoopConf.set("fs.s3a.connection.ssl.enabled", if (config.s3UseSSL) "true" else "false")
+        // Configure S3 settings on Spark's Hadoop Configuration (per-bucket
+        // so that snapshot bucket and backfill source bucket can use
+        // different credentials in the same Spark session).
+        configureHadoopS3ForPath(spark, s3Path, config, isSource = false)
 
         // Use Spark's DataFrame API to read the file (avoids Hadoop version issues)
         val df = spark.read.text(s3Path)
@@ -762,7 +1009,13 @@ object MilvusBackfill {
     } catch {
       case e: Exception =>
         logger.error(s"Failed to read snapshot JSON: ${e.getMessage}", e)
-        Left(DataReadError(snapshotPath, s"Failed to read snapshot file: ${e.getMessage}", Some(e)))
+        Left(
+          DataReadError(
+            snapshotPath,
+            s"Failed to read snapshot file: ${e.getMessage}",
+            Some(e)
+          )
+        )
     }
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -242,9 +242,14 @@ object MilvusBackfill {
     */
   private def readBackfillData(
       spark: SparkSession,
-      path: String,
+      rawPath: String,
       config: BackfillConfig
   ): Either[BackfillError, DataFrame] = {
+    // Hadoop 3.4.1 has separate s3:// and s3a:// FileSystem implementations
+    // and per-bucket fs.s3a.bucket.<b>.* config is only honored by
+    // S3AFileSystem. Force the s3a scheme so the credentials we just wrote
+    // actually take effect.
+    val path = normalizeS3Scheme(rawPath)
     try {
       // Ensure Hadoop S3A is configured for the source bucket (may differ
       // from the Milvus storage bucket) before reading the parquet.
@@ -863,9 +868,13 @@ object MilvusBackfill {
   def writeResultJson(
       spark: SparkSession,
       result: BackfillResult,
-      outputPath: String,
+      rawOutputPath: String,
       config: BackfillConfig
   ): Either[BackfillError, Unit] = {
+    // Same s3:// → s3a:// normalization as readSnapshotJson /
+    // readBackfillData. Without it, an s3:// URL would route to the legacy
+    // S3FileSystem which ignores fs.s3a.bucket.<b>.* config.
+    val outputPath = normalizeS3Scheme(rawOutputPath)
     try {
       configureHadoopS3ForPath(spark, outputPath, config, isSource = false)
       val hadoopPath = new Path(outputPath)
@@ -895,6 +904,18 @@ object MilvusBackfill {
           )
         )
     }
+  }
+
+  /** Normalize an `s3://` URL to `s3a://`. The legacy `s3://` scheme maps to
+    * Hadoop's S3FileSystem (or, on 3.4.x, an alias that does NOT honor
+    * `fs.s3a.bucket.<b>.*` per-bucket config), so per-bucket credentials we
+    * write would be silently ignored. All read/write code paths in this object
+    * route through this helper before touching Hadoop FS APIs.
+    */
+  private[backfill] def normalizeS3Scheme(path: String): String = {
+    if (path == null) null
+    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else path
   }
 
   /** Configure Hadoop S3A credentials for the bucket referenced by `path`.
@@ -968,11 +989,23 @@ object MilvusBackfill {
     )
 
     if (useIam) {
-      // Defer credential resolution to the default AWS provider chain for
-      // this bucket (env vars, instance profile, IRSA web identity, etc.).
+      // Build an explicit IRSA/EKS-friendly provider chain instead of the
+      // v1 DefaultAWSCredentialsProviderChain, which has historically been
+      // unreliable on EKS pods (it does not always pick up the projected
+      // service-account web-identity token before falling back to the
+      // EC2 instance profile of the node — leaking the node's role).
+      //
+      // Order matters:
+      //   1. WebIdentityTokenCredentialsProvider — IRSA / GKE Workload Identity
+      //   2. EnvironmentVariableCredentialsProvider — local dev / CI overrides
+      //   3. IAMInstanceCredentialsProvider — EC2 / EKS node role fallback
       hadoopConf.set(
         s"$prefix.aws.credentials.provider",
-        "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+        Seq(
+          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+        ).mkString(",")
       )
     } else {
       hadoopConf.set(s"$prefix.access.key", accessKey)
@@ -1011,7 +1044,7 @@ object MilvusBackfill {
 
         // Construct full S3 path (ensure s3a:// scheme for Hadoop)
         val s3Path = if (snapshotPath.startsWith("s3://")) {
-          snapshotPath.replace("s3://", "s3a://")
+          normalizeS3Scheme(snapshotPath)
         } else {
           snapshotPath
         }

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -848,13 +848,26 @@ object MilvusBackfill {
 
   /** Write backfill result JSON to the given output path (S3 or local). Uses
     * Spark's Hadoop FileSystem API for portability.
+    *
+    * Returns Right(()) on success and Left(BackfillError) on failure — callers
+    * MUST check the result and propagate failure to the user. The previous
+    * version swallowed exceptions, which caused silent successes (exit 0 with
+    * success message printed but no result file written).
+    *
+    * The output path may live in a bucket whose credentials are not yet
+    * configured on the Spark Hadoop conf, so we run
+    * [[configureHadoopS3ForPath]] for it first (treated as a "main bucket" path
+    * — same credentials as the Milvus storage bucket; override via --source-*
+    * if you need a separate sink for results).
     */
   def writeResultJson(
       spark: SparkSession,
       result: BackfillResult,
-      outputPath: String
-  ): Unit = {
+      outputPath: String,
+      config: BackfillConfig
+  ): Either[BackfillError, Unit] = {
     try {
+      configureHadoopS3ForPath(spark, outputPath, config, isSource = false)
       val hadoopPath = new Path(outputPath)
       val fs = hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
       val out = fs.create(hadoopPath, true)
@@ -866,11 +879,20 @@ object MilvusBackfill {
         out.close()
       }
       logger.info(s"Backfill result JSON written to: $outputPath")
+      Right(())
     } catch {
       case e: Exception =>
         logger.error(
           s"Failed to write result JSON to $outputPath: ${e.getMessage}",
           e
+        )
+        Left(
+          WriteError(
+            segmentId = -1,
+            outputPath = outputPath,
+            message = s"Failed to write result JSON: ${e.getMessage}",
+            cause = Some(e)
+          )
         )
     }
   }
@@ -887,7 +909,7 @@ object MilvusBackfill {
     *   consult the `sourceS3*` overrides and fall back to the main credentials
     *   when a particular field is unset.
     */
-  private def configureHadoopS3ForPath(
+  private[backfill] def configureHadoopS3ForPath(
       spark: SparkSession,
       path: String,
       config: BackfillConfig,
@@ -922,6 +944,9 @@ object MilvusBackfill {
     val useIam =
       if (isSource) config.sourceS3UseIam.getOrElse(config.s3UseIam)
       else config.s3UseIam
+    val region =
+      if (isSource) config.sourceS3Region.getOrElse(config.s3Region)
+      else config.s3Region
 
     val hadoopConf = spark.sparkContext.hadoopConfiguration
     val prefix = s"fs.s3a.bucket.$bucket"
@@ -929,6 +954,12 @@ object MilvusBackfill {
     // Endpoint + path style + SSL are safe to set in both IAM and static modes
     if (endpoint != null && endpoint.nonEmpty) {
       hadoopConf.set(s"$prefix.endpoint", endpoint)
+    }
+    if (region != null && region.nonEmpty) {
+      // Newer hadoop-aws (3.3.x+) reads endpoint.region; set both keys for
+      // compatibility with older versions that only honor `region`.
+      hadoopConf.set(s"$prefix.endpoint.region", region)
+      hadoopConf.set(s"$prefix.region", region)
     }
     hadoopConf.set(s"$prefix.path.style.access", "true")
     hadoopConf.set(

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -1,307 +1,209 @@
 # Backfill API
 
-The Backfill API provides a streamlined way to add new fields to existing Milvus collections by joining original data with new field values and writing per-segment binlog files.
+The Backfill API adds new fields to existing Milvus collections by joining
+the original primary-key column with new field values and writing per-segment
+binlog files directly into Milvus storage. It can run as a programmatic API
+from Scala/PySpark, or as a standalone `spark-submit` job (for example on
+Apache Spark Operator / Kubernetes).
 
-## Quick Start
+## Modes
 
-### 1. Prepare New Field Data
+The backfill operation has two read modes for the original collection:
 
-Create a Parquet file with schema `(pk, new_field1, new_field2, ...)`:
+1. **Snapshot mode (recommended)** — `MilvusBackfill.run` is given a Milvus
+   snapshot manifest JSON. The original PK column and segment metadata are
+   read directly from S3 via the storage-v2 FFI reader. **No connection to a
+   running Milvus server is required.** Field IDs are derived from the
+   snapshot's collection schema.
+2. **Client mode** — when no snapshot path is provided, the connector falls
+   back to talking to a Milvus server (`milvus.uri` / `milvus.token`) to fetch
+   the schema and segment list. ADDFIELD writes still require field-ID
+   mapping, so client mode currently rejects ADDFIELD backfill — provide a
+   snapshot.
+
+## Spark-submit entry point: `BackfillApp`
+
+`com.zilliz.spark.connector.operations.backfill.BackfillApp` is the main
+class for running backfill as a Spark application:
+
+```bash
+spark-submit \
+  --class com.zilliz.spark.connector.operations.backfill.BackfillApp \
+  spark-connector-assembly.jar \
+  --parquet      s3a://source-bucket/new_fields.parquet \
+  --snapshot     s3a://milvus-bucket/snapshots/foo.json \
+  --s3-endpoint  s3.us-west-2.amazonaws.com \
+  --s3-bucket    milvus-bucket \
+  --s3-region    us-west-2 \
+  [--s3-access-key AKIA... --s3-secret-key ...] \
+  [--s3-use-ssl] \
+  [--use-iam] \
+  [--source-s3-endpoint   s3.us-east-1.amazonaws.com] \
+  [--source-s3-access-key ... --source-s3-secret-key ...] \
+  [--source-s3-use-ssl] \
+  [--source-use-iam] \
+  [--source-s3-region us-east-1] \
+  [--batch-size 1024] \
+  [--output-result s3a://milvus-bucket/backfill/result.json]
+```
+
+### Authentication and dual-bucket credentials
+
+- **Static credentials**: pass `--s3-access-key` / `--s3-secret-key`. These
+  are forwarded to both Spark's Hadoop S3A client (per-bucket
+  `fs.s3a.bucket.<bucket>.*`) and the Milvus storage FFI.
+- **IAM / IRSA**: pass `--use-iam`, or simply omit both AK/SK. `BackfillApp`
+  auto-enables `useIam` when both keys are empty, so no flag is required
+  under IRSA. In IAM mode the connector defers to
+  `DefaultAWSCredentialsProviderChain` (env vars / web identity token /
+  instance profile).
+- **Different bucket for input parquet**: when the parquet file lives in a
+  different bucket (or even region/account) from the Milvus storage bucket,
+  use the `--source-s3-*` flags. They are written as per-bucket Hadoop S3A
+  config, so each bucket can independently use static AK/SK or IAM in the
+  same Spark session. Any unset `--source-*` falls back to the main
+  credentials.
+
+### Required flags
+
+| Flag           | Description                                       |
+|----------------|---------------------------------------------------|
+| `--parquet`    | Path to the new-field parquet (`pk, field1, ...`) |
+| `--snapshot`   | Path to the Milvus snapshot manifest JSON          |
+| `--s3-endpoint`| S3 endpoint for the Milvus storage bucket          |
+| `--s3-bucket`  | Milvus storage bucket name                         |
+
+## Programmatic API
 
 ```scala
 import org.apache.spark.sql.SparkSession
-
-val spark = SparkSession.builder()
-  .appName("Backfill")
-  .master("local[*]")
-  .getOrCreate()
-
-// Create new field data with primary key
-val newFieldData = Seq(
-  (1L, "value_1", 100),
-  (2L, "value_2", 200),
-  (3L, "value_3", 300)
-).toDF("pk", "new_string_field", "new_int_field")
-
-// Save to Parquet
-val dataPath = "/tmp/new_field_data.parquet"
-newFieldData.write.mode("overwrite").parquet(dataPath)
-```
-
-### 2. Configure and Execute
-
-```scala
 import com.zilliz.spark.connector.operations.backfill._
 
-// Configure backfill
+val spark = SparkSession.builder().appName("Backfill").getOrCreate()
+
 val config = BackfillConfig(
-  // Milvus connection
-  milvusUri = "http://localhost:19530",
-  milvusToken = "root:Milvus",
-  databaseName = "default",
-  collectionName = "my_collection",
-  
-  // Primary key field ID to read
-  pkFieldToRead = 100,
-  
-  // S3/Minio storage
-  s3Endpoint = "localhost:9000",
-  s3BucketName = "a-bucket",
-  s3AccessKey = "minioadmin",
-  s3SecretKey = "minioadmin",
-  s3UseSSL = false,
-  s3RootPath = "files",
-  s3Region = "us-east-1",
-  
-  // Optional: tuning
+  // Optional in snapshot mode — leave empty when using --snapshot
+  milvusUri      = "",
+  milvusToken    = "",
+  databaseName   = "default",
+  collectionName = "",
+
+  // Milvus storage bucket (writes + snapshot reads)
+  s3Endpoint     = "s3.us-west-2.amazonaws.com",
+  s3BucketName   = "milvus-bucket",
+  s3AccessKey    = "",          // empty => IAM/IRSA
+  s3SecretKey    = "",
+  s3UseIam       = true,
+  s3Region       = "us-west-2",
+  s3RootPath     = "files",
+  s3UseSSL       = true,
+
+  // Optional: separate bucket for the *input* parquet
+  sourceS3Endpoint  = Some("s3.us-east-1.amazonaws.com"),
+  sourceS3UseIam    = Some(true),
+  sourceS3Region    = Some("us-east-1"),
+
   batchSize = 1024
 )
 
-// Execute backfill
 val result = MilvusBackfill.run(
-  spark = spark,
-  backfillDataPath = dataPath,
-  config = config
+  spark            = spark,
+  backfillDataPath = "s3a://source-bucket/new_fields.parquet",
+  snapshotPath     = "s3a://milvus-bucket/snapshots/foo.json",
+  config           = config
 )
 
-// Handle result
 result match {
   case Right(success) =>
     println(success.summary)
-    println(s"Segments processed: ${success.segmentsProcessed}")
-    println(s"Total rows: ${success.totalRowsWritten}")
-    println(s"Execution time: ${success.executionTimeSec}s")
-    
+    println(success.segmentSummary)
   case Left(error) =>
     println(s"Backfill failed: ${error.message}")
     error.cause.foreach(_.printStackTrace())
 }
 ```
 
-## Configuration
+## Configuration reference
 
-### Required Parameters
+### Required
 
-- `milvusUri`: Milvus server URI (e.g., "http://localhost:19530")
-- `collectionName`: Collection name to backfill
-- `pkFieldToRead`: Primary key field ID (e.g., 100)
-- `s3Endpoint`: S3/Minio endpoint (e.g., "localhost:9000")
-- `s3BucketName`: S3 bucket name
-- `s3AccessKey`: S3 access key
-- `s3SecretKey`: S3 secret key
+- `s3Endpoint`, `s3BucketName` — Milvus storage bucket.
+- `s3AccessKey`, `s3SecretKey` — may be empty when `s3UseIam = true`.
 
-### Optional Parameters
+### Optional
 
-- `milvusToken`: Authentication token (default: "")
-- `databaseName`: Database name (default: "default")
-- `partitionName`: Specific partition to backfill (default: None)
-- `s3UseSSL`: Use SSL for S3 (default: false)
-- `s3RootPath`: Root path in bucket (default: "files")
-- `s3Region`: S3 region (default: "us-east-1")
-- `batchSize`: Write batch size (default: 1024)
-- `customOutputPath`: Custom S3 output path (default: None)
+- `milvusUri`, `milvusToken`, `databaseName`, `collectionName` — required
+  only in client mode (no snapshot).
+- `partitionName` — backfill a specific partition.
+- `s3UseIam` — use the AWS default credentials chain instead of static AK/SK.
+- `s3UseSSL`, `s3RootPath`, `s3Region` — standard S3 options.
+- `sourceS3Endpoint`, `sourceS3AccessKey`, `sourceS3SecretKey`,
+  `sourceS3UseSSL`, `sourceS3UseIam`, `sourceS3Region` — overrides for the
+  input parquet bucket. Any field left as `None` falls back to the
+  corresponding main `s3*` value.
+- `batchSize` — writer batch size (default 1024).
+- `customOutputPath` — override the per-segment output path.
 
-## Error Handling
+## Error handling
 
-The API returns `Either[BackfillError, BackfillResult]`:
+`MilvusBackfill.run` returns `Either[BackfillError, BackfillResult]`:
 
 ```scala
 result match {
-  case Right(success) =>
-    // Process successful result
-    
-  case Left(ConnectionError(msg, _)) =>
-    println(s"Connection error: $msg")
-    
-  case Left(SchemaValidationError(msg, _)) =>
-    println(s"Schema error: $msg")
-    
-  case Left(DataReadError(path, msg, _)) =>
-    println(s"Read error at $path: $msg")
-    
-  case Left(WriteError(segmentId, path, msg, _)) =>
-    println(s"Write error for segment $segmentId: $msg")
-    
-  case Left(error) =>
-    println(s"Error: ${error.message}")
+  case Right(success)              => /* process result */
+  case Left(ConnectionError(m, _)) => println(s"Connection error: $m")
+  case Left(SchemaValidationError(m, _)) => println(s"Schema error: $m")
+  case Left(DataReadError(p, m, _))  => println(s"Read error at $p: $m")
+  case Left(WriteError(seg, p, m, _)) =>
+    println(s"Write error for segment $seg at $p: $m")
+  case Left(other) => println(s"Error: ${other.message}")
 }
 ```
 
-## Error Types
+## Output structure
 
-- `ConnectionError`: Failed to connect to Milvus or retrieve metadata
-- `SchemaValidationError`: Schema incompatibility between original and new data
-- `DataReadError`: Failed to read new field data or collection data
-- `SegmentProcessingError`: Error processing a specific segment
-- `WriteError`: Failed to write backfill data for a segment
-- `SparkConfigError`: Spark configuration issue
-- `UnexpectedError`: General unexpected error
+When using a snapshot, each segment is written under the manifest's
+`basePath` (so binlogs land alongside the existing segment files). When no
+basePath is available, the default layout is used:
 
-## Result Structure
+```
+s3://{bucket}/{rootPath}/insert_log/{collectionID}/{partitionID}/{segmentID}/new_field/
+```
+
+Override via `customOutputPath` if needed.
+
+## How it works
+
+1. Validate S3/writer configuration. Empty AK/SK is allowed (IAM/IRSA).
+2. Load the snapshot manifest JSON (per-bucket S3A credentials are
+   configured automatically).
+3. Resolve PK field name and field ID from the snapshot schema (or via the
+   Milvus client in client mode).
+4. Read the new-field parquet, configuring S3A credentials for the source
+   bucket as needed.
+5. Read the original PK column + `segment_id` / `row_offset` via
+   `spark.read.format("com.zilliz.spark.connector.sources.MilvusDataSource")`
+   in snapshot mode (FQCN avoids shortName collisions with other connectors).
+6. Validate PK type compatibility, then left-join on the PK.
+7. For each segment, repartition with a custom segment partitioner, sort by
+   `row_offset`, and write per-segment binlogs via `MilvusLoonWriter`.
+8. Return a `BackfillResult` with manifest paths and per-segment stats.
+
+## Testing helper
 
 ```scala
-case class BackfillResult(
-  success: Boolean,
-  segmentsProcessed: Int,
-  totalRowsWritten: Long,
-  manifestPaths: Seq[String],
-  segmentResults: Map[Long, SegmentBackfillResult],
-  executionTimeMs: Long,
-  collectionId: Long,
-  partitionId: Long,
-  newFieldNames: Seq[String]
-)
+val config = BackfillConfig.forTest(collectionName = "test_collection")
 ```
 
-### Helper Methods
+`forTest` produces a localhost / Minio config suitable for the integration
+tests in `MilvusBackfillTest`. Unit tests for `parseArgs`, the new
+`validate()` invariants and `configureHadoopS3ForPath` live in
+`BackfillAppTest`.
 
-```scala
-// Formatted summary
-success.summary
-
-// Per-segment details
-success.segmentSummary
-
-// Check all segments succeeded
-success.allSegmentsSuccessful
-
-// Execution time in seconds
-success.executionTimeSec
-```
-
-## Output Structure
-
-Backfill data is written to:
+## API location
 
 ```
-s3://{bucket}/{root_path}/insert_log/{collectionID}/{partitionID}/{segmentID}/new_field/
-└── binlog_0/
-    └── task_{taskPartitionId}_{taskId}/
-        └── *.parquet files
-```
-
-By default, the output path follows the Milvus binlog structure. You can customize it using `customOutputPath` parameter.
-
-## Best Practices
-
-1. **Schema Matching**: Ensure `pk` field type in new data matches collection's primary key type (Int64 or VarChar)
-2. **Primary Key Field**: Use `pkFieldToRead` to specify the primary key field ID (typically 100)
-   - This field is used for joining with new data
-   - Only this field (plus segment_id and row_offset) is read from the collection to minimize data transfer
-3. **Batch Size**: Adjust based on data size (default 1024 works for most cases)
-   - Larger batches: faster but more memory usage
-   - Smaller batches: slower but safer for large datasets
-4. **Error Handling**: Always use pattern matching on `Either` result to handle all error cases
-5. **Cleanup**: Remove temporary Parquet files after successful backfill
-6. **Data Preparation**: Save new field data as Parquet for best performance and type safety
-
-## Complete Example
-
-```scala
-import org.apache.spark.sql.SparkSession
-import com.zilliz.spark.connector.operations.backfill._
-
-object BackfillExample {
-  def main(args: Array[String]): Unit = {
-    val spark = SparkSession.builder()
-      .appName("Backfill")
-      .master("local[*]")
-      .getOrCreate()
-
-    try {
-      // Step 1: Prepare new field data
-      val newFieldData = Seq(
-        (1L, "value_1"),
-        (2L, "value_2"),
-        (3L, "value_3")
-      ).toDF("pk", "new_description")
-      
-      val dataPath = "/tmp/new_fields.parquet"
-      newFieldData.write.mode("overwrite").parquet(dataPath)
-
-      // Step 2: Configure
-      val config = BackfillConfig(
-        milvusUri = "http://localhost:19530",
-        milvusToken = "root:Milvus",
-        collectionName = "my_collection",
-        pkFieldToRead = 100,
-        s3Endpoint = "localhost:9000",
-        s3BucketName = "a-bucket",
-        s3AccessKey = "minioadmin",
-        s3SecretKey = "minioadmin"
-      )
-
-      // Step 3: Execute
-      val result = MilvusBackfill.backfill(spark, dataPath, config)
-
-      // Step 4: Handle result
-      result match {
-        case Right(success) =>
-          println("✓ Backfill completed!")
-          println(success.summary)
-          
-        case Left(error) =>
-          println(s"✗ Backfill failed: ${error.message}")
-          System.exit(1)
-      }
-
-    } finally {
-      spark.stop()
-    }
-  }
-}
-```
-
-## Testing
-
-Use the test helper for quick setup:
-
-```scala
-val config = BackfillConfig.forTest(
-  collectionName = "test_collection",
-  pkFieldToRead = 100
-)
-```
-
-## How It Works
-
-The backfill operation follows these steps:
-
-1. **Validate Configuration**: Checks all required parameters are set
-2. **Read New Field Data**: Loads Parquet file with `(pk, new_field1, ...)` schema
-3. **Read Original Collection**: Reads only primary key field + metadata (segment_id, row_offset) from Milvus
-4. **Get Primary Key Name**: Retrieves actual PK field name from Milvus schema (not hardcoded)
-5. **Validate Schema**: Ensures PK types match between original and new data
-6. **Perform Join**: Left joins original data with new field data on primary key
-7. **Retrieve Metadata**: Gets collection ID and partition ID from Milvus
-8. **Process Segments in Parallel**: For each segment:
-   - Filters joined data for that segment
-   - Sorts by row_offset to maintain original order
-   - Writes new field binlog files to S3 using MilvusLoonWriter
-9. **Return Results**: Provides detailed results including manifest paths
-
-## Troubleshooting
-
-### Schema validation error
-- Ensure `pk` column exists in new field data
-- Verify `pk` type matches collection's primary key type (use same type: Long for Int64, String for VarChar)
-- Check that new field data has at least one field besides `pk`
-
-### Connection error
-- Check Milvus server is running and accessible at specified URI
-- Verify Milvus token format is correct: "username:password"
-- Verify S3/Minio endpoint is accessible and credentials are correct
-- Check database and collection names are correct
-
-### Write error
-- Check S3 bucket exists and is writable
-- Verify path permissions and bucket policies
-- Ensure sufficient disk space on executors
-- Check batch size isn't too large for available memory
-
-## API Location
-
-```
+com.zilliz.spark.connector.operations.backfill.BackfillApp
 com.zilliz.spark.connector.operations.backfill.MilvusBackfill
 com.zilliz.spark.connector.operations.backfill.BackfillConfig
 com.zilliz.spark.connector.operations.backfill.BackfillResult

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -213,12 +213,104 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       isSource = false
     )
     val hc = spark.sparkContext.hadoopConfiguration
-    hc.get(
-      "fs.s3a.bucket.irsa-bucket.aws.credentials.provider"
-    ) shouldBe "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+    val provider =
+      hc.get("fs.s3a.bucket.irsa-bucket.aws.credentials.provider")
+    // The IRSA-friendly chain must include WebIdentityTokenCredentialsProvider
+    // (used by both EKS service account tokens and GKE Workload Identity)
+    // and IAMInstanceCredentialsProvider for the EC2/EKS node fallback.
+    // The legacy v1 DefaultAWSCredentialsProviderChain must NOT be used
+    // because it has been unreliable on EKS pods.
+    provider should include(
+      "com.amazonaws.auth.WebIdentityTokenCredentialsProvider"
+    )
+    provider should include(
+      "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+    )
+    provider should not include "DefaultAWSCredentialsProviderChain"
     // No static keys should be written in IAM mode
     hc.get("fs.s3a.bucket.irsa-bucket.access.key") shouldBe null
     hc.get("fs.s3a.bucket.irsa-bucket.secret.key") shouldBe null
+  }
+
+  // ============ normalizeS3Scheme ============
+
+  test("normalizeS3Scheme rewrites s3:// to s3a://") {
+    MilvusBackfill.normalizeS3Scheme(
+      "s3://bucket/key.parquet"
+    ) shouldBe "s3a://bucket/key.parquet"
+  }
+
+  test("normalizeS3Scheme leaves s3a:// and other schemes alone") {
+    MilvusBackfill.normalizeS3Scheme(
+      "s3a://bucket/key"
+    ) shouldBe "s3a://bucket/key"
+    MilvusBackfill.normalizeS3Scheme(
+      "file:///tmp/x"
+    ) shouldBe "file:///tmp/x"
+    MilvusBackfill.normalizeS3Scheme("/local/path") shouldBe "/local/path"
+    MilvusBackfill.normalizeS3Scheme(null) shouldBe null
+  }
+
+  // ============ parseArgs whitelist ============
+
+  test("parseArgs rejects unknown flags (typo guard)") {
+    // Common typos like --s3access-key (missing dash) should be rejected at
+    // parse time instead of being silently absorbed and later ignored.
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseArgs(Array("--s3access-key", "ak"))
+    }
+    ex.getMessage should include("Unknown argument")
+  }
+
+  test("parseArgs accepts the full known flag set") {
+    // Smoke test that every documented CLI flag is in the whitelist.
+    val args = (BackfillApp.KvFlags.toSeq.flatMap(k =>
+      Seq("--" + k, "value")
+    ) ++ BackfillApp.BoolFlags.toSeq.map("--" + _)).toArray
+    val parsed = BackfillApp.parseArgs(args)
+    parsed.keySet shouldBe BackfillApp.KnownFlags
+  }
+
+  // ============ FFI options skip static credentials in IAM mode ============
+
+  test("getMilvusReadOptions omits AK/SK when s3UseIam=true") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "irsa-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val opts = cfg.getMilvusReadOptions
+    opts.get("fs.access_key_id") shouldBe None
+    opts.get("fs.access_key_value") shouldBe None
+    opts("fs.use_iam") shouldBe "true"
+  }
+
+  test("getMilvusReadOptions includes AK/SK when s3UseIam=false") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "minio:9000",
+      s3BucketName = "b",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    val opts = cfg.getMilvusReadOptions
+    opts("fs.access_key_id") shouldBe "ak"
+    opts("fs.access_key_value") shouldBe "sk"
+  }
+
+  test("getS3WriteOptionsForBasePath omits AK/SK when s3UseIam=true") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "irsa-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val opts = cfg.getS3WriteOptionsForBasePath("base/path", 1L)
+    opts.get("fs.access_key_id") shouldBe None
+    opts.get("fs.access_key_value") shouldBe None
+    opts("fs.use_iam") shouldBe "true"
   }
 
   test(

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -1,0 +1,259 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/** Unit tests for BackfillApp.parseArgs,
+  * MilvusBackfill.configureHadoopS3ForPath, the MilvusDataSource FQCN used by
+  * spark.read.format(...), and the new IAM/IRSA invariants of
+  * BackfillConfig.validate().
+  */
+class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("BackfillAppTest")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  // ============ parseArgs ============
+
+  test("parseArgs handles flag and key/value pairs") {
+    val args = Array(
+      "--parquet",
+      "/tmp/data.parquet",
+      "--snapshot",
+      "/tmp/snap.json",
+      "--s3-endpoint",
+      "minio:9000",
+      "--s3-bucket",
+      "a-bucket",
+      "--s3-access-key",
+      "ak",
+      "--s3-secret-key",
+      "sk",
+      "--s3-use-ssl",
+      "--use-iam"
+    )
+    val parsed = BackfillApp.parseArgs(args)
+    parsed("parquet") shouldBe "/tmp/data.parquet"
+    parsed("snapshot") shouldBe "/tmp/snap.json"
+    parsed("s3-endpoint") shouldBe "minio:9000"
+    parsed("s3-bucket") shouldBe "a-bucket"
+    parsed("s3-access-key") shouldBe "ak"
+    parsed("s3-secret-key") shouldBe "sk"
+    parsed("s3-use-ssl") shouldBe "true"
+    parsed("use-iam") shouldBe "true"
+  }
+
+  test("parseArgs handles source-* dual bucket flags") {
+    val parsed = BackfillApp.parseArgs(
+      Array(
+        "--source-s3-endpoint",
+        "src:9000",
+        "--source-s3-access-key",
+        "src-ak",
+        "--source-s3-secret-key",
+        "src-sk",
+        "--source-s3-use-ssl",
+        "--source-use-iam"
+      )
+    )
+    parsed("source-s3-endpoint") shouldBe "src:9000"
+    parsed("source-s3-access-key") shouldBe "src-ak"
+    parsed("source-s3-secret-key") shouldBe "src-sk"
+    parsed("source-s3-use-ssl") shouldBe "true"
+    parsed("source-use-iam") shouldBe "true"
+  }
+
+  test("parseArgs throws on missing value for non-flag") {
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.parseArgs(Array("--parquet"))
+    }
+  }
+
+  test("parseArgs throws on unexpected positional arg") {
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.parseArgs(Array("oops"))
+    }
+  }
+
+  // ============ validate() invariants ============
+
+  test("validate fails on empty s3Endpoint") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "",
+      s3BucketName = "b",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    cfg.validate() shouldBe Left("s3Endpoint cannot be empty")
+  }
+
+  test("validate fails on empty s3BucketName") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "ep",
+      s3BucketName = "",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    cfg.validate() shouldBe Left("s3BucketName cannot be empty")
+  }
+
+  test("validate fails on non-positive batchSize") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "ep",
+      s3BucketName = "b",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk",
+      batchSize = 0
+    )
+    cfg.validate() shouldBe Left("batchSize must be positive")
+  }
+
+  test("validate accepts empty AK/SK (IAM/IRSA)") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "ep",
+      s3BucketName = "b",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    cfg.validate() shouldBe Right(())
+  }
+
+  test("validateForClientMode requires milvusUri and collectionName") {
+    val base = BackfillConfig(
+      s3Endpoint = "ep",
+      s3BucketName = "b",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    base.validateForClientMode().isLeft shouldBe true
+    base
+      .copy(milvusUri = "http://x:19530")
+      .validateForClientMode()
+      .isLeft shouldBe true
+    base
+      .copy(milvusUri = "http://x:19530", collectionName = "c")
+      .validateForClientMode() shouldBe Right(())
+  }
+
+  // ============ configureHadoopS3ForPath ============
+
+  test("configureHadoopS3ForPath is a no-op for non-s3 paths") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "ep",
+      s3BucketName = "b",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    val key = "fs.s3a.bucket.never.endpoint"
+    spark.sparkContext.hadoopConfiguration.unset(key)
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "file:///tmp/x",
+      cfg,
+      isSource = false
+    )
+    spark.sparkContext.hadoopConfiguration.get(key) shouldBe null
+  }
+
+  test("configureHadoopS3ForPath writes per-bucket static credentials") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "minio:9000",
+      s3BucketName = "main-bucket",
+      s3AccessKey = "ak1",
+      s3SecretKey = "sk1",
+      s3UseSSL = false
+    )
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "s3a://main-bucket/path/to/file",
+      cfg,
+      isSource = false
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.get("fs.s3a.bucket.main-bucket.endpoint") shouldBe "minio:9000"
+    hc.get("fs.s3a.bucket.main-bucket.path.style.access") shouldBe "true"
+    hc.get(
+      "fs.s3a.bucket.main-bucket.connection.ssl.enabled"
+    ) shouldBe "false"
+    hc.get("fs.s3a.bucket.main-bucket.access.key") shouldBe "ak1"
+    hc.get("fs.s3a.bucket.main-bucket.secret.key") shouldBe "sk1"
+    hc.get(
+      "fs.s3a.bucket.main-bucket.aws.credentials.provider"
+    ) shouldBe "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  }
+
+  test("configureHadoopS3ForPath uses IAM provider when useIam=true") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "irsa-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "s3a://irsa-bucket/key",
+      cfg,
+      isSource = false
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.get(
+      "fs.s3a.bucket.irsa-bucket.aws.credentials.provider"
+    ) shouldBe "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+    // No static keys should be written in IAM mode
+    hc.get("fs.s3a.bucket.irsa-bucket.access.key") shouldBe null
+    hc.get("fs.s3a.bucket.irsa-bucket.secret.key") shouldBe null
+  }
+
+  test(
+    "configureHadoopS3ForPath with isSource=true honors source overrides and falls back to main"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "minio:9000",
+      s3BucketName = "main-bucket",
+      s3AccessKey = "main-ak",
+      s3SecretKey = "main-sk",
+      sourceS3Endpoint = Some("src:9000"),
+      sourceS3AccessKey = Some("src-ak"),
+      sourceS3SecretKey = Some("src-sk")
+      // sourceS3UseSSL/UseIam left None — should fall back to main
+    )
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "s3a://source-bucket/data.parquet",
+      cfg,
+      isSource = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.get("fs.s3a.bucket.source-bucket.endpoint") shouldBe "src:9000"
+    hc.get("fs.s3a.bucket.source-bucket.access.key") shouldBe "src-ak"
+    hc.get("fs.s3a.bucket.source-bucket.secret.key") shouldBe "src-sk"
+  }
+
+  // ============ FQCN smoke test ============
+
+  test("MilvusDataSource fully qualified class name resolves") {
+    // MilvusBackfill.readCollectionWithMetadata uses
+    // spark.read.format("com.zilliz.spark.connector.sources.MilvusDataSource")
+    // to avoid shortName collisions with other connectors. This test pins the
+    // FQCN so a future rename or move is caught at unit-test time.
+    val fqcn = "com.zilliz.spark.connector.sources.MilvusDataSource"
+    noException should be thrownBy Class.forName(fqcn)
+  }
+}

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -3,9 +3,8 @@ package com.zilliz.spark.connector.operations.backfill
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-/**
- * Unit tests for BackfillConfig validation and options generation
- */
+/** Unit tests for BackfillConfig validation and options generation
+  */
 class BackfillConfigTest extends AnyFunSuite with Matchers {
 
   // ============ Validation Tests ============
@@ -24,7 +23,35 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.validate() shouldBe Right(())
   }
 
-  test("Empty milvusUri fails validation") {
+  test(
+    "Empty milvusUri/collectionName is allowed by validate() in snapshot mode"
+  ) {
+    // milvusUri and collectionName are only required in client mode (no snapshot).
+    // validate() must accept empty values; only validateForClientMode rejects them.
+    val config = BackfillConfig(
+      milvusUri = "",
+      collectionName = "",
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin"
+    )
+
+    config.validate() shouldBe Right(())
+  }
+
+  test("validate accepts empty AK/SK when s3UseIam=true") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    config.validate() shouldBe Right(())
+  }
+
+  test("validateForClientMode fails on empty milvusUri") {
     val config = BackfillConfig(
       milvusUri = "",
       collectionName = "test_collection",
@@ -34,10 +61,10 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       s3SecretKey = "minioadmin"
     )
 
-    config.validate() shouldBe Left("milvusUri cannot be empty")
+    config.validateForClientMode().isLeft shouldBe true
   }
 
-  test("Empty collectionName fails validation") {
+  test("validateForClientMode fails on empty collectionName") {
     val config = BackfillConfig(
       milvusUri = "http://localhost:19530",
       collectionName = "",
@@ -47,7 +74,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       s3SecretKey = "minioadmin"
     )
 
-    config.validate() shouldBe Left("collectionName cannot be empty")
+    config.validateForClientMode().isLeft shouldBe true
   }
 
   test("Empty s3Endpoint fails validation") {
@@ -76,30 +103,72 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.validate() shouldBe Left("s3BucketName cannot be empty")
   }
 
-  test("Empty s3AccessKey fails validation") {
+  test("Empty s3AccessKey/s3SecretKey is allowed (IAM/IRSA mode)") {
+    // Under IAM/IRSA the SDK falls back to the default AWS credentials chain,
+    // so empty static credentials must NOT fail validation.
     val config = BackfillConfig(
       milvusUri = "http://localhost:19530",
       collectionName = "test_collection",
       s3Endpoint = "localhost:9000",
       s3BucketName = "test-bucket",
       s3AccessKey = "",
-      s3SecretKey = "minioadmin"
+      s3SecretKey = "",
+      s3UseIam = true
     )
 
-    config.validate() shouldBe Left("s3AccessKey cannot be empty")
+    config.validate() shouldBe Right(())
   }
 
-  test("Empty s3SecretKey fails validation") {
+  test("Empty s3AccessKey/s3SecretKey without useIam is rejected") {
+    // Hard invariant: must use IAM or supply both AK and SK. Half-set or
+    // fully-empty static credentials without useIam are never valid.
     val config = BackfillConfig(
       milvusUri = "http://localhost:19530",
       collectionName = "test_collection",
       s3Endpoint = "localhost:9000",
       s3BucketName = "test-bucket",
-      s3AccessKey = "minioadmin",
+      s3AccessKey = "",
       s3SecretKey = ""
     )
 
-    config.validate() shouldBe Left("s3SecretKey cannot be empty")
+    config.validate().isLeft shouldBe true
+  }
+
+  test("Half-set s3AccessKey without s3SecretKey is rejected") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "ak",
+      s3SecretKey = ""
+    )
+    config.validate().isLeft shouldBe true
+  }
+
+  test(
+    "Source bucket half-set credentials without sourceS3UseIam are rejected"
+  ) {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "main-ak",
+      s3SecretKey = "main-sk",
+      sourceS3AccessKey = Some("src-ak"),
+      sourceS3SecretKey = Some("")
+    )
+    config.validate().isLeft shouldBe true
+  }
+
+  test("Source bucket override with sourceS3UseIam=true is accepted") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "main-ak",
+      s3SecretKey = "main-sk",
+      sourceS3AccessKey = Some(""),
+      sourceS3SecretKey = Some(""),
+      sourceS3UseIam = Some(true)
+    )
+    config.validate() shouldBe Right(())
   }
 
   test("Zero batchSize fails validation") {
@@ -213,7 +282,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
 
     val options = config.getMilvusReadOptions
 
-    options should not contain key ("milvus.partition.name")
+    options should not contain key("milvus.partition.name")
   }
 
   // ============ getS3WriteOptions Tests ============
@@ -247,7 +316,9 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     options("fs.use_ssl") shouldBe "true"
     options("fs.region") shouldBe "us-west-2"
     options("milvus.collection.name") shouldBe "segment_789_backfill"
-    options("milvus.writer.customPath") shouldBe "test-bucket/files/insert_log/123/456/789/new_field"
+    options(
+      "milvus.writer.customPath"
+    ) shouldBe "files/insert_log/123/456/789"
     options("milvus.insertMaxBatchSize") shouldBe "2048"
   }
 


### PR DESCRIPTION
Make MilvusBackfill deployable as a standalone spark-submit job on Kubernetes (Apache Spark Operator), with first-class support for IRSA auth and an input parquet bucket separate from the Milvus storage bucket.

New entry point and config:
- BackfillApp: new spark-submit main class. Parses --parquet/--snapshot /--s3-* / --use-iam / --source-s3-* / --source-use-iam, builds a BackfillConfig and invokes MilvusBackfill.run(). Auto-enables use_iam when both ak/sk are empty so no flag is needed under IRSA.
- BackfillConfig: add s3UseIam plus optional sourceS3Endpoint / sourceS3AccessKey / sourceS3SecretKey / sourceS3UseSSL / sourceS3UseIam / sourceS3Region. Both read and write option builders forward fs.use_iam to the Milvus FFI so it picks up the AWS default credentials chain (env / web identity / instance profile).

Backfill core:
- MilvusBackfill: program per-bucket fs.s3a.bucket.<name>.* on the SparkContext hadoopConfiguration for both the snapshot path and the backfill parquet path, so each bucket can independently use static AK/SK or IAM. Stop unconditionally overwriting fs.s3a.access.key/ secret.key (which previously broke DefaultAWSCredentialsProviderChain under IRSA). Use the fully qualified MilvusDataSource class in spark.read.format(...) to avoid shortName collisions when other connectors also register "milvus".

Build / packaging:
- Mark hadoop-common, hadoop-aws and parquet-hadoop as provided,test — Spark images already ship them, and bundling caused "X not a subtype of Y" classloader errors (especially with userClassPathFirst=true).
- Globally exclude slf4j-log4j12 / slf4j-reload4j / log4j 1.x / reload4j to remove the duplicate StaticLoggerBinder against Spark's log4j2.
- Filter slf4j-api out of the assembly fat jar so the runtime org.slf4j.Logger only comes from /opt/spark/jars, eliminating LinkageError on the Logging trait when the user JAR is loaded first.

Submodule:
- Bump milvus-storage to pick up the JNI fat-jar SONAME-versioned .so packaging fix and the aws-c-* shared-lib build.