### PR TITLE
chore: add sbt-scalafmt plugin and apply code formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,10 @@
 version = "3.7.15"
 runner.dialect = scala213
 
+project.excludePaths = [
+  "glob:**/target/**"
+]
+
 indent.main = 2
 
 rewrite.rules = [SortModifiers, Imports]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,6 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.7")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -325,12 +325,15 @@ class MilvusClient(params: MilvusConnectionParams) {
           collectionNames = collectionNames
         )
       )
-      checkStatus("flush", flushResponse.status.getOrElse(
-        Status(
-          errorCode = ErrorCode.UnexpectedError,
-          reason = "Flush Status is empty"
+      checkStatus(
+        "flush",
+        flushResponse.status.getOrElse(
+          Status(
+            errorCode = ErrorCode.UnexpectedError,
+            reason = "Flush Status is empty"
+          )
         )
-      ))
+      )
     } catch {
       case e: Exception =>
         Failure(

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -10,9 +10,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import com.zilliz.spark.connector.MilvusConnectionException
 
-/**
- * Vector search configuration for Milvus Storage V2
- */
+/** Vector search configuration for Milvus Storage V2
+  */
 case class VectorSearchConfig(
     queryVector: Array[Float],
     topK: Int,
@@ -115,16 +114,21 @@ object MilvusOption {
 
   // Writer config
   val WriterCustomPath = "milvus.writer.customPath"
-  val WriterCommitType = "milvus.writer.commitType"  // "addfield" for backfill, default "addfiles"
-  val WriterFieldIds = "milvus.writer.fieldIds"      // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
+  val WriterCommitType =
+    "milvus.writer.commitType" // "addfield" for backfill, default "addfiles"
+  val WriterFieldIds =
+    "milvus.writer.fieldIds" // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
 
   // Snapshot-based reading options (for offline/client-free mode)
-  val SnapshotMode = "milvus.snapshot.mode"                 // "true" to enable snapshot mode
-  val SnapshotManifests = "milvus.snapshot.manifests"       // JSON array of StorageV2ManifestItem
+  val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
+  val SnapshotManifests =
+    "milvus.snapshot.manifests" // JSON array of StorageV2ManifestItem
   val SnapshotCollectionId = "milvus.snapshot.collection.id"
   val SnapshotPartitionIds = "milvus.snapshot.partition.ids"
-  val SnapshotSchemaJson = "milvus.snapshot.schema.json"    // Optional: raw schema JSON for building MilvusCollectionInfo
-  val SnapshotSchemaBytes = "milvus.snapshot.schema.bytes"  // Base64 encoded protobuf CollectionSchema bytes
+  val SnapshotSchemaJson =
+    "milvus.snapshot.schema.json" // Optional: raw schema JSON for building MilvusCollectionInfo
+  val SnapshotSchemaBytes =
+    "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {
@@ -188,9 +192,8 @@ object MilvusOption {
     )
   }
 
-  /**
-   * Parse vector search configuration from options
-   */
+  /** Parse vector search configuration from options
+    */
   private def parseVectorSearchConfig(
       options: CaseInsensitiveStringMap
   ): Option[VectorSearchConfig] = {
@@ -216,10 +219,9 @@ object MilvusOption {
     }
   }
 
-  /**
-   * Parse query vector from JSON string format
-   * Expected format: "[0.1, 0.2, 0.3, ...]"
-   */
+  /** Parse query vector from JSON string format Expected format: "[0.1, 0.2,
+    * 0.3, ...]"
+    */
   private def parseQueryVector(jsonStr: String): Array[Float] = {
     jsonStr.trim
       .stripPrefix("[")
@@ -232,15 +234,14 @@ object MilvusOption {
     milvusPKType.toLowerCase() == "int64"
   }
 
-  /**
-   * Generate vector dimension configuration key for a given field name
-   * Format: vector.{fieldName}.dim
-   */
+  /** Generate vector dimension configuration key for a given field name Format:
+    * vector.{fieldName}.dim
+    */
   def vectorDimKey(fieldName: String): String = s"vector.$fieldName.dim"
 
-  /**
-   * Helper method to convert Map to CaseInsensitiveStringMap and create MilvusOption
-   */
+  /** Helper method to convert Map to CaseInsensitiveStringMap and create
+    * MilvusOption
+    */
   def apply(options: Map[String, String]): MilvusOption = {
     import scala.collection.JavaConverters._
     apply(new CaseInsensitiveStringMap(options.asJava))

--- a/src/main/scala/MilvusUtil.scala
+++ b/src/main/scala/MilvusUtil.scala
@@ -559,4 +559,3 @@ object SparseFloatVectorConverter {
     buf.array()
   }
 }
-

--- a/src/main/scala/expressions/VectorExpressions.scala
+++ b/src/main/scala/expressions/VectorExpressions.scala
@@ -1,80 +1,91 @@
 package com.zilliz.spark.connector.expressions
 
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector, Vector, Vectors}
+import org.apache.spark.mllib.linalg.{
+  DenseVector => OldDenseVector,
+  SparseVector => OldSparseVector,
+  Vector => OldVector
+}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.ml.linalg.{Vector, DenseVector, SparseVector, Vectors}
-import org.apache.spark.mllib.linalg.{Vector => OldVector, DenseVector => OldDenseVector, SparseVector => OldSparseVector}
 
-/**
- * Base trait for binary vector expressions
- */
-abstract class BinaryVectorExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryExpression with CodegenFallback with Serializable {
-  
+/** Base trait for binary vector expressions
+  */
+abstract class BinaryVectorExpression(_left: Expression, _right: Expression)
+    extends BinaryExpression
+    with CodegenFallback
+    with Serializable {
+
   override def left: Expression = _left
   override def right: Expression = _right
-  
+
   // Thread-local cache for vector conversions to avoid repeated conversions
   @transient private var cachedLeftVector: Vector = _
   @transient private var cachedRightVector: Vector = _
   @transient private var lastLeftValue: Any = _
   @transient private var lastRightValue: Any = _
-  
+
   override def dataType: DataType = DoubleType
   override def nullable: Boolean = true
-  
-  protected def validateVectorTypes(leftType: DataType, rightType: DataType): Boolean = {
+
+  protected def validateVectorTypes(
+      leftType: DataType,
+      rightType: DataType
+  ): Boolean = {
     import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
-    
+
     (leftType, rightType) match {
       // Spark ML Vector types (preferred)
-      case (VectorType, VectorType) => true
+      case (VectorType, VectorType)      => true
       case (VectorType, ArrayType(_, _)) => true
       case (ArrayType(_, _), VectorType) => true
-      
+
       // Array types (fallback)
-      case (ArrayType(FloatType, _), ArrayType(FloatType, _)) => true
-      case (ArrayType(DoubleType, _), ArrayType(DoubleType, _)) => true
-      case (ArrayType(IntegerType, _), ArrayType(IntegerType, _)) => true
-      case (ArrayType(LongType, _), ArrayType(LongType, _)) => true
+      case (ArrayType(FloatType, _), ArrayType(FloatType, _))         => true
+      case (ArrayType(DoubleType, _), ArrayType(DoubleType, _))       => true
+      case (ArrayType(IntegerType, _), ArrayType(IntegerType, _))     => true
+      case (ArrayType(LongType, _), ArrayType(LongType, _))           => true
       case (ArrayType(DecimalType(), _), ArrayType(DecimalType(), _)) => true
-      case (ArrayType(FloatType, _), ArrayType(DoubleType, _)) => true
-      case (ArrayType(DoubleType, _), ArrayType(FloatType, _)) => true
-      case (ArrayType(_, _), ArrayType(_, _)) => true // Allow mixed numeric types
+      case (ArrayType(FloatType, _), ArrayType(DoubleType, _))        => true
+      case (ArrayType(DoubleType, _), ArrayType(FloatType, _))        => true
+      case (ArrayType(_, _), ArrayType(_, _)) =>
+        true // Allow mixed numeric types
       case _ => false
     }
   }
-  
+
   protected def extractVector(value: Any): Vector = {
     value match {
       // Spark ML Vector (preferred)
       case vector: Vector => vector
-      
+
       // Spark MLlib Vector (legacy)
-      case oldVector: OldVector => 
+      case oldVector: OldVector =>
         oldVector match {
           case dense: OldDenseVector => Vectors.dense(dense.values)
-          case sparse: OldSparseVector => Vectors.sparse(sparse.size, sparse.indices, sparse.values)
+          case sparse: OldSparseVector =>
+            Vectors.sparse(sparse.size, sparse.indices, sparse.values)
         }
-      
+
       // Array data - convert to DenseVector (optimized)
       case arrayData: ArrayData =>
         extractVectorFromArrayData(arrayData)
-        
+
       case _ => null
     }
   }
-  
+
   // Cached vector extraction with reference equality check
   protected def extractVectorCached(value: Any, isLeft: Boolean): Vector = {
     if (isLeft) {
-      if (lastLeftValue != null && (lastLeftValue.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef])) {
+      if (
+        lastLeftValue != null && (lastLeftValue.asInstanceOf[AnyRef] eq value
+          .asInstanceOf[AnyRef])
+      ) {
         cachedLeftVector
       } else {
         cachedLeftVector = extractVector(value)
@@ -82,7 +93,10 @@ abstract class BinaryVectorExpression(
         cachedLeftVector
       }
     } else {
-      if (lastRightValue != null && (lastRightValue.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef])) {
+      if (
+        lastRightValue != null && (lastRightValue.asInstanceOf[AnyRef] eq value
+          .asInstanceOf[AnyRef])
+      ) {
         cachedRightVector
       } else {
         cachedRightVector = extractVector(value)
@@ -91,12 +105,12 @@ abstract class BinaryVectorExpression(
       }
     }
   }
-  
+
   // Optimized method to extract vector from ArrayData
   private def extractVectorFromArrayData(arrayData: ArrayData): Vector = {
     val size = arrayData.numElements()
     val values = new Array[Double](size)
-    
+
     // Optimized extraction - try double first, then fallback
     var i = 0
     try {
@@ -115,10 +129,10 @@ abstract class BinaryVectorExpression(
           i += 1
         }
     }
-    
+
     Vectors.dense(values)
   }
-  
+
   // Keep the old method for backward compatibility
   protected def extractFloatArray(value: Any): Array[Float] = {
     val vector = extractVector(value)
@@ -128,7 +142,7 @@ abstract class BinaryVectorExpression(
       vector.toArray.map(_.toFloat)
     }
   }
-  
+
   protected def extractDoubleArray(value: Any): Array[Double] = {
     val vector = extractVector(value)
     if (vector == null) {
@@ -137,68 +151,75 @@ abstract class BinaryVectorExpression(
       vector.toArray
     }
   }
-  
+
   protected def convertToFloat(value: Any): Float = {
     value match {
-      case f: Float => f
+      case f: Float  => f
       case d: Double => d.toFloat
-      case i: Int => i.toFloat
-      case l: Long => l.toFloat
-      case decimal: org.apache.spark.sql.types.Decimal => decimal.toDouble.toFloat
+      case i: Int    => i.toFloat
+      case l: Long   => l.toFloat
+      case decimal: org.apache.spark.sql.types.Decimal =>
+        decimal.toDouble.toFloat
       case null => 0.0f
-      case _ => throw new IllegalArgumentException(s"Cannot convert ${value.getClass} to Float: $value")
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot convert ${value.getClass} to Float: $value"
+        )
     }
   }
-  
+
   protected def convertToDouble(value: Any): Double = {
     value match {
-      case f: Float => f.toDouble
-      case d: Double => d
-      case i: Int => i.toDouble
-      case l: Long => l.toDouble
+      case f: Float                                    => f.toDouble
+      case d: Double                                   => d
+      case i: Int                                      => i.toDouble
+      case l: Long                                     => l.toDouble
       case decimal: org.apache.spark.sql.types.Decimal => decimal.toDouble
-      case null => 0.0
-      case _ => throw new IllegalArgumentException(s"Cannot convert ${value.getClass} to Double: $value")
+      case null                                        => 0.0
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot convert ${value.getClass} to Double: $value"
+        )
     }
   }
 }
 
-/**
- * Cosine Similarity Expression
- */
-case class CosineSimilarityExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryVectorExpression(_left, _right) with Serializable {
-  
+/** Cosine Similarity Expression
+  */
+case class CosineSimilarityExpression(_left: Expression, _right: Expression)
+    extends BinaryVectorExpression(_left, _right)
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newLeft: Expression, 
-    newRight: Expression
+      newLeft: Expression,
+      newRight: Expression
   ): Expression = copy(_left = newLeft, _right = newRight)
-  
+
   override def nullSafeEval(leftValue: Any, rightValue: Any): Any = {
     val leftVector = extractVectorCached(leftValue, isLeft = true)
     val rightVector = extractVectorCached(rightValue, isLeft = false)
-    
-    if (leftVector == null || rightVector == null || leftVector.size != rightVector.size) {
+
+    if (
+      leftVector == null || rightVector == null || leftVector.size != rightVector.size
+    ) {
       null
     } else {
       computeCosineSimilarity(leftVector, rightVector)
     }
   }
-  
+
   private def computeCosineSimilarity(v1: Vector, v2: Vector): Double = {
     if (v1.size != v2.size) return 0.0
-    
+
     // Optimized computation using raw arrays for better performance
     val arr1 = v1.toArray
     val arr2 = v2.toArray
     val size = arr1.length
-    
+
     var dotProduct = 0.0
     var norm1Sq = 0.0
     var norm2Sq = 0.0
-    
+
     // Single loop to compute all values
     var i = 0
     while (i < size) {
@@ -209,49 +230,49 @@ case class CosineSimilarityExpression(
       norm2Sq += v2Val * v2Val
       i += 1
     }
-    
+
     if (norm1Sq == 0.0 || norm2Sq == 0.0) {
       0.0
     } else {
       dotProduct / (math.sqrt(norm1Sq) * math.sqrt(norm2Sq))
     }
   }
-  
+
   override def prettyName: String = "cosine_similarity"
 }
 
-/**
- * L2 Distance Expression
- */
-case class L2DistanceExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryVectorExpression(_left, _right) with Serializable {
-  
+/** L2 Distance Expression
+  */
+case class L2DistanceExpression(_left: Expression, _right: Expression)
+    extends BinaryVectorExpression(_left, _right)
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newLeft: Expression, 
-    newRight: Expression
+      newLeft: Expression,
+      newRight: Expression
   ): Expression = copy(_left = newLeft, _right = newRight)
-  
+
   override def nullSafeEval(leftValue: Any, rightValue: Any): Any = {
     val leftVector = extractVectorCached(leftValue, isLeft = true)
     val rightVector = extractVectorCached(rightValue, isLeft = false)
-    
-    if (leftVector == null || rightVector == null || leftVector.size != rightVector.size) {
+
+    if (
+      leftVector == null || rightVector == null || leftVector.size != rightVector.size
+    ) {
       null
     } else {
       computeL2Distance(leftVector, rightVector)
     }
   }
-  
+
   private def computeL2Distance(v1: Vector, v2: Vector): Double = {
     if (v1.size != v2.size) return Double.MaxValue
-    
+
     // Optimized computation using raw arrays for better performance
     val arr1 = v1.toArray
     val arr2 = v2.toArray
     val size = arr1.length
-    
+
     var sum = 0.0
     var i = 0
     while (i < size) {
@@ -261,68 +282,68 @@ case class L2DistanceExpression(
     }
     math.sqrt(sum)
   }
-  
+
   override def prettyName: String = "l2_distance"
 }
 
-/**
- * Inner Product Expression
- */
-case class InnerProductExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryVectorExpression(_left, _right) with Serializable {
-  
+/** Inner Product Expression
+  */
+case class InnerProductExpression(_left: Expression, _right: Expression)
+    extends BinaryVectorExpression(_left, _right)
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newLeft: Expression, 
-    newRight: Expression
+      newLeft: Expression,
+      newRight: Expression
   ): Expression = copy(_left = newLeft, _right = newRight)
-  
+
   override def nullSafeEval(leftValue: Any, rightValue: Any): Any = {
     val leftVector = extractVector(leftValue)
     val rightVector = extractVector(rightValue)
-    
-    if (leftVector == null || rightVector == null || leftVector.size != rightVector.size) {
+
+    if (
+      leftVector == null || rightVector == null || leftVector.size != rightVector.size
+    ) {
       null
     } else {
       computeInnerProduct(leftVector, rightVector)
     }
   }
-  
+
   private def computeInnerProduct(v1: Vector, v2: Vector): Double = {
     if (v1.size != v2.size) return 0.0
-    
+
     // Use optimized Vector dot product like VectorBruteForceSearch
     v1.dot(v2)
   }
-  
+
   override def prettyName: String = "inner_product"
 }
 
-/**
- * Hamming Distance Expression for binary vectors
- */
-case class HammingDistanceExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryVectorExpression(_left, _right) with Serializable {
-  
+/** Hamming Distance Expression for binary vectors
+  */
+case class HammingDistanceExpression(_left: Expression, _right: Expression)
+    extends BinaryVectorExpression(_left, _right)
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newLeft: Expression, 
-    newRight: Expression
+      newLeft: Expression,
+      newRight: Expression
   ): Expression = copy(_left = newLeft, _right = newRight)
-  
+
   override def nullSafeEval(leftValue: Any, rightValue: Any): Any = {
     val leftArray = extractByteArray(leftValue)
     val rightArray = extractByteArray(rightValue)
-    
-    if (leftArray == null || rightArray == null || leftArray.length != rightArray.length) {
+
+    if (
+      leftArray == null || rightArray == null || leftArray.length != rightArray.length
+    ) {
       null
     } else {
       computeHammingDistance(leftArray, rightArray)
     }
   }
-  
+
   private def extractByteArray(value: Any): Array[Byte] = {
     value match {
       case arrayData: ArrayData =>
@@ -338,23 +359,29 @@ case class HammingDistanceExpression(
       case _ => null
     }
   }
-  
+
   private def convertToByte(value: Any): Byte = {
     value match {
-      case b: Byte => b
-      case i: Int => i.toByte
-      case l: Long => l.toByte
-      case f: Float => f.toByte
-      case d: Double => d.toByte
+      case b: Byte                                     => b
+      case i: Int                                      => i.toByte
+      case l: Long                                     => l.toByte
+      case f: Float                                    => f.toByte
+      case d: Double                                   => d.toByte
       case decimal: org.apache.spark.sql.types.Decimal => decimal.toInt.toByte
-      case null => 0.toByte
-      case _ => throw new IllegalArgumentException(s"Cannot convert ${value.getClass} to Byte: $value")
+      case null                                        => 0.toByte
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot convert ${value.getClass} to Byte: $value"
+        )
     }
   }
-  
-  private def computeHammingDistance(v1: Array[Byte], v2: Array[Byte]): Double = {
+
+  private def computeHammingDistance(
+      v1: Array[Byte],
+      v2: Array[Byte]
+  ): Double = {
     if (v1.length != v2.length) return Double.MaxValue
-    
+
     var distance = 0
     var i = 0
     while (i < v1.length) {
@@ -362,37 +389,37 @@ case class HammingDistanceExpression(
       distance += java.lang.Integer.bitCount(xor & 0xff)
       i += 1
     }
-    
+
     distance.toDouble
   }
-  
+
   override def prettyName: String = "hamming_distance"
 }
 
-/**
- * Jaccard Distance Expression for binary vectors
- */
-case class JaccardDistanceExpression(
-    _left: Expression,
-    _right: Expression)
-  extends BinaryVectorExpression(_left, _right) with Serializable {
-  
+/** Jaccard Distance Expression for binary vectors
+  */
+case class JaccardDistanceExpression(_left: Expression, _right: Expression)
+    extends BinaryVectorExpression(_left, _right)
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newLeft: Expression, 
-    newRight: Expression
+      newLeft: Expression,
+      newRight: Expression
   ): Expression = copy(_left = newLeft, _right = newRight)
-  
+
   override def nullSafeEval(leftValue: Any, rightValue: Any): Any = {
     val leftArray = extractByteArray(leftValue)
     val rightArray = extractByteArray(rightValue)
-    
-    if (leftArray == null || rightArray == null || leftArray.length != rightArray.length) {
+
+    if (
+      leftArray == null || rightArray == null || leftArray.length != rightArray.length
+    ) {
       null
     } else {
       computeJaccardDistance(leftArray, rightArray)
     }
   }
-  
+
   private def extractByteArray(value: Any): Array[Byte] = {
     value match {
       case arrayData: ArrayData =>
@@ -408,26 +435,32 @@ case class JaccardDistanceExpression(
       case _ => null
     }
   }
-  
+
   private def convertToByte(value: Any): Byte = {
     value match {
-      case b: Byte => b
-      case i: Int => i.toByte
-      case l: Long => l.toByte
-      case f: Float => f.toByte
-      case d: Double => d.toByte
+      case b: Byte                                     => b
+      case i: Int                                      => i.toByte
+      case l: Long                                     => l.toByte
+      case f: Float                                    => f.toByte
+      case d: Double                                   => d.toByte
       case decimal: org.apache.spark.sql.types.Decimal => decimal.toInt.toByte
-      case null => 0.toByte
-      case _ => throw new IllegalArgumentException(s"Cannot convert ${value.getClass} to Byte: $value")
+      case null                                        => 0.toByte
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot convert ${value.getClass} to Byte: $value"
+        )
     }
   }
-  
-  private def computeJaccardDistance(v1: Array[Byte], v2: Array[Byte]): Double = {
+
+  private def computeJaccardDistance(
+      v1: Array[Byte],
+      v2: Array[Byte]
+  ): Double = {
     if (v1.length != v2.length) return 1.0 // Maximum distance
-    
+
     var intersection = 0
     var union = 0
-    
+
     var i = 0
     while (i < v1.length) {
       val and = v1(i) & v2(i)
@@ -436,26 +469,27 @@ case class JaccardDistanceExpression(
       union += java.lang.Integer.bitCount(or & 0xff)
       i += 1
     }
-    
+
     if (union == 0) 0.0 else 1.0 - (intersection.toDouble / union.toDouble)
   }
-  
+
   override def prettyName: String = "jaccard_distance"
 }
 
-/**
- * Vector KNN Expression - simplified version
- * This is a basic implementation for demonstration
- */
+/** Vector KNN Expression - simplified version This is a basic implementation
+  * for demonstration
+  */
 case class VectorKNNExpression(
-  vectors: Expression,
-  queryVector: Expression, 
-  k: Expression,
-  distanceType: Expression
-) extends Expression with CodegenFallback with Serializable {
-  
+    vectors: Expression,
+    queryVector: Expression,
+    k: Expression,
+    distanceType: Expression
+) extends Expression
+    with CodegenFallback
+    with Serializable {
+
   override protected def withNewChildrenInternal(
-    newChildren: IndexedSeq[Expression]
+      newChildren: IndexedSeq[Expression]
   ): Expression = {
     require(newChildren.length == 4)
     copy(
@@ -465,19 +499,24 @@ case class VectorKNNExpression(
       distanceType = newChildren(3)
     )
   }
-  
-  override def children: Seq[Expression] = Seq(vectors, queryVector, k, distanceType)
-  override def dataType: DataType = ArrayType(StructType(Seq(
-    StructField("index", IntegerType, false),
-    StructField("score", DoubleType, false)
-  )))
+
+  override def children: Seq[Expression] =
+    Seq(vectors, queryVector, k, distanceType)
+  override def dataType: DataType = ArrayType(
+    StructType(
+      Seq(
+        StructField("index", IntegerType, false),
+        StructField("score", DoubleType, false)
+      )
+    )
+  )
   override def nullable: Boolean = true
-  
+
   override def eval(input: InternalRow): Any = {
     // This is a simplified implementation
     // In practice, this would need more sophisticated logic
     null
   }
-  
+
   override def prettyName: String = "vector_knn"
 }

--- a/src/main/scala/operations/backfill/BackfillError.scala
+++ b/src/main/scala/operations/backfill/BackfillError.scala
@@ -1,50 +1,45 @@
 package com.zilliz.spark.connector.operations.backfill
 
-/**
- * Sealed trait representing all possible errors during backfill operations
- */
+/** Sealed trait representing all possible errors during backfill operations
+  */
 sealed trait BackfillError {
   def message: String
   def cause: Option[Throwable]
 }
 
-/**
- * Error connecting to Milvus or retrieving metadata
- */
+/** Error connecting to Milvus or retrieving metadata
+  */
 case class ConnectionError(
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * Error validating schema compatibility between original collection and new field data
- */
+/** Error validating schema compatibility between original collection and new
+  * field data
+  */
 case class SchemaValidationError(
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * Error reading new field data from the provided path
- */
+/** Error reading new field data from the provided path
+  */
 case class DataReadError(
     path: String,
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * Error processing a specific segment during backfill
- */
+/** Error processing a specific segment during backfill
+  */
 case class SegmentProcessingError(
     segmentId: Long,
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * Error writing backfill data for a segment
- */
+/** Error writing backfill data for a segment
+  */
 case class WriteError(
     segmentId: Long,
     outputPath: String,
@@ -52,26 +47,24 @@ case class WriteError(
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * Error with Spark configuration or join strategy
- */
+/** Error with Spark configuration or join strategy
+  */
 case class SparkConfigError(
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
-/**
- * General unexpected error during backfill
- */
+/** General unexpected error during backfill
+  */
 case class UnexpectedError(
     message: String,
     cause: Option[Throwable] = None
 ) extends BackfillError
 
 object BackfillError {
-  /**
-   * Helper to create error from exception
-   */
+
+  /** Helper to create error from exception
+    */
   def fromException(e: Throwable): BackfillError = {
     UnexpectedError(
       message = s"Unexpected error: ${e.getMessage}",
@@ -79,38 +72,46 @@ object BackfillError {
     )
   }
 
-  /**
-   * Helper to create connection error from exception
-   */
+  /** Helper to create connection error from exception
+    */
   def connectionError(message: String, e: Throwable): ConnectionError = {
     ConnectionError(message, Some(e))
   }
 
-  /**
-   * Helper to create schema validation error
-   */
+  /** Helper to create schema validation error
+    */
   def schemaError(message: String): SchemaValidationError = {
     SchemaValidationError(message)
   }
 
-  /**
-   * Helper to create data read error
-   */
-  def dataReadError(path: String, message: String, e: Option[Throwable] = None): DataReadError = {
+  /** Helper to create data read error
+    */
+  def dataReadError(
+      path: String,
+      message: String,
+      e: Option[Throwable] = None
+  ): DataReadError = {
     DataReadError(path, message, e)
   }
 
-  /**
-   * Helper to create segment processing error
-   */
-  def segmentError(segmentId: Long, message: String, e: Throwable): SegmentProcessingError = {
+  /** Helper to create segment processing error
+    */
+  def segmentError(
+      segmentId: Long,
+      message: String,
+      e: Throwable
+  ): SegmentProcessingError = {
     SegmentProcessingError(segmentId, message, Some(e))
   }
 
-  /**
-   * Helper to create write error
-   */
-  def writeError(segmentId: Long, path: String, message: String, e: Throwable): WriteError = {
+  /** Helper to create write error
+    */
+  def writeError(
+      segmentId: Long,
+      path: String,
+      message: String,
+      e: Throwable
+  ): WriteError = {
     WriteError(segmentId, path, message, Some(e))
   }
 }

--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -3,9 +3,8 @@ package com.zilliz.spark.connector.operations.backfill
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
-/**
- * Result of backfilling a single segment
- */
+/** Result of backfilling a single segment
+  */
 case class SegmentBackfillResult(
     segmentId: Long,
     rowCount: Long,
@@ -15,9 +14,8 @@ case class SegmentBackfillResult(
     committedVersion: Long = -1
 )
 
-/**
- * Comprehensive result of backfill operation
- */
+/** Comprehensive result of backfill operation
+  */
 case class BackfillResult(
     success: Boolean,
     segmentsProcessed: Int,
@@ -29,9 +27,9 @@ case class BackfillResult(
     partitionId: Long,
     newFieldNames: Seq[String]
 ) {
-  /**
-   * Get a summary string of the backfill operation
-   */
+
+  /** Get a summary string of the backfill operation
+    */
   def summary: String = {
     s"""Backfill Summary:
        |  Status: ${if (success) "SUCCESS" else "FAILED"}
@@ -45,32 +43,34 @@ case class BackfillResult(
        |""".stripMargin
   }
 
-  /**
-   * Get detailed per-segment results
-   */
+  /** Get detailed per-segment results
+    */
   def segmentSummary: String = {
-    val segmentLines = segmentResults.toSeq.sortBy(_._1).map { case (segId, result) =>
-      s"    Segment $segId: ${result.rowCount} rows, version=${result.committedVersion}, ${result.executionTimeMs}ms, path=${result.outputPath}"
-    }
+    val segmentLines =
+      segmentResults.toSeq.sortBy(_._1).map { case (segId, result) =>
+        s"    Segment $segId: ${result.rowCount} rows, version=${result.committedVersion}, ${result.executionTimeMs}ms, path=${result.outputPath}"
+      }
     s"Segment Details:\n${segmentLines.mkString("\n")}"
   }
 
-  /**
-   * Serialize this result to a JSON string
-   */
+  /** Serialize this result to a JSON string
+    */
   def toJson: String = {
     val mapper = new ObjectMapper()
     mapper.registerModule(DefaultScalaModule)
 
-    val segments = segmentResults.toSeq.sortBy(_._1).map { case (segId, r) =>
-      segId.toString -> Map(
-        "version" -> r.committedVersion,
-        "rowCount" -> r.rowCount,
-        "executionTimeMs" -> r.executionTimeMs,
-        "outputPath" -> r.outputPath,
-        "manifestPaths" -> r.manifestPaths
-      )
-    }.toMap
+    val segments = segmentResults.toSeq
+      .sortBy(_._1)
+      .map { case (segId, r) =>
+        segId.toString -> Map(
+          "version" -> r.committedVersion,
+          "rowCount" -> r.rowCount,
+          "executionTimeMs" -> r.executionTimeMs,
+          "outputPath" -> r.outputPath,
+          "manifestPaths" -> r.manifestPaths
+        )
+      }
+      .toMap
 
     val result = Map(
       "success" -> success,
@@ -86,21 +86,20 @@ case class BackfillResult(
     mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result)
   }
 
-  /**
-   * Check if all segments were processed successfully
-   */
-  def allSegmentsSuccessful: Boolean = success && segmentsProcessed == segmentResults.size
+  /** Check if all segments were processed successfully
+    */
+  def allSegmentsSuccessful: Boolean =
+    success && segmentsProcessed == segmentResults.size
 
-  /**
-   * Get total execution time in seconds
-   */
+  /** Get total execution time in seconds
+    */
   def executionTimeSec: Double = executionTimeMs / 1000.0
 }
 
 object BackfillResult {
-  /**
-   * Create a successful result
-   */
+
+  /** Create a successful result
+    */
   def success(
       segmentResults: Map[Long, SegmentBackfillResult],
       executionTimeMs: Long,
@@ -124,9 +123,8 @@ object BackfillResult {
     )
   }
 
-  /**
-   * Create a failed result
-   */
+  /** Create a failed result
+    */
   def failure(
       executionTimeMs: Long,
       collectionId: Long = -1,

--- a/src/main/scala/operations/backfill/SegmentPartitioner.scala
+++ b/src/main/scala/operations/backfill/SegmentPartitioner.scala
@@ -2,33 +2,38 @@ package com.zilliz.spark.connector.operations.backfill
 
 import org.apache.spark.Partitioner
 
-/**
- * Custom partitioner that ensures each segment goes to exactly one partition
- *
- * Maps each segment_id to a unique partition index via exact lookup table,
- * eliminating hash collisions entirely. This guarantees:
- * - Each partition contains exactly one segment's data
- * - Each segment's data is in exactly one partition
- *
- * @param segmentIds Array of all segment IDs in the collection
- */
+/** Custom partitioner that ensures each segment goes to exactly one partition
+  *
+  * Maps each segment_id to a unique partition index via exact lookup table,
+  * eliminating hash collisions entirely. This guarantees:
+  *   - Each partition contains exactly one segment's data
+  *   - Each segment's data is in exactly one partition
+  *
+  * @param segmentIds
+  *   Array of all segment IDs in the collection
+  */
 class SegmentPartitioner(segmentIds: Array[Long]) extends Partitioner {
 
   // Create exact mapping: segment_id -> partition_index
   // Sorted to ensure deterministic partition assignment
-  private val segmentToIndex: Map[Long, Int] = segmentIds.sorted.zipWithIndex.toMap
+  private val segmentToIndex: Map[Long, Int] =
+    segmentIds.sorted.zipWithIndex.toMap
 
   override def numPartitions: Int = segmentIds.length
 
   override def getPartition(key: Any): Int = {
     val segmentId = key.asInstanceOf[Long]
-    segmentToIndex.getOrElse(segmentId,
-      throw new IllegalArgumentException(s"Unknown segment ID: $segmentId. Known segments: ${segmentIds.mkString(", ")}"))
+    segmentToIndex.getOrElse(
+      segmentId,
+      throw new IllegalArgumentException(
+        s"Unknown segment ID: $segmentId. Known segments: ${segmentIds.mkString(", ")}"
+      )
+    )
   }
 
   override def equals(other: Any): Boolean = other match {
     case h: SegmentPartitioner => h.segmentToIndex == segmentToIndex
-    case _ => false
+    case _                     => false
   }
 
   override def hashCode(): Int = segmentToIndex.hashCode()

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -1,12 +1,13 @@
 package com.zilliz.spark.connector.read
 
 import org.apache.spark.sql.connector.read.InputPartition
+
 import com.zilliz.spark.connector.MilvusOption
 
 // Storage V2 InputPartition - requires Milvus 2.6+
 case class MilvusStorageV2InputPartition(
-    manifestPath: String,  // Path to manifest in S3/MinIO
-    milvusSchemaBytes: Array[Byte],  // Serialized protobuf
+    manifestPath: String, // Path to manifest in S3/MinIO
+    milvusSchemaBytes: Array[Byte], // Serialized protobuf
     partitionName: String,
     milvusOption: MilvusOption,
     topK: Option[Int] = None,
@@ -14,5 +15,6 @@ case class MilvusStorageV2InputPartition(
     metricType: Option[String] = None,
     vectorColumn: Option[String] = None,
     segmentID: Long = -1L,
-    readVersion: Long = -1L  // -1 = LATEST, >0 = specific manifest version from snapshot
+    readVersion: Long =
+      -1L // -1 = LATEST, >0 = specific manifest version from snapshot
 ) extends InputPartition

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -3,7 +3,10 @@ package com.zilliz.spark.connector.read
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
+import org.apache.arrow.c.{ArrowArrayStream, ArrowSchema, Data}
+import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.spark.internal.Logging
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.sources.Filter
@@ -19,21 +22,24 @@ import org.apache.spark.sql.types.{
   StringType,
   StructType
 }
-import org.apache.spark.ml.linalg.Vectors
 
-import io.milvus.grpc.schema.CollectionSchema
-import com.zilliz.spark.connector.MilvusOption
+import com.zilliz.spark.connector.filter.VectorBruteForceSearch
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
-import io.milvus.storage.{ArrowUtils, NativeLibraryLoader, MilvusStorageReader, MilvusStorageManifest, LatestColumnGroupsResult}
-import com.zilliz.spark.connector.filter.VectorBruteForceSearch
-import org.apache.arrow.c.{ArrowArrayStream, ArrowSchema, Data}
-import org.apache.arrow.vector.VectorSchemaRoot
+import com.zilliz.spark.connector.MilvusOption
+import io.milvus.grpc.schema.CollectionSchema
+import io.milvus.storage.{
+  ArrowUtils,
+  LatestColumnGroupsResult,
+  MilvusStorageManifest,
+  MilvusStorageReader,
+  NativeLibraryLoader
+}
 
 // for Milvus 2.6+ version data source and milvus lake data
 class MilvusLoonPartitionReader(
     schema: StructType,
-    manifestPath: String,  // Path to manifest in S3/MinIO
+    manifestPath: String, // Path to manifest in S3/MinIO
     milvusSchema: CollectionSchema,
     milvusOption: MilvusOption,
     optionsMap: Map[String, String],
@@ -42,8 +48,10 @@ class MilvusLoonPartitionReader(
     metricType: Option[String] = None,
     vectorColumn: Option[String] = None,
     pushedFilters: Array[Filter] = Array.empty[Filter],
-    readVersion: Long = -1L  // -1 = LATEST, >0 = specific manifest version from snapshot
-) extends PartitionReader[InternalRow] with Logging {
+    readVersion: Long =
+      -1L // -1 = LATEST, >0 = specific manifest version from snapshot
+) extends PartitionReader[InternalRow]
+    with Logging {
 
   // Load native library
   NativeLibraryLoader.loadLibrary()
@@ -74,16 +82,23 @@ class MilvusLoonPartitionReader(
   // Get column groups from manifest (use specific version if provided, otherwise latest)
   private val manifestResult: LatestColumnGroupsResult = if (readVersion > 0) {
     logInfo(s"Reading manifest at version $readVersion for path: $manifestPath")
-    MilvusStorageManifest.getColumnGroupsScala(manifestPath, readerProperties, readVersion)
+    MilvusStorageManifest.getColumnGroupsScala(
+      manifestPath,
+      readerProperties,
+      readVersion
+    )
   } else {
-    MilvusStorageManifest.getLatestColumnGroupsScala(manifestPath, readerProperties)
+    MilvusStorageManifest.getLatestColumnGroupsScala(
+      manifestPath,
+      readerProperties
+    )
   }
 
   if (manifestResult.readVersion == 0) {
     throw new IllegalStateException(
       s"No manifest file found at path: $manifestPath. " +
-      "The milvus-storage format manifest files do not exist. " +
-      "Please turn on useLoonFFI and compact the data before reading through Spark connector."
+        "The milvus-storage format manifest files do not exist. " +
+        "Please turn on useLoonFFI and compact the data before reading through Spark connector."
     )
   }
 
@@ -125,7 +140,6 @@ class MilvusLoonPartitionReader(
   private var vectorSearchResults: Iterator[(InternalRow, Double)] = _
   private var vectorSearchCompleted = false
 
-
   override def next(): Boolean = {
     if (vectorSearchEnabled) {
       if (!vectorSearchCompleted) {
@@ -137,10 +151,17 @@ class MilvusLoonPartitionReader(
       // Loop to find next row that passes filters
       while (true) {
         // Check if we have more rows in current batch
-        if (_currentBatch != null && _currentRowIndex < _currentBatch.getRowCount) {
+        if (
+          _currentBatch != null && _currentRowIndex < _currentBatch.getRowCount
+        ) {
           // If we have filters, check if current row passes
           if (pushedFilters.nonEmpty) {
-            val row = ArrowConverter.arrowToInternalRow(_currentBatch, _currentRowIndex, sourceSchema, fieldNameToIdString)
+            val row = ArrowConverter.arrowToInternalRow(
+              _currentBatch,
+              _currentRowIndex,
+              sourceSchema,
+              fieldNameToIdString
+            )
             _currentRowIndex += 1
             if (applyFilters(row)) {
               // Found a matching row, back up index so get() will return it
@@ -185,7 +206,12 @@ class MilvusLoonPartitionReader(
         throw new IllegalStateException("No batch loaded")
       }
 
-      val row = ArrowConverter.arrowToInternalRow(_currentBatch, _currentRowIndex, sourceSchema, fieldNameToIdString)
+      val row = ArrowConverter.arrowToInternalRow(
+        _currentBatch,
+        _currentRowIndex,
+        sourceSchema,
+        fieldNameToIdString
+      )
       _currentRowIndex += 1
       row
     }
@@ -208,7 +234,8 @@ class MilvusLoonPartitionReader(
     // Convert Milvus schema to Arrow schema with field IDs as field names
     // This is required because milvus-storage reader matches columns by field ID
     // The manifest stores column groups with field IDs (e.g., "100", "101")
-    val arrowSchema = com.zilliz.spark.connector.MilvusSchemaUtil.convertToArrowSchemaWithFieldIdNames(milvusSchema)
+    val arrowSchema = com.zilliz.spark.connector.MilvusSchemaUtil
+      .convertToArrowSchemaWithFieldIdNames(milvusSchema)
     val arrowSchemaC = ArrowSchema.allocateNew(allocator)
     Data.exportSchema(allocator, arrowSchema, null, arrowSchemaC)
     (arrowSchemaC, arrowSchemaC.memoryAddress())
@@ -224,35 +251,44 @@ class MilvusLoonPartitionReader(
     }
   }
 
-  /**
-   * Perform per-segment vector search and maintain top-K results
-   */
+  /** Perform per-segment vector search and maintain top-K results
+    */
   private def performSegmentVectorSearch(): Unit = {
     val k = topK.get
     val qv = queryVector.get
     val metric = metricType.getOrElse("L2")
     val vecCol = vectorColumn.getOrElse("vector")
 
-    logInfo(s"Starting per-segment vector search: k=$k, metric=$metric, vectorColumn=$vecCol")
+    logInfo(
+      s"Starting per-segment vector search: k=$k, metric=$metric, vectorColumn=$vecCol"
+    )
 
     // Find vector column index in source schema
-    val vectorColIndex = try {
-      sourceSchema.fieldIndex(vecCol)
-    } catch {
-      case _: IllegalArgumentException =>
-        throw new IllegalArgumentException(s"Vector column '$vecCol' not found in schema: ${sourceSchema.fieldNames.mkString(", ")}")
-    }
+    val vectorColIndex =
+      try {
+        sourceSchema.fieldIndex(vecCol)
+      } catch {
+        case _: IllegalArgumentException =>
+          throw new IllegalArgumentException(
+            s"Vector column '$vecCol' not found in schema: ${sourceSchema.fieldNames.mkString(", ")}"
+          )
+      }
 
     // Use priority queue to maintain top-K
     // For L2: min-heap (smaller distance is better, so we keep max at top to evict)
     // For IP/COSINE: max-heap (larger score is better, so we keep min at top to evict)
     val ordering: Ordering[(InternalRow, Double)] = metric match {
-      case "L2" => Ordering.by[(InternalRow, Double), Double](_._2)  // Max-heap for L2
-      case "IP" | "COSINE" => Ordering.by[(InternalRow, Double), Double](_._2).reverse  // Min-heap for IP/COSINE
+      case "L2" =>
+        Ordering.by[(InternalRow, Double), Double](_._2) // Max-heap for L2
+      case "IP" | "COSINE" =>
+        Ordering
+          .by[(InternalRow, Double), Double](_._2)
+          .reverse // Min-heap for IP/COSINE
       case _ => Ordering.by[(InternalRow, Double), Double](_._2)
     }
 
-    val heap = scala.collection.mutable.PriorityQueue.empty[(InternalRow, Double)](ordering)
+    val heap = scala.collection.mutable.PriorityQueue
+      .empty[(InternalRow, Double)](ordering)
     var rowCount = 0
 
     // Helper function to process a batch
@@ -262,16 +298,28 @@ class MilvusLoonPartitionReader(
 
       // Process each row in batch
       for (i <- 0 until batchSize) {
-        val row = ArrowConverter.arrowToInternalRow(batch, i, sourceSchema, fieldNameToIdString)
+        val row = ArrowConverter.arrowToInternalRow(
+          batch,
+          i,
+          sourceSchema,
+          fieldNameToIdString
+        )
 
         // Extract vector from row
-        val vector = try {
-          extractVectorFromRow(row, vectorColIndex, sourceSchema(vectorColIndex).dataType)
-        } catch {
-          case e: Exception =>
-            logWarning(s"Failed to extract vector from row $rowCount: ${e.getMessage}")
-            null
-        }
+        val vector =
+          try {
+            extractVectorFromRow(
+              row,
+              vectorColIndex,
+              sourceSchema(vectorColIndex).dataType
+            )
+          } catch {
+            case e: Exception =>
+              logWarning(
+                s"Failed to extract vector from row $rowCount: ${e.getMessage}"
+              )
+              null
+          }
 
         if (vector != null) {
           // Calculate distance
@@ -283,8 +331,9 @@ class MilvusLoonPartitionReader(
           } else {
             val (_, worstDist) = heap.head
             val shouldReplace = metric match {
-              case "L2" => distance < worstDist  // Smaller L2 distance is better
-              case "IP" | "COSINE" => distance > worstDist  // Larger IP/COSINE is better
+              case "L2" => distance < worstDist // Smaller L2 distance is better
+              case "IP" | "COSINE" =>
+                distance > worstDist // Larger IP/COSINE is better
               case _ => distance < worstDist
             }
 
@@ -308,27 +357,36 @@ class MilvusLoonPartitionReader(
       processBatch(batch)
     }
 
-    logInfo(s"Per-segment vector search completed: processed $rowCount rows, kept ${heap.size} top-K results")
+    logInfo(
+      s"Per-segment vector search completed: processed $rowCount rows, kept ${heap.size} top-K results"
+    )
 
     // Sort results and create iterator
     val sortedResults = metric match {
-      case "L2" => heap.dequeueAll.sortBy[(Double)](x => x._2)  // Ascending for L2
-      case "IP" | "COSINE" => heap.dequeueAll.sortBy[(Double)](x => -x._2)  // Descending for IP/COSINE
+      case "L2" =>
+        heap.dequeueAll.sortBy[(Double)](x => x._2) // Ascending for L2
+      case "IP" | "COSINE" =>
+        heap.dequeueAll.sortBy[(Double)](x => -x._2) // Descending for IP/COSINE
       case _ => heap.dequeueAll.sortBy[(Double)](x => x._2)
     }
 
     vectorSearchResults = sortedResults.iterator
   }
 
-  /**
-   * Extract vector from InternalRow based on data type
-   */
-  private def extractVectorFromRow(row: InternalRow, colIndex: Int, dataType: org.apache.spark.sql.types.DataType): Array[Float] = {
+  /** Extract vector from InternalRow based on data type
+    */
+  private def extractVectorFromRow(
+      row: InternalRow,
+      colIndex: Int,
+      dataType: org.apache.spark.sql.types.DataType
+  ): Array[Float] = {
     dataType match {
       case ArrayType(FloatType, _) =>
         // Array[Float] type
         val arrayData = row.getArray(colIndex)
-        (0 until arrayData.numElements()).map(i => arrayData.getFloat(i)).toArray
+        (0 until arrayData.numElements())
+          .map(i => arrayData.getFloat(i))
+          .toArray
 
       case BinaryType =>
         // Binary type (for FixedSizeBinary float vectors)
@@ -337,13 +395,21 @@ class MilvusLoonPartitionReader(
         (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
 
       case _ =>
-        throw new IllegalArgumentException(s"Unsupported vector type: $dataType")
+        throw new IllegalArgumentException(
+          s"Unsupported vector type: $dataType"
+        )
     }
   }
 
-  private def calculateDistance(queryVec: Array[Float], dataVec: Array[Float], metric: String): Double = {
+  private def calculateDistance(
+      queryVec: Array[Float],
+      dataVec: Array[Float],
+      metric: String
+  ): Double = {
     if (queryVec.length != dataVec.length) {
-      logWarning(s"Vector dimension mismatch: query=${queryVec.length}, data=${dataVec.length}")
+      logWarning(
+        s"Vector dimension mismatch: query=${queryVec.length}, data=${dataVec.length}"
+      )
       return Double.MaxValue
     }
 
@@ -351,18 +417,22 @@ class MilvusLoonPartitionReader(
     val dataVector = Vectors.dense(dataVec.map(_.toDouble))
 
     val distanceType = metric match {
-      case "L2" => VectorBruteForceSearch.DistanceType.L2
-      case "IP" => VectorBruteForceSearch.DistanceType.IP
+      case "L2"     => VectorBruteForceSearch.DistanceType.L2
+      case "IP"     => VectorBruteForceSearch.DistanceType.IP
       case "COSINE" => VectorBruteForceSearch.DistanceType.COSINE
-      case _ => throw new IllegalArgumentException(s"Unsupported metric type: $metric")
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported metric type: $metric")
     }
 
-    VectorBruteForceSearch.calculateDistance(queryVector, dataVector, distanceType)
+    VectorBruteForceSearch.calculateDistance(
+      queryVector,
+      dataVector,
+      distanceType
+    )
   }
 
-  /**
-   * Apply all pushed filters to a row
-   */
+  /** Apply all pushed filters to a row
+    */
   private def applyFilters(row: InternalRow): Boolean = {
     if (pushedFilters.isEmpty) {
       return true
@@ -370,9 +440,8 @@ class MilvusLoonPartitionReader(
     pushedFilters.forall(filter => evaluateFilter(filter, row))
   }
 
-  /**
-   * Recursively evaluate a filter against a row
-   */
+  /** Recursively evaluate a filter against a row
+    */
   private def evaluateFilter(filter: Filter, row: InternalRow): Boolean = {
     import org.apache.spark.sql.sources._
 
@@ -435,9 +504,8 @@ class MilvusLoonPartitionReader(
     }
   }
 
-  /**
-   * Get column index by name, returns -1 if not found
-   */
+  /** Get column index by name, returns -1 if not found
+    */
   private def getColumnIndex(columnName: String): Int = {
     try {
       sourceSchema.fieldIndex(columnName)
@@ -446,50 +514,52 @@ class MilvusLoonPartitionReader(
     }
   }
 
-  /**
-   * Get value from row at given column index
-   */
-  private def getRowValue(row: InternalRow, columnIndex: Int, columnName: String): Any = {
+  /** Get value from row at given column index
+    */
+  private def getRowValue(
+      row: InternalRow,
+      columnIndex: Int,
+      columnName: String
+  ): Any = {
     if (row.isNullAt(columnIndex)) {
       return null
     }
 
     val field = sourceSchema.fields(columnIndex)
     field.dataType match {
-      case LongType => row.getLong(columnIndex)
+      case LongType    => row.getLong(columnIndex)
       case IntegerType => row.getInt(columnIndex)
-      case ShortType => row.getShort(columnIndex)
-      case FloatType => row.getFloat(columnIndex)
-      case DoubleType => row.getDouble(columnIndex)
+      case ShortType   => row.getShort(columnIndex)
+      case FloatType   => row.getFloat(columnIndex)
+      case DoubleType  => row.getDouble(columnIndex)
       case BooleanType => row.getBoolean(columnIndex)
-      case StringType => row.getUTF8String(columnIndex).toString
-      case BinaryType => row.getBinary(columnIndex)
-      case _ =>
+      case StringType  => row.getUTF8String(columnIndex).toString
+      case BinaryType  => row.getBinary(columnIndex)
+      case _           =>
         // For complex types (arrays, maps, structs), return the raw value
         row.get(columnIndex, field.dataType)
     }
   }
 
-  /**
-   * Compare two values, handling type conversions
-   */
+  /** Compare two values, handling type conversions
+    */
   private def compareValues(rowValue: Any, filterValue: Any): Int = {
     (rowValue, filterValue) match {
-      case (null, null) => 0
-      case (null, _) => -1
-      case (_, null) => 1
-      case (rv: Long, fv: Long) => rv.compareTo(fv)
-      case (rv: Long, fv: Int) => rv.compareTo(fv.toLong)
-      case (rv: Int, fv: Int) => rv.compareTo(fv)
-      case (rv: Int, fv: Long) => rv.toLong.compareTo(fv)
-      case (rv: Short, fv: Short) => rv.compareTo(fv)
-      case (rv: Short, fv: Int) => rv.toInt.compareTo(fv)
-      case (rv: Float, fv: Float) => rv.compareTo(fv)
-      case (rv: Float, fv: Double) => rv.toDouble.compareTo(fv)
-      case (rv: Double, fv: Double) => rv.compareTo(fv)
-      case (rv: Double, fv: Float) => rv.compareTo(fv.toDouble)
+      case (null, null)               => 0
+      case (null, _)                  => -1
+      case (_, null)                  => 1
+      case (rv: Long, fv: Long)       => rv.compareTo(fv)
+      case (rv: Long, fv: Int)        => rv.compareTo(fv.toLong)
+      case (rv: Int, fv: Int)         => rv.compareTo(fv)
+      case (rv: Int, fv: Long)        => rv.toLong.compareTo(fv)
+      case (rv: Short, fv: Short)     => rv.compareTo(fv)
+      case (rv: Short, fv: Int)       => rv.toInt.compareTo(fv)
+      case (rv: Float, fv: Float)     => rv.compareTo(fv)
+      case (rv: Float, fv: Double)    => rv.toDouble.compareTo(fv)
+      case (rv: Double, fv: Double)   => rv.compareTo(fv)
+      case (rv: Double, fv: Float)    => rv.compareTo(fv.toDouble)
       case (rv: Boolean, fv: Boolean) => rv.compareTo(fv)
-      case (rv: String, fv: String) => rv.compareTo(fv)
+      case (rv: String, fv: String)   => rv.compareTo(fv)
       case (rv: Array[Byte], fv: Array[Byte]) =>
         java.util.Arrays.compare(rv, fv)
       case _ =>

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -2,7 +2,11 @@ package com.zilliz.spark.connector.read
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.connector.read.{
+  InputPartition,
+  PartitionReader,
+  PartitionReaderFactory
+}
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
@@ -13,12 +17,17 @@ class MilvusPartitionReaderFactory(
     schema: StructType,
     optionsMap: Map[String, String],
     pushedFilters: Array[Filter] = Array.empty[Filter]
-) extends PartitionReaderFactory with Logging {
+) extends PartitionReaderFactory
+    with Logging {
 
-  override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
+  override def createReader(
+      partition: InputPartition
+  ): PartitionReader[InternalRow] = {
     partition match {
       case p: MilvusStorageV2InputPartition =>
-        logInfo(s"Creating V2 reader for partition with segmentID=${p.segmentID}")
+        logInfo(
+          s"Creating V2 reader for partition with segmentID=${p.segmentID}"
+        )
 
         // Storage V2 doesn't support system fields (row_id, timestamp) and extra metadata columns (segment_id, row_offset)
         // Filter them out from the schema for the underlying reader
@@ -110,7 +119,7 @@ class MilvusPartitionReaderFactory(
       case _ =>
         throw new IllegalArgumentException(
           s"Unsupported partition type: ${partition.getClass.getName}. " +
-          "This connector requires Milvus 2.6+ (Storage V2)."
+            "This connector requires Milvus 2.6+ (Storage V2)."
         )
     }
   }

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -1,45 +1,52 @@
 package com.zilliz.spark.connector.read
 
 import com.fasterxml.jackson.annotation.{JsonAlias, JsonProperty}
-import com.fasterxml.jackson.databind.{DeserializationFeature, JsonNode, ObjectMapper}
+import com.fasterxml.jackson.databind.{
+  DeserializationFeature,
+  JsonNode,
+  ObjectMapper
+}
 import com.fasterxml.jackson.databind.cfg.CoercionAction
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
+import com.fasterxml.jackson.module.scala.{
+  DefaultScalaModule,
+  ScalaObjectMapper
+}
 import org.apache.spark.sql.types._
 
-/**
- * Helper object for converting JSON values that may be either numeric or string to Long/Int
- * Milvus snapshot JSON format may serialize numbers as strings in some versions
- */
+/** Helper object for converting JSON values that may be either numeric or
+  * string to Long/Int Milvus snapshot JSON format may serialize numbers as
+  * strings in some versions
+  */
 private[read] object JsonTypeConverter {
   def toLong(value: Any): Long = value match {
-    case l: Long => l
-    case i: Int => i.toLong
-    case n: Number => n.longValue()
-    case s: String => s.toLong
-    case node: JsonNode if node.isNumber => node.asLong()
+    case l: Long                          => l
+    case i: Int                           => i.toLong
+    case n: Number                        => n.longValue()
+    case s: String                        => s.toLong
+    case node: JsonNode if node.isNumber  => node.asLong()
     case node: JsonNode if node.isTextual => node.asText().toLong
-    case _ => 0L
+    case _                                => 0L
   }
 
   def toInt(value: Any): Int = value match {
-    case i: Int => i
-    case l: Long => l.toInt
-    case n: Number => n.intValue()
-    case s: String => s.toInt
-    case node: JsonNode if node.isNumber => node.asInt()
+    case i: Int                           => i
+    case l: Long                          => l.toInt
+    case n: Number                        => n.intValue()
+    case s: String                        => s.toInt
+    case node: JsonNode if node.isNumber  => node.asInt()
     case node: JsonNode if node.isTextual => node.asText().toInt
-    case _ => 0
+    case _                                => 0
   }
 
   def toOptionalInt(value: Option[Any]): Option[Int] = value.map {
-    case i: Int => i
-    case l: Long => l.toInt
-    case n: Number => n.intValue()
-    case s: String => s.toInt
-    case node: JsonNode if node.isNumber => node.asInt()
+    case i: Int                           => i
+    case l: Long                          => l.toInt
+    case n: Number                        => n.intValue()
+    case s: String                        => s.toInt
+    case node: JsonNode if node.isNumber  => node.asInt()
     case node: JsonNode if node.isTextual => node.asText().toInt
-    case _ => 0
+    case _                                => 0
   }
 
   def toLongSeq(value: Any): Seq[Long] = value match {
@@ -50,13 +57,12 @@ private[read] object JsonTypeConverter {
     case _ => Seq.empty
   }
 
-  /**
-   * Convert a JsonNode or Any value to a data type code.
-   * Handles both numeric values (e.g., 5) and string type names (e.g., "Int64")
-   */
+  /** Convert a JsonNode or Any value to a data type code. Handles both numeric
+    * values (e.g., 5) and string type names (e.g., "Int64")
+    */
   def toDataTypeCode(value: Any): Int = value match {
-    case i: Int => i
-    case l: Long => l.toInt
+    case i: Int    => i
+    case l: Long   => l.toInt
     case n: Number => n.intValue()
     case s: String =>
       // Try parsing as number first, then as type name
@@ -77,32 +83,33 @@ private[read] object JsonTypeConverter {
   }
 }
 
-/**
- * Type parameter for Milvus field
- */
+/** Type parameter for Milvus field
+  */
 case class TypeParam(
     @JsonProperty("key") key: String,
     @JsonProperty("value") value: String
 )
 
-/**
- * Field schema definition
- */
+/** Field schema definition
+  */
 case class Field(
-    @JsonProperty("fieldID") fieldID: Option[JsonNode] = None,  // Can be Int or Long from JSON
+    @JsonProperty("fieldID") fieldID: Option[JsonNode] =
+      None, // Can be Int or Long from JSON
     @JsonProperty("name") name: String,
     @JsonProperty("description") description: Option[String] = None,
-    @JsonProperty("data_type") rawDataType: Option[JsonNode] = None,  // Can be Int or String (e.g., 5 or "Int64")
+    @JsonProperty("data_type") rawDataType: Option[JsonNode] =
+      None, // Can be Int or String (e.g., 5 or "Int64")
     @JsonProperty("is_primary_key") isPrimaryKey: Option[Boolean] = None,
     @JsonProperty("is_clustering_key") isClusteringKey: Option[Boolean] = None,
     @JsonProperty("type_params") typeParams: Option[Seq[TypeParam]] = None
 ) {
-  /**
-   * Get the data type as Int, handling both numeric and string formats
-   * String format examples: "Bool", "Int8", "Int16", "Int32", "Int64", "Float", "Double",
-   *                         "String", "VarChar", "JSON", "Array", "FloatVector", etc.
-   */
-  def dataType: Int = rawDataType.map(JsonTypeConverter.toDataTypeCode).getOrElse(0)
+
+  /** Get the data type as Int, handling both numeric and string formats String
+    * format examples: "Bool", "Int8", "Int16", "Int32", "Int64", "Float",
+    * "Double", "String", "VarChar", "JSON", "Array", "FloatVector", etc.
+    */
+  def dataType: Int =
+    rawDataType.map(JsonTypeConverter.toDataTypeCode).getOrElse(0)
 
   def getTypeParam(key: String): Option[String] = {
     typeParams.flatMap(_.find(_.key == key).map(_.value))
@@ -111,16 +118,16 @@ case class Field(
   def getFieldIDAsLong: Long = {
     fieldID match {
       case Some(node) => JsonTypeConverter.toLong(node)
-      case _ => 0L
+      case _          => 0L
     }
   }
 }
 
 object Field {
-  /**
-   * Mapping from data type name strings to numeric codes
-   * Based on Milvus DataType enum values
-   */
+
+  /** Mapping from data type name strings to numeric codes Based on Milvus
+    * DataType enum values
+    */
   private val dataTypeNameToCodeMap: Map[String, Int] = Map(
     "None" -> 0,
     "Bool" -> 1,
@@ -156,17 +163,15 @@ object Field {
   }
 }
 
-/**
- * Property key-value pair
- */
+/** Property key-value pair
+  */
 case class Property(
     @JsonProperty("key") key: String,
     @JsonProperty("value") value: String
 )
 
-/**
- * Collection schema definition
- */
+/** Collection schema definition
+  */
 case class CollectionSchema(
     @JsonProperty("name") name: String,
     @JsonProperty("description") description: Option[String] = None,
@@ -178,69 +183,84 @@ case class CollectionSchema(
   }
 }
 
-/**
- * Collection metadata
- */
+/** Collection metadata
+  */
 case class Collection(
     @JsonProperty("schema") schema: CollectionSchema,
-    @JsonProperty("num_partitions") rawNumPartitions: Option[JsonNode] = None,  // Can be Int or String
-    @JsonProperty("num_shards") rawNumShards: Option[JsonNode] = None,  // Can be Int or String
+    @JsonProperty("num_partitions") rawNumPartitions: Option[JsonNode] =
+      None, // Can be Int or String
+    @JsonProperty("num_shards") rawNumShards: Option[JsonNode] =
+      None, // Can be Int or String
     @JsonProperty("properties") properties: Option[Seq[Property]] = None,
-    @JsonProperty("consistency_level") rawConsistencyLevel: Option[JsonNode] = None  // Can be Int or String
+    @JsonProperty("consistency_level") rawConsistencyLevel: Option[JsonNode] =
+      None // Can be Int or String
 ) {
-  def numPartitions: Option[Int] = rawNumPartitions.map(n => JsonTypeConverter.toInt(n))
+  def numPartitions: Option[Int] =
+    rawNumPartitions.map(n => JsonTypeConverter.toInt(n))
   def numShards: Option[Int] = rawNumShards.map(n => JsonTypeConverter.toInt(n))
-  def consistencyLevel: Option[Int] = rawConsistencyLevel.map(n => JsonTypeConverter.toInt(n))
+  def consistencyLevel: Option[Int] =
+    rawConsistencyLevel.map(n => JsonTypeConverter.toInt(n))
 }
 
-/**
- * Snapshot information
- */
+/** Snapshot information
+  */
 case class SnapshotInfo(
     @JsonProperty("name") name: String,
-    @JsonProperty("id") rawId: Option[JsonNode] = None,  // Can be Long or String from JSON
+    @JsonProperty("id") rawId: Option[JsonNode] =
+      None, // Can be Long or String from JSON
     @JsonProperty("description") description: Option[String] = None,
-    @JsonProperty("collection_id") rawCollectionId: Option[JsonNode] = None,  // Can be Long or String from JSON
-    @JsonProperty("partition_ids") rawPartitionIds: Option[JsonNode] = None,  // Can be Seq[Long] or Seq[String] from JSON
-    @JsonProperty("create_ts") rawCreateTs: Option[JsonNode] = None,  // Can be Long or String from JSON
-    @JsonProperty("state") state: Option[String] = None,  // New field: snapshot state
-    @JsonProperty("pending_start_time") pendingStartTime: Option[JsonNode] = None  // New field
+    @JsonProperty("collection_id") rawCollectionId: Option[JsonNode] =
+      None, // Can be Long or String from JSON
+    @JsonProperty("partition_ids") rawPartitionIds: Option[JsonNode] =
+      None, // Can be Seq[Long] or Seq[String] from JSON
+    @JsonProperty("create_ts") rawCreateTs: Option[JsonNode] =
+      None, // Can be Long or String from JSON
+    @JsonProperty("state") state: Option[String] =
+      None, // New field: snapshot state
+    @JsonProperty("pending_start_time") pendingStartTime: Option[JsonNode] =
+      None // New field
 ) {
   def id: Long = rawId.map(JsonTypeConverter.toLong).getOrElse(0L)
-  def collectionId: Long = rawCollectionId.map(JsonTypeConverter.toLong).getOrElse(0L)
-  def partitionIds: Seq[Long] = rawPartitionIds.map(JsonTypeConverter.toLongSeq).getOrElse(Seq.empty)
+  def collectionId: Long =
+    rawCollectionId.map(JsonTypeConverter.toLong).getOrElse(0L)
+  def partitionIds: Seq[Long] =
+    rawPartitionIds.map(JsonTypeConverter.toLongSeq).getOrElse(Seq.empty)
   def createTs: Long = rawCreateTs.map(JsonTypeConverter.toLong).getOrElse(0L)
 }
 
-/**
- * Parsed manifest content from Storage V2
- */
+/** Parsed manifest content from Storage V2
+  */
 case class ManifestContent(
     @JsonProperty("ver") ver: Int,
     @JsonProperty("base_path") basePath: String
 )
 
-/**
- * Storage V2 manifest item
- */
+/** Storage V2 manifest item
+  */
 case class StorageV2ManifestItem(
-    @JsonProperty("segmentID") @JsonAlias(Array("segment_id")) rawSegmentID: Option[JsonNode] = None,  // Can be Long or String from JSON
+    @JsonProperty("segmentID") @JsonAlias(
+      Array("segment_id")
+    ) rawSegmentID: Option[JsonNode] = None, // Can be Long or String from JSON
     @JsonProperty("manifest") manifest: String = "",
-    @JsonProperty("segmentIDLong") rawSegmentIDLong: Option[JsonNode] = None  // For serialization (using JsonNode to handle Int/Long)
+    @JsonProperty("segmentIDLong") rawSegmentIDLong: Option[JsonNode] =
+      None // For serialization (using JsonNode to handle Int/Long)
 ) {
   def segmentID: Long = {
     // First try rawSegmentIDLong (used when creating new items for serialization)
     // Then fall back to rawSegmentID (from original JSON)
-    rawSegmentIDLong.map(JsonTypeConverter.toLong)
+    rawSegmentIDLong
+      .map(JsonTypeConverter.toLong)
       .orElse(rawSegmentID.map(JsonTypeConverter.toLong))
       .getOrElse(0L)
   }
 
-  /**
-   * Parse the manifest JSON string to extract structured content
-   * @return Either containing parsed ManifestContent or error
-   */
-  private[read] def parseManifest(mapper: ObjectMapper with ScalaObjectMapper): Either[Throwable, ManifestContent] = {
+  /** Parse the manifest JSON string to extract structured content
+    * @return
+    *   Either containing parsed ManifestContent or error
+    */
+  private[read] def parseManifest(
+      mapper: ObjectMapper with ScalaObjectMapper
+  ): Either[Throwable, ManifestContent] = {
     try {
       Right(mapper.readValue[ManifestContent](manifest))
     } catch {
@@ -252,29 +272,32 @@ case class StorageV2ManifestItem(
 object StorageV2ManifestItem {
   import com.fasterxml.jackson.databind.node.LongNode
 
-  /**
-   * Create a StorageV2ManifestItem with a Long segmentID (for serialization)
-   */
+  /** Create a StorageV2ManifestItem with a Long segmentID (for serialization)
+    */
   def apply(segmentID: Long, manifest: String): StorageV2ManifestItem = {
     new StorageV2ManifestItem(None, manifest, Some(LongNode.valueOf(segmentID)))
   }
 }
 
-/**
- * Complete snapshot metadata
- */
+/** Complete snapshot metadata
+  */
 case class SnapshotMetadata(
-    @JsonProperty("snapshot_info") @JsonAlias(Array("snapshot-info")) snapshotInfo: SnapshotInfo,
+    @JsonProperty("snapshot_info") @JsonAlias(
+      Array("snapshot-info")
+    ) snapshotInfo: SnapshotInfo,
     @JsonProperty("collection") collection: Collection,
     @JsonProperty("format_version") formatVersion: Option[Int] = None,
     @JsonProperty("indexes") indexes: Seq[Any] = Seq.empty,
-    @JsonProperty("manifest_list") @JsonAlias(Array("manifest-list")) manifestList: Seq[String] = Seq.empty,
-    @JsonProperty("storagev2_manifest_list") @JsonAlias(Array("storagev2-manifest-list")) storageV2ManifestList: Option[Seq[StorageV2ManifestItem]] = None
+    @JsonProperty("manifest_list") @JsonAlias(
+      Array("manifest-list")
+    ) manifestList: Seq[String] = Seq.empty,
+    @JsonProperty("storagev2_manifest_list") @JsonAlias(
+      Array("storagev2-manifest-list")
+    ) storageV2ManifestList: Option[Seq[StorageV2ManifestItem]] = None
 )
 
-/**
- * Reader for Milvus snapshot metadata JSON files
- */
+/** Reader for Milvus snapshot metadata JSON files
+  */
 object MilvusSnapshotReader {
 
   private val mapper: ObjectMapper with ScalaObjectMapper = {
@@ -283,20 +306,27 @@ object MilvusSnapshotReader {
     m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     m.configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, false)
     // Allow coercion from String to numeric types (e.g., "5" -> 5, "123456789" -> 123456789L)
-    m.coercionConfigFor(classOf[java.lang.Integer]).setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
-    m.coercionConfigFor(classOf[java.lang.Long]).setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
-    m.coercionConfigFor(classOf[Int]).setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
-    m.coercionConfigFor(classOf[Long]).setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[java.lang.Integer])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[java.lang.Long])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[Int])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[Long])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
     m
   }
 
-  /**
-   * Parse snapshot metadata from JSON string
-   *
-   * @param json JSON string containing snapshot metadata
-   * @return Either containing parsed SnapshotMetadata or error
-   */
-  def parseSnapshotMetadata(json: String): Either[Throwable, SnapshotMetadata] = {
+  /** Parse snapshot metadata from JSON string
+    *
+    * @param json
+    *   JSON string containing snapshot metadata
+    * @return
+    *   Either containing parsed SnapshotMetadata or error
+    */
+  def parseSnapshotMetadata(
+      json: String
+  ): Either[Throwable, SnapshotMetadata] = {
     try {
       Right(mapper.readValue[SnapshotMetadata](json))
     } catch {
@@ -304,13 +334,16 @@ object MilvusSnapshotReader {
     }
   }
 
-  /**
-   * Read snapshot metadata from file
-   *
-   * @param path Path to the snapshot metadata JSON file
-   * @return Either containing parsed SnapshotMetadata or error
-   */
-  def readSnapshotMetadataFromFile(path: String): Either[Throwable, SnapshotMetadata] = {
+  /** Read snapshot metadata from file
+    *
+    * @param path
+    *   Path to the snapshot metadata JSON file
+    * @return
+    *   Either containing parsed SnapshotMetadata or error
+    */
+  def readSnapshotMetadataFromFile(
+      path: String
+  ): Either[Throwable, SnapshotMetadata] = {
     try {
       val source = scala.io.Source.fromFile(path)
       try {
@@ -324,56 +357,66 @@ object MilvusSnapshotReader {
     }
   }
 
-  /**
-   * Get primary key name from snapshot JSON
-   *
-   * @param json JSON string containing snapshot metadata
-   * @return Either containing primary key field name or error
-   */
+  /** Get primary key name from snapshot JSON
+    *
+    * @param json
+    *   JSON string containing snapshot metadata
+    * @return
+    *   Either containing primary key field name or error
+    */
   def getPkName(json: String): Either[Throwable, String] = {
     parseSnapshotMetadata(json).flatMap { metadata =>
       metadata.collection.schema.fields
         .find(_.isPrimaryKey == Some(true))
         .map(_.name)
-        .toRight(new IllegalArgumentException("No primary key field found in snapshot"))
+        .toRight(
+          new IllegalArgumentException("No primary key field found in snapshot")
+        )
     }
   }
 
-  /**
-   * Get primary key name from snapshot file
-   *
-   * @param path Path to the snapshot metadata JSON file
-   * @return Either containing primary key field name or error
-   */
+  /** Get primary key name from snapshot file
+    *
+    * @param path
+    *   Path to the snapshot metadata JSON file
+    * @return
+    *   Either containing primary key field name or error
+    */
   def getPkNameFromFile(path: String): Either[Throwable, String] = {
     readSnapshotMetadataFromFile(path).flatMap { metadata =>
       metadata.collection.schema.fields
         .find(_.isPrimaryKey == Some(true))
         .map(_.name)
-        .toRight(new IllegalArgumentException("No primary key field found in snapshot"))
+        .toRight(
+          new IllegalArgumentException("No primary key field found in snapshot")
+        )
     }
   }
 
-  /**
-   * Get collection schema from snapshot file
-   *
-   * @param path Path to the snapshot metadata JSON file
-   * @return Either containing CollectionSchema or error
-   */
+  /** Get collection schema from snapshot file
+    *
+    * @param path
+    *   Path to the snapshot metadata JSON file
+    * @return
+    *   Either containing CollectionSchema or error
+    */
   def getSchemaFromFile(path: String): Either[Throwable, CollectionSchema] = {
     readSnapshotMetadataFromFile(path).map { metadata =>
       metadata.collection.schema
     }
   }
 
-  /**
-   * Get Storage V2 segment manifest map from snapshot file
-   * Returns a map from segment ID to parsed manifest content (version and base path)
-   *
-   * @param path Path to the snapshot metadata JSON file
-   * @return Either containing Map[segmentID -> ManifestContent] or error
-   */
-  def getStorageV2ManifestMap(path: String): Either[Throwable, Map[Long, ManifestContent]] = {
+  /** Get Storage V2 segment manifest map from snapshot file Returns a map from
+    * segment ID to parsed manifest content (version and base path)
+    *
+    * @param path
+    *   Path to the snapshot metadata JSON file
+    * @return
+    *   Either containing Map[segmentID -> ManifestContent] or error
+    */
+  def getStorageV2ManifestMap(
+      path: String
+  ): Either[Throwable, Map[Long, ManifestContent]] = {
     readSnapshotMetadataFromFile(path).flatMap { metadata =>
       metadata.storageV2ManifestList match {
         case Some(manifestList) =>
@@ -384,7 +427,11 @@ object MilvusSnapshotReader {
           // Check if all parsing succeeded
           val failures = results.collect { case Left(e) => e }
           if (failures.nonEmpty) {
-            Left(new Exception(s"Failed to parse ${failures.size} manifest(s): ${failures.head.getMessage}"))
+            Left(
+              new Exception(
+                s"Failed to parse ${failures.size} manifest(s): ${failures.head.getMessage}"
+              )
+            )
           } else {
             Right(results.collect { case Right(pair) => pair }.toMap)
           }
@@ -395,16 +442,23 @@ object MilvusSnapshotReader {
     }
   }
 
-  /**
-   * Convert snapshot CollectionSchema to Spark StructType
-   *
-   * @param schema CollectionSchema from snapshot metadata
-   * @param includeSystemFields Whether to include RowID and Timestamp system fields
-   * @return Spark StructType representing the collection schema
-   */
-  def toSparkSchema(schema: CollectionSchema, includeSystemFields: Boolean = false): StructType = {
+  /** Convert snapshot CollectionSchema to Spark StructType
+    *
+    * @param schema
+    *   CollectionSchema from snapshot metadata
+    * @param includeSystemFields
+    *   Whether to include RowID and Timestamp system fields
+    * @return
+    *   Spark StructType representing the collection schema
+    */
+  def toSparkSchema(
+      schema: CollectionSchema,
+      includeSystemFields: Boolean = false
+  ): StructType = {
     val userFields = schema.fields
-      .filterNot(f => !includeSystemFields && (f.name == "RowID" || f.name == "Timestamp"))
+      .filterNot(f =>
+        !includeSystemFields && (f.name == "RowID" || f.name == "Timestamp")
+      )
       .map { field =>
         StructField(
           field.name,
@@ -415,85 +469,99 @@ object MilvusSnapshotReader {
     StructType(userFields)
   }
 
-  /**
-   * Convert a Field to Spark DataType
-   *
-   * @param field Field from snapshot schema
-   * @return Corresponding Spark DataType
-   */
+  /** Convert a Field to Spark DataType
+    *
+    * @param field
+    *   Field from snapshot schema
+    * @return
+    *   Corresponding Spark DataType
+    */
   def fieldToSparkType(field: Field): DataType = {
     dataTypeToSparkType(field.dataType, field.typeParams)
   }
 
-  /**
-   * Convert Milvus data type to Spark DataType
-   *
-   * @param dataType Milvus data type integer code
-   * @param typeParams Optional type parameters (e.g., dim for vectors, max_length for varchar)
-   * @return Corresponding Spark DataType
-   */
-  private def dataTypeToSparkType(dataType: Int, typeParams: Option[Seq[TypeParam]]): DataType = {
+  /** Convert Milvus data type to Spark DataType
+    *
+    * @param dataType
+    *   Milvus data type integer code
+    * @param typeParams
+    *   Optional type parameters (e.g., dim for vectors, max_length for varchar)
+    * @return
+    *   Corresponding Spark DataType
+    */
+  private def dataTypeToSparkType(
+      dataType: Int,
+      typeParams: Option[Seq[TypeParam]]
+  ): DataType = {
     dataType match {
-      case 1 => BooleanType       // Bool
-      case 2 => ByteType          // Int8
-      case 3 => ShortType         // Int16
-      case 4 => IntegerType       // Int32
-      case 5 => LongType          // Int64
-      case 10 => FloatType        // Float
-      case 11 => DoubleType       // Double
-      case 20 => StringType       // String
-      case 21 => StringType       // VarChar
-      case 22 => StringType       // JSON (as string)
-      case 23 => ArrayType(BooleanType)   // Array[Bool]
-      case 24 => ArrayType(ByteType)      // Array[Int8]
-      case 25 => ArrayType(ShortType)     // Array[Int16]
-      case 26 => ArrayType(IntegerType)   // Array[Int32]
-      case 27 => ArrayType(LongType)      // Array[Int64]
-      case 28 => ArrayType(FloatType)     // Array[Float]
-      case 29 => ArrayType(DoubleType)    // Array[Double]
-      case 30 => ArrayType(StringType)    // Array[VarChar]
-      case 101 => ArrayType(FloatType)    // FloatVector
-      case 102 => ArrayType(ByteType)     // BinaryVector
-      case 103 => ArrayType(ShortType)    // Float16Vector
-      case 104 => ArrayType(ShortType)    // BFloat16Vector
+      case 1   => BooleanType // Bool
+      case 2   => ByteType // Int8
+      case 3   => ShortType // Int16
+      case 4   => IntegerType // Int32
+      case 5   => LongType // Int64
+      case 10  => FloatType // Float
+      case 11  => DoubleType // Double
+      case 20  => StringType // String
+      case 21  => StringType // VarChar
+      case 22  => StringType // JSON (as string)
+      case 23  => ArrayType(BooleanType) // Array[Bool]
+      case 24  => ArrayType(ByteType) // Array[Int8]
+      case 25  => ArrayType(ShortType) // Array[Int16]
+      case 26  => ArrayType(IntegerType) // Array[Int32]
+      case 27  => ArrayType(LongType) // Array[Int64]
+      case 28  => ArrayType(FloatType) // Array[Float]
+      case 29  => ArrayType(DoubleType) // Array[Double]
+      case 30  => ArrayType(StringType) // Array[VarChar]
+      case 101 => ArrayType(FloatType) // FloatVector
+      case 102 => ArrayType(ByteType) // BinaryVector
+      case 103 => ArrayType(ShortType) // Float16Vector
+      case 104 => ArrayType(ShortType) // BFloat16Vector
       case 105 => MapType(LongType, FloatType) // SparseFloatVector
-      case _ => BinaryType        // Unknown types as binary
+      case _   => BinaryType // Unknown types as binary
     }
   }
 
-  /**
-   * Get field ID to name mapping for column pruning
-   *
-   * @param schema CollectionSchema from snapshot metadata
-   * @return Map from field ID to field name
-   */
+  /** Get field ID to name mapping for column pruning
+    *
+    * @param schema
+    *   CollectionSchema from snapshot metadata
+    * @return
+    *   Map from field ID to field name
+    */
   def getFieldIdMap(schema: CollectionSchema): Map[Long, String] = {
     schema.fields.map(f => f.getFieldIDAsLong -> f.name).toMap
   }
 
-  /**
-   * Get field name to ID mapping
-   *
-   * @param schema CollectionSchema from snapshot metadata
-   * @return Map from field name to field ID
-   */
+  /** Get field name to ID mapping
+    *
+    * @param schema
+    *   CollectionSchema from snapshot metadata
+    * @return
+    *   Map from field name to field ID
+    */
   def getFieldNameToIdMap(schema: CollectionSchema): Map[String, Long] = {
     schema.fields.map(f => f.name -> f.getFieldIDAsLong).toMap
   }
 
-  /**
-   * Convert snapshot CollectionSchema to protobuf CollectionSchema bytes
-   * This is needed for FFI reader which requires protobuf schema format
-   *
-   * @param schema CollectionSchema from snapshot metadata
-   * @return Protobuf CollectionSchema bytes
-   */
+  /** Convert snapshot CollectionSchema to protobuf CollectionSchema bytes This
+    * is needed for FFI reader which requires protobuf schema format
+    *
+    * @param schema
+    *   CollectionSchema from snapshot metadata
+    * @return
+    *   Protobuf CollectionSchema bytes
+    */
   def toProtobufSchemaBytes(schema: CollectionSchema): Array[Byte] = {
-    import io.milvus.grpc.schema.{CollectionSchema => ProtoCollectionSchema, FieldSchema, DataType}
+    import io.milvus.grpc.schema.{
+      CollectionSchema => ProtoCollectionSchema,
+      FieldSchema,
+      DataType
+    }
     import io.milvus.grpc.common.KeyValuePair
 
     // Filter out system fields (RowID and Timestamp) - only include user fields
-    val userFields = schema.fields.filterNot(f => f.name == "RowID" || f.name == "Timestamp")
+    val userFields =
+      schema.fields.filterNot(f => f.name == "RowID" || f.name == "Timestamp")
 
     val protoFields = userFields.map { field =>
       FieldSchema(
@@ -518,23 +586,29 @@ object MilvusSnapshotReader {
     protoSchema.toByteArray
   }
 
-  /**
-   * Serialize StorageV2ManifestList to JSON string for passing via options
-   *
-   * @param manifestList List of StorageV2ManifestItem
-   * @return JSON string representation
-   */
-  def serializeManifestList(manifestList: Seq[StorageV2ManifestItem]): String = {
+  /** Serialize StorageV2ManifestList to JSON string for passing via options
+    *
+    * @param manifestList
+    *   List of StorageV2ManifestItem
+    * @return
+    *   JSON string representation
+    */
+  def serializeManifestList(
+      manifestList: Seq[StorageV2ManifestItem]
+  ): String = {
     mapper.writeValueAsString(manifestList)
   }
 
-  /**
-   * Deserialize StorageV2ManifestList from JSON string
-   *
-   * @param json JSON string representation
-   * @return Either containing parsed manifest list or error
-   */
-  def deserializeManifestList(json: String): Either[Throwable, Seq[StorageV2ManifestItem]] = {
+  /** Deserialize StorageV2ManifestList from JSON string
+    *
+    * @param json
+    *   JSON string representation
+    * @return
+    *   Either containing parsed manifest list or error
+    */
+  def deserializeManifestList(
+      json: String
+  ): Either[Throwable, Seq[StorageV2ManifestItem]] = {
     try {
       Right(mapper.readValue[Seq[StorageV2ManifestItem]](json))
     } catch {
@@ -542,13 +616,14 @@ object MilvusSnapshotReader {
     }
   }
 
-  /**
-   * Parse simplified manifest content JSON string
-   * Format: {"ver":1,"base_path":"..."}
-   *
-   * @param json JSON string containing simplified manifest
-   * @return Either containing parsed ManifestContent or error
-   */
+  /** Parse simplified manifest content JSON string Format:
+    * {"ver":1,"base_path":"..."}
+    *
+    * @param json
+    *   JSON string containing simplified manifest
+    * @return
+    *   Either containing parsed ManifestContent or error
+    */
   def parseManifestContent(json: String): Either[Throwable, ManifestContent] = {
     try {
       Right(mapper.readValue[ManifestContent](json))
@@ -557,20 +632,25 @@ object MilvusSnapshotReader {
     }
   }
 
-  /**
-   * Transform Storage V2 manifest JSON by converting column field IDs to field names.
-   * The FFI reader expects field names in the columns array, but Storage V2 manifest files
-   * use field IDs as strings (e.g., "100", "101", "0", "1").
-   *
-   * Also strips bucket/rootPath prefix from paths if present, since the FFI reader
-   * will prepend these when accessing files.
-   *
-   * @param manifestJson The original manifest JSON from Storage V2
-   * @param schema CollectionSchema from snapshot metadata for ID-to-name mapping
-   * @param bucket Optional bucket name to strip from paths
-   * @param rootPath Optional root path to strip from paths
-   * @return Transformed manifest JSON with field names instead of IDs
-   */
+  /** Transform Storage V2 manifest JSON by converting column field IDs to field
+    * names. The FFI reader expects field names in the columns array, but
+    * Storage V2 manifest files use field IDs as strings (e.g., "100", "101",
+    * "0", "1").
+    *
+    * Also strips bucket/rootPath prefix from paths if present, since the FFI
+    * reader will prepend these when accessing files.
+    *
+    * @param manifestJson
+    *   The original manifest JSON from Storage V2
+    * @param schema
+    *   CollectionSchema from snapshot metadata for ID-to-name mapping
+    * @param bucket
+    *   Optional bucket name to strip from paths
+    * @param rootPath
+    *   Optional root path to strip from paths
+    * @return
+    *   Transformed manifest JSON with field names instead of IDs
+    */
   def transformManifestColumnsToNames(
       manifestJson: String,
       schema: CollectionSchema,
@@ -596,57 +676,58 @@ object MilvusSnapshotReader {
       // Build path prefix to strip (if provided)
       val pathPrefixToStrip = (bucket, rootPath) match {
         case (Some(b), Some(r)) => Some(s"$b/$r/")
-        case (Some(b), None) => Some(s"$b/")
-        case _ => None
+        case (Some(b), None)    => Some(s"$b/")
+        case _                  => None
       }
 
       // Transform column_groups
-      val columnGroups = manifestObj.getOrElse("column_groups", Seq.empty) match {
-        case groups: Seq[_] =>
-          groups.flatMap {
-            case group: Map[String, Any] @unchecked =>
-              // Transform columns - filter out system fields and map IDs to names
-              val columns = group.getOrElse("columns", Seq.empty) match {
-                case cols: Seq[_] =>
-                  cols.flatMap {
-                    case col: String =>
-                      // Skip system field IDs (0=RowID, 1=Timestamp)
-                      if (systemFieldIds.contains(col)) {
-                        None
-                      } else {
-                        // Map field ID to name, keep if mapping exists
-                        fieldIdToName.get(col)
-                      }
-                    case _ => None
-                  }
-                case _ => Seq.empty
-              }
-
-              // Skip column groups that have no user fields after filtering
-              if (columns.isEmpty) {
-                None
-              } else {
-                // Transform paths (strip bucket/rootPath prefix if present)
-                val paths = group.getOrElse("paths", Seq.empty) match {
-                  case ps: Seq[_] =>
-                    ps.map {
-                      case path: String =>
-                        pathPrefixToStrip match {
-                          case Some(prefix) if path.startsWith(prefix) =>
-                            path.stripPrefix(prefix)
-                          case _ => path
+      val columnGroups =
+        manifestObj.getOrElse("column_groups", Seq.empty) match {
+          case groups: Seq[_] =>
+            groups.flatMap {
+              case group: Map[String, Any] @unchecked =>
+                // Transform columns - filter out system fields and map IDs to names
+                val columns = group.getOrElse("columns", Seq.empty) match {
+                  case cols: Seq[_] =>
+                    cols.flatMap {
+                      case col: String =>
+                        // Skip system field IDs (0=RowID, 1=Timestamp)
+                        if (systemFieldIds.contains(col)) {
+                          None
+                        } else {
+                          // Map field ID to name, keep if mapping exists
+                          fieldIdToName.get(col)
                         }
-                      case other => other.toString
+                      case _ => None
                     }
                   case _ => Seq.empty
                 }
 
-                Some(group + ("columns" -> columns) + ("paths" -> paths))
-              }
-            case other => Some(other)
-          }
-        case _ => Seq.empty
-      }
+                // Skip column groups that have no user fields after filtering
+                if (columns.isEmpty) {
+                  None
+                } else {
+                  // Transform paths (strip bucket/rootPath prefix if present)
+                  val paths = group.getOrElse("paths", Seq.empty) match {
+                    case ps: Seq[_] =>
+                      ps.map {
+                        case path: String =>
+                          pathPrefixToStrip match {
+                            case Some(prefix) if path.startsWith(prefix) =>
+                              path.stripPrefix(prefix)
+                            case _ => path
+                          }
+                        case other => other.toString
+                      }
+                    case _ => Seq.empty
+                  }
+
+                  Some(group + ("columns" -> columns) + ("paths" -> paths))
+                }
+              case other => Some(other)
+            }
+          case _ => Seq.empty
+        }
 
       // Rebuild manifest with transformed column_groups
       // Add "version" field (expected by FFI reader) and remove "metadata" if present

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -6,26 +6,29 @@ import scala.collection.JavaConverters._
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-/**
- * Utilities for converting between Spark InternalRow and Arrow vectors
- */
+/** Utilities for converting between Spark InternalRow and Arrow vectors
+  */
 object ArrowConverter extends Logging {
 
-  /**
-   * Convert an Arrow VectorSchemaRoot row to Spark InternalRow
-   *
-   * @param root Arrow VectorSchemaRoot containing the data
-   * @param rowIndex Index of the row to convert
-   * @param sparkSchema Spark schema for the target InternalRow
-   * @param fieldNameMapping Optional mapping from Spark field name to Arrow column name
-   *                         (e.g., "id" -> "100" when Arrow uses field IDs as column names)
-   * @return Spark InternalRow
-   */
+  /** Convert an Arrow VectorSchemaRoot row to Spark InternalRow
+    *
+    * @param root
+    *   Arrow VectorSchemaRoot containing the data
+    * @param rowIndex
+    *   Index of the row to convert
+    * @param sparkSchema
+    *   Spark schema for the target InternalRow
+    * @param fieldNameMapping
+    *   Optional mapping from Spark field name to Arrow column name (e.g., "id"
+    *   -> "100" when Arrow uses field IDs as column names)
+    * @return
+    *   Spark InternalRow
+    */
   def arrowToInternalRow(
       root: VectorSchemaRoot,
       rowIndex: Int,
@@ -51,14 +54,17 @@ object ArrowConverter extends Logging {
     InternalRow.fromSeq(values)
   }
 
-  /**
-   * Convert a value from an Arrow vector to a Spark value
-   *
-   * @param vector Arrow FieldVector containing the value
-   * @param rowIndex Index of the row to extract
-   * @param sparkType Target Spark data type
-   * @return Spark value
-   */
+  /** Convert a value from an Arrow vector to a Spark value
+    *
+    * @param vector
+    *   Arrow FieldVector containing the value
+    * @param rowIndex
+    *   Index of the row to extract
+    * @param sparkType
+    *   Target Spark data type
+    * @return
+    *   Spark value
+    */
   def arrowValueToSparkValue(
       vector: FieldVector,
       rowIndex: Int,
@@ -91,7 +97,8 @@ object ArrowConverter extends Logging {
         // FloatVector stored as FixedSizeBinaryVector
         val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
         val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        val floats = (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+        val floats =
+          (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
         ArrayData.toArrayData(floats)
 
       case ArrayType(elementType, _) =>
@@ -129,8 +136,16 @@ object ArrowConverter extends Logging {
 
         (0 until length).foreach { i =>
           val elemIndex = startIndex + i
-          keys(i) = arrowValueToSparkValue(dataVector.getChild("key"), elemIndex, keyType)
-          values(i) = arrowValueToSparkValue(dataVector.getChild("value"), elemIndex, valueType)
+          keys(i) = arrowValueToSparkValue(
+            dataVector.getChild("key"),
+            elemIndex,
+            keyType
+          )
+          values(i) = arrowValueToSparkValue(
+            dataVector.getChild("value"),
+            elemIndex,
+            valueType
+          )
         }
 
         ArrayBasedMapData(keys, values)
@@ -141,15 +156,19 @@ object ArrowConverter extends Logging {
     }
   }
 
-  /**
-   * Set a value in an Arrow vector from a Spark InternalRow
-   *
-   * @param vector Arrow FieldVector to write to
-   * @param rowIndex Index of the row to write
-   * @param record Spark InternalRow containing the data
-   * @param colIndex Column index in the InternalRow
-   * @param sparkType Spark data type of the column
-   */
+  /** Set a value in an Arrow vector from a Spark InternalRow
+    *
+    * @param vector
+    *   Arrow FieldVector to write to
+    * @param rowIndex
+    *   Index of the row to write
+    * @param record
+    *   Spark InternalRow containing the data
+    * @param colIndex
+    *   Column index in the InternalRow
+    * @param sparkType
+    *   Spark data type of the column
+    */
   def sparkValueToArrowValue(
       vector: FieldVector,
       rowIndex: Int,
@@ -164,22 +183,32 @@ object ArrowConverter extends Logging {
 
     sparkType match {
       case LongType =>
-        vector.asInstanceOf[BigIntVector].set(rowIndex, record.getLong(colIndex))
+        vector
+          .asInstanceOf[BigIntVector]
+          .set(rowIndex, record.getLong(colIndex))
 
       case IntegerType =>
         vector.asInstanceOf[IntVector].set(rowIndex, record.getInt(colIndex))
 
       case ShortType =>
-        vector.asInstanceOf[SmallIntVector].set(rowIndex, record.getShort(colIndex))
+        vector
+          .asInstanceOf[SmallIntVector]
+          .set(rowIndex, record.getShort(colIndex))
 
       case FloatType =>
-        vector.asInstanceOf[Float4Vector].set(rowIndex, record.getFloat(colIndex))
+        vector
+          .asInstanceOf[Float4Vector]
+          .set(rowIndex, record.getFloat(colIndex))
 
       case DoubleType =>
-        vector.asInstanceOf[Float8Vector].set(rowIndex, record.getDouble(colIndex))
+        vector
+          .asInstanceOf[Float8Vector]
+          .set(rowIndex, record.getDouble(colIndex))
 
       case BooleanType =>
-        vector.asInstanceOf[BitVector].set(rowIndex, if (record.getBoolean(colIndex)) 1 else 0)
+        vector
+          .asInstanceOf[BitVector]
+          .set(rowIndex, if (record.getBoolean(colIndex)) 1 else 0)
 
       case StringType =>
         val str = record.getUTF8String(colIndex)
@@ -192,7 +221,9 @@ object ArrowConverter extends Logging {
       case ArrayType(FloatType, _) =>
         // FloatVector stored as FixedSizeBinaryVector
         val arrayData = record.getArray(colIndex)
-        val floats = (0 until arrayData.numElements()).map(i => arrayData.getFloat(i)).toArray
+        val floats = (0 until arrayData.numElements())
+          .map(i => arrayData.getFloat(i))
+          .toArray
         val bytes = new Array[Byte](floats.length * 4)
         val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
         floats.foreach(buffer.putFloat)
@@ -214,7 +245,13 @@ object ArrowConverter extends Logging {
           } else {
             // Recursively set element value
             val elemRow = InternalRow(arrayData.get(i, elementType))
-            sparkValueToArrowValue(dataVector, elemIndex, elemRow, 0, elementType)
+            sparkValueToArrowValue(
+              dataVector,
+              elemIndex,
+              elemRow,
+              0,
+              elementType
+            )
           }
         }
 
@@ -244,8 +281,20 @@ object ArrowConverter extends Logging {
           val keyRow = InternalRow(keys.get(i, keyType))
           val valueRow = InternalRow(values.get(i, valueType))
 
-          sparkValueToArrowValue(structVector.getChild("key"), elemIndex, keyRow, 0, keyType)
-          sparkValueToArrowValue(structVector.getChild("value"), elemIndex, valueRow, 0, valueType)
+          sparkValueToArrowValue(
+            structVector.getChild("key"),
+            elemIndex,
+            keyRow,
+            0,
+            keyType
+          )
+          sparkValueToArrowValue(
+            structVector.getChild("value"),
+            elemIndex,
+            valueRow,
+            0,
+            valueType
+          )
         }
 
         mapVector.endValue(rowIndex, mapData.numElements())
@@ -255,14 +304,17 @@ object ArrowConverter extends Logging {
     }
   }
 
-  /**
-   * Add a Spark InternalRow to an Arrow VectorSchemaRoot
-   *
-   * @param root Arrow VectorSchemaRoot to write to
-   * @param rowIndex Index of the row to write
-   * @param record Spark InternalRow to convert
-   * @param sparkSchema Spark schema of the InternalRow
-   */
+  /** Add a Spark InternalRow to an Arrow VectorSchemaRoot
+    *
+    * @param root
+    *   Arrow VectorSchemaRoot to write to
+    * @param rowIndex
+    *   Index of the row to write
+    * @param record
+    *   Spark InternalRow to convert
+    * @param sparkSchema
+    *   Spark schema of the InternalRow
+    */
   def internalRowToArrow(
       root: VectorSchemaRoot,
       rowIndex: Int,

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -1,37 +1,49 @@
 package com.zilliz.spark.connector
 
-import org.apache.spark.sql.types.{DataType => SparkDataType}
-import org.apache.spark.sql.types.DataTypes
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.spark.sql.types.{DataType => SparkDataType}
+import org.apache.spark.sql.types.DataTypes
 
 import com.zilliz.spark.connector.DataParseException
 import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
 object DataTypeUtil {
-  /**
-   * Converts Milvus DataType to Arrow type given dimension and element type
-   */
+
+  /** Converts Milvus DataType to Arrow type given dimension and element type
+    */
   def toArrowType(dim: Int, dataType: MilvusDataType): ArrowType = {
     dataType match {
-      case MilvusDataType.Bool => new ArrowType.Bool()
-      case MilvusDataType.Int8 => new ArrowType.Int(8, true)
+      case MilvusDataType.Bool  => new ArrowType.Bool()
+      case MilvusDataType.Int8  => new ArrowType.Int(8, true)
       case MilvusDataType.Int16 => new ArrowType.Int(16, true)
       case MilvusDataType.Int32 => new ArrowType.Int(32, true)
       case MilvusDataType.Int64 => new ArrowType.Int(64, true)
-      case MilvusDataType.Float => new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
-      case MilvusDataType.Double => new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+      case MilvusDataType.Float =>
+        new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+      case MilvusDataType.Double =>
+        new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
       case MilvusDataType.Timestamptz => new ArrowType.Int(64, true)
-      case MilvusDataType.VarChar | MilvusDataType.String | MilvusDataType.Text => new ArrowType.Utf8()
-      case MilvusDataType.Array | MilvusDataType.JSON | MilvusDataType.Geometry => new ArrowType.Binary()
-      case MilvusDataType.BinaryVector => new ArrowType.FixedSizeBinary((dim + 7) / 8)
-      case MilvusDataType.Float16Vector => new ArrowType.FixedSizeBinary(dim * 2)
-      case MilvusDataType.BFloat16Vector => new ArrowType.FixedSizeBinary(dim * 2)
-      case MilvusDataType.Int8Vector => new ArrowType.FixedSizeBinary(dim)
+      case MilvusDataType.VarChar | MilvusDataType.String |
+          MilvusDataType.Text =>
+        new ArrowType.Utf8()
+      case MilvusDataType.Array | MilvusDataType.JSON |
+          MilvusDataType.Geometry =>
+        new ArrowType.Binary()
+      case MilvusDataType.BinaryVector =>
+        new ArrowType.FixedSizeBinary((dim + 7) / 8)
+      case MilvusDataType.Float16Vector =>
+        new ArrowType.FixedSizeBinary(dim * 2)
+      case MilvusDataType.BFloat16Vector =>
+        new ArrowType.FixedSizeBinary(dim * 2)
+      case MilvusDataType.Int8Vector  => new ArrowType.FixedSizeBinary(dim)
       case MilvusDataType.FloatVector => new ArrowType.FixedSizeBinary(dim * 4)
       case MilvusDataType.SparseFloatVector => new ArrowType.Binary()
-      case MilvusDataType.ArrayOfVector => new ArrowType.List()
-      case _ => throw new DataParseException(s"Unsupported Milvus data type for Arrow conversion: $dataType")
+      case MilvusDataType.ArrayOfVector     => new ArrowType.List()
+      case _ =>
+        throw new DataParseException(
+          s"Unsupported Milvus data type for Arrow conversion: $dataType"
+        )
     }
   }
 

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -19,9 +19,9 @@ import io.milvus.grpc.schema.{
   VectorField
 }
 
-/**
- * MilvusSchemaUtil provides utilities for converting between Milvus and Arrow schemas
- */
+/** MilvusSchemaUtil provides utilities for converting between Milvus and Arrow
+  * schemas
+  */
 object MilvusSchemaUtil {
   def getDim(fieldSchema: FieldSchema): Int = {
     for (param <- fieldSchema.typeParams) {
@@ -34,9 +34,8 @@ object MilvusSchemaUtil {
     )
   }
 
-  /**
-   * Convert Milvus FieldSchema to Arrow Field
-   */
+  /** Convert Milvus FieldSchema to Arrow Field
+    */
   def convertToArrowField(
       field: FieldSchema,
       arrowType: org.apache.arrow.vector.types.pojo.ArrowType
@@ -63,14 +62,15 @@ object MilvusSchemaUtil {
     )
   }
 
-  /**
-   * Convert Milvus CollectionSchema to Arrow Schema
-   * This function converts a Milvus collection schema to an Arrow schema format.
-   * Now uses the serdeMap for consistent type conversion.
-   *
-   * @param collectionSchema The Milvus collection schema
-   * @return Arrow Schema
-   */
+  /** Convert Milvus CollectionSchema to Arrow Schema This function converts a
+    * Milvus collection schema to an Arrow schema format. Now uses the serdeMap
+    * for consistent type conversion.
+    *
+    * @param collectionSchema
+    *   The Milvus collection schema
+    * @return
+    *   Arrow Schema
+    */
   def convertToArrowSchema(
       collectionSchema: io.milvus.grpc.schema.CollectionSchema
   ): org.apache.arrow.vector.types.pojo.Schema = {
@@ -84,8 +84,8 @@ object MilvusSchemaUtil {
       // Get dimension for vector types
       val dim = field.dataType match {
         case DataType.BinaryVector | DataType.Float16Vector |
-             DataType.BFloat16Vector | DataType.Int8Vector |
-             DataType.FloatVector | DataType.ArrayOfVector =>
+            DataType.BFloat16Vector | DataType.Int8Vector |
+            DataType.FloatVector | DataType.ArrayOfVector =>
           try {
             getDim(field)
           } catch {
@@ -144,20 +144,22 @@ object MilvusSchemaUtil {
     new org.apache.arrow.vector.types.pojo.Schema(arrowFields.asJava)
   }
 
-  /**
-   * Convert Milvus CollectionSchema to Arrow Schema using field IDs as field names.
-   * This is required for milvus-storage reader which matches columns by field ID.
-   *
-   * The manifest stores column groups with field IDs (e.g., "100", "101"),
-   * so the Arrow schema must use field IDs as field names for the reader to
-   * correctly match requested columns with column groups.
-   *
-   * Note: System fields (row_id, timestamp) are NOT included here.
-   * They are handled by MilvusPartitionReaderFactory.
-   *
-   * @param collectionSchema The Milvus collection schema
-   * @return Arrow Schema with field IDs as field names
-   */
+  /** Convert Milvus CollectionSchema to Arrow Schema using field IDs as field
+    * names. This is required for milvus-storage reader which matches columns by
+    * field ID.
+    *
+    * The manifest stores column groups with field IDs (e.g., "100", "101"), so
+    * the Arrow schema must use field IDs as field names for the reader to
+    * correctly match requested columns with column groups.
+    *
+    * Note: System fields (row_id, timestamp) are NOT included here. They are
+    * handled by MilvusPartitionReaderFactory.
+    *
+    * @param collectionSchema
+    *   The Milvus collection schema
+    * @return
+    *   Arrow Schema with field IDs as field names
+    */
   def convertToArrowSchemaWithFieldIdNames(
       collectionSchema: io.milvus.grpc.schema.CollectionSchema
   ): org.apache.arrow.vector.types.pojo.Schema = {
@@ -171,8 +173,8 @@ object MilvusSchemaUtil {
       // Get dimension for vector types
       val dim = field.dataType match {
         case DataType.BinaryVector | DataType.Float16Vector |
-             DataType.BFloat16Vector | DataType.Int8Vector |
-             DataType.FloatVector | DataType.ArrayOfVector =>
+            DataType.BFloat16Vector | DataType.Int8Vector |
+            DataType.FloatVector | DataType.ArrayOfVector =>
           try {
             getDim(field)
           } catch {
@@ -218,14 +220,17 @@ object MilvusSchemaUtil {
     new org.apache.arrow.vector.types.pojo.Schema(arrowFields.asJava)
   }
 
-  /**
-   * Convert Spark StructType to Arrow Schema
-   * This enables direct DataFrame to Arrow conversion without Milvus schema
-   *
-   * @param sparkSchema The Spark StructType schema
-   * @param vectorDimensions Optional map of field name to vector dimension (for float arrays as vectors)
-   * @return Arrow Schema
-   */
+  /** Convert Spark StructType to Arrow Schema This enables direct DataFrame to
+    * Arrow conversion without Milvus schema
+    *
+    * @param sparkSchema
+    *   The Spark StructType schema
+    * @param vectorDimensions
+    *   Optional map of field name to vector dimension (for float arrays as
+    *   vectors)
+    * @return
+    *   Arrow Schema
+    */
   def convertSparkSchemaToArrow(
       sparkSchema: org.apache.spark.sql.types.StructType,
       vectorDimensions: Map[String, Int] = Map.empty,
@@ -238,15 +243,17 @@ object MilvusSchemaUtil {
 
     val fields = sparkSchema.fields.zipWithIndex.map { case (field, idx) =>
       val arrowType: ArrowType = field.dataType match {
-        case LongType => new ArrowType.Int(64, true)
+        case LongType    => new ArrowType.Int(64, true)
         case IntegerType => new ArrowType.Int(32, true)
-        case ShortType => new ArrowType.Int(16, true)
-        case ByteType => new ArrowType.Int(8, true)
-        case FloatType => new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
-        case DoubleType => new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
-        case BooleanType => new ArrowType.Bool()
-        case StringType => new ArrowType.Utf8()
-        case BinaryType => new ArrowType.Binary()
+        case ShortType   => new ArrowType.Int(16, true)
+        case ByteType    => new ArrowType.Int(8, true)
+        case FloatType =>
+          new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+        case DoubleType =>
+          new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+        case BooleanType             => new ArrowType.Bool()
+        case StringType              => new ArrowType.Utf8()
+        case BinaryType              => new ArrowType.Binary()
         case ArrayType(FloatType, _) =>
           // Check if this field is a vector (has dimension specified)
           vectorDimensions.get(field.name) match {
@@ -258,14 +265,16 @@ object MilvusSchemaUtil {
               new ArrowType.List()
           }
         case ArrayType(IntegerType, _) => new ArrowType.List()
-        case ArrayType(LongType, _) => new ArrowType.List()
-        case ArrayType(DoubleType, _) => new ArrowType.List()
-        case ArrayType(StringType, _) => new ArrowType.List()
-        case ArrayType(_, _) => new ArrowType.List()
-        case MapType(_, _, _) => new ArrowType.Map(false)
-        case StructType(_) => new ArrowType.Struct()
+        case ArrayType(LongType, _)    => new ArrowType.List()
+        case ArrayType(DoubleType, _)  => new ArrowType.List()
+        case ArrayType(StringType, _)  => new ArrowType.List()
+        case ArrayType(_, _)           => new ArrowType.List()
+        case MapType(_, _, _)          => new ArrowType.Map(false)
+        case StructType(_)             => new ArrowType.Struct()
         case _ =>
-          throw new IllegalArgumentException(s"Unsupported Spark type: ${field.dataType}")
+          throw new IllegalArgumentException(
+            s"Unsupported Spark type: ${field.dataType}"
+          )
       }
 
       // Use explicit field ID if provided, otherwise fall back to idx + 1
@@ -274,7 +283,8 @@ object MilvusSchemaUtil {
 
       val fieldType = new FieldType(true, arrowType, null, metadata)
       // Use field ID as column name when explicit field IDs are provided
-      val fieldName = if (fieldIds.contains(field.name)) fieldId.toString else field.name
+      val fieldName =
+        if (fieldIds.contains(field.name)) fieldId.toString else field.name
       new Field(fieldName, fieldType, null)
     }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -41,12 +41,12 @@ import com.zilliz.spark.connector.{
   MilvusOption,
   VectorSearchConfig
 }
+import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusPartitionReaderFactory,
   MilvusStorageV2InputPartition
 }
 import com.zilliz.spark.connector.write.{MilvusWrite, MilvusWriteBuilder}
-import com.zilliz.spark.connector.loon.Properties
 import io.milvus.grpc.schema.CollectionSchema
 
 // 1. DataSourceRegister and TableProvider
@@ -58,8 +58,9 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
   ): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val milvusOption = MilvusOption(options)
-    val isSnapshotMode = Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-                         Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode =
+      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
+        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
     if (milvusOption.uri.isEmpty && !isSnapshotMode) {
       throw new IllegalArgumentException(
         s"Option '${MilvusOption.MilvusUri}' is required for reading milvus data."
@@ -75,23 +76,31 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
     val milvusOption = MilvusOption(options)
 
     // Check for snapshot mode - use snapshot schema if provided
-    val isSnapshotMode = Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-                         Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode =
+      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
+        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
 
     if (isSnapshotMode) {
       // Try to get schema from snapshot JSON
-      Option(options.get(MilvusOption.SnapshotSchemaJson)).flatMap { json =>
-        import com.zilliz.spark.connector.read.MilvusSnapshotReader
-        MilvusSnapshotReader.parseSnapshotMetadata(json) match {
-          case Right(metadata) =>
-            Some(MilvusSnapshotReader.toSparkSchema(metadata.collection.schema, includeSystemFields = true))
-          case Left(_) => None
+      Option(options.get(MilvusOption.SnapshotSchemaJson))
+        .flatMap { json =>
+          import com.zilliz.spark.connector.read.MilvusSnapshotReader
+          MilvusSnapshotReader.parseSnapshotMetadata(json) match {
+            case Right(metadata) =>
+              Some(
+                MilvusSnapshotReader.toSparkSchema(
+                  metadata.collection.schema,
+                  includeSystemFields = true
+                )
+              )
+            case Left(_) => None
+          }
         }
-      }.getOrElse {
-        // If no snapshot schema provided, return empty schema
-        // The actual schema should be provided via .schema() call
-        StructType(Seq.empty)
-      }
+        .getOrElse {
+          // If no snapshot schema provided, return empty schema
+          // The actual schema should be provided via .schema() call
+          StructType(Seq.empty)
+        }
     } else {
       // Client-based mode (existing behavior)
       if (milvusOption.collectionName.isEmpty) {
@@ -146,9 +155,8 @@ case class MilvusTable(
     }
   logInfo(s"MilvusTable fieldIDs: $fieldIDs")
 
-  /**
-   * Check if snapshot mode is enabled (data comes from snapshot, not client)
-   */
+  /** Check if snapshot mode is enabled (data comes from snapshot, not client)
+    */
   private def isSnapshotMode: Boolean = {
     milvusOption.options.get(MilvusOption.SnapshotMode).contains("true") &&
     milvusOption.options.contains(MilvusOption.SnapshotManifests)
@@ -157,7 +165,9 @@ case class MilvusTable(
   def initInfo(): Unit = {
     // Check for snapshot mode first - skip client calls if snapshot data is provided
     if (isSnapshotMode) {
-      logInfo("Snapshot mode enabled - skipping Milvus client connection for collection info")
+      logInfo(
+        "Snapshot mode enabled - skipping Milvus client connection for collection info"
+      )
       initFromSnapshot()
     } else {
       // Client-based mode (existing behavior)
@@ -165,19 +175,20 @@ case class MilvusTable(
     }
   }
 
-  /**
-   * Initialize collection info from snapshot metadata (no client connection)
-   */
+  /** Initialize collection info from snapshot metadata (no client connection)
+    */
   private def initFromSnapshot(): Unit = {
     import com.zilliz.spark.connector.read.MilvusSnapshotReader
 
     // Get collection ID from options
-    val collectionId = milvusOption.options.get(MilvusOption.SnapshotCollectionId)
+    val collectionId = milvusOption.options
+      .get(MilvusOption.SnapshotCollectionId)
       .map(_.toLong)
       .getOrElse(0L)
 
     // Get partition IDs from options
-    val partitionIds = milvusOption.options.get(MilvusOption.SnapshotPartitionIds)
+    val partitionIds = milvusOption.options
+      .get(MilvusOption.SnapshotPartitionIds)
       .map(_.split(",").map(_.trim).filter(_.nonEmpty).map(_.toLong).toSeq)
       .getOrElse(Seq.empty[Long])
 
@@ -189,7 +200,7 @@ case class MilvusTable(
     val snapshotSchema = schemaJson.flatMap { json =>
       MilvusSnapshotReader.parseSnapshotMetadata(json) match {
         case Right(metadata) => Some(metadata.collection.schema)
-        case Left(_) => None
+        case Left(_)         => None
       }
     }
 
@@ -202,17 +213,21 @@ case class MilvusTable(
       schema = createMinimalCollectionSchema(snapshotSchema)
     )
 
-    logInfo(s"Initialized from snapshot: collectionID=$collectionId, partitionID=$partitionID")
+    logInfo(
+      s"Initialized from snapshot: collectionID=$collectionId, partitionID=$partitionID"
+    )
   }
 
-  /**
-   * Create a minimal CollectionSchema for snapshot mode
-   * This is used when we have snapshot data but need a protobuf schema structure
-   */
+  /** Create a minimal CollectionSchema for snapshot mode This is used when we
+    * have snapshot data but need a protobuf schema structure
+    */
   private def createMinimalCollectionSchema(
       snapshotSchema: Option[com.zilliz.spark.connector.read.CollectionSchema]
   ): CollectionSchema = {
-    import io.milvus.grpc.schema.{CollectionSchema => ProtoCollectionSchema, FieldSchema}
+    import io.milvus.grpc.schema.{
+      CollectionSchema => ProtoCollectionSchema,
+      FieldSchema
+    }
     import io.milvus.grpc.common.KeyValuePair
 
     snapshotSchema match {
@@ -249,9 +264,8 @@ case class MilvusTable(
     }
   }
 
-  /**
-   * Initialize collection info from Milvus client (existing behavior)
-   */
+  /** Initialize collection info from Milvus client (existing behavior)
+    */
   private def initFromClient(): Unit = {
     val client = MilvusClient(milvusOption)
     try {
@@ -317,7 +331,9 @@ case class MilvusTable(
     // In snapshot mode with provided sparkSchema, use it directly
     // This avoids the need to parse milvusCollection.schema which may be incomplete
     if (isSnapshotMode && sparkSchema.isDefined && sparkSchema.get.nonEmpty) {
-      logInfo(s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}")
+      logInfo(
+        s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
+      )
       return sparkSchema.get
     }
 
@@ -349,18 +365,33 @@ case class MilvusTable(
       )
     )
     // Safely get maxFieldID, default to 100 if empty
-    val maxFieldID = if (fieldName2ID.values.nonEmpty) fieldName2ID.values.max else 100L
-    if (milvusCollection.schema.enableDynamicField &&
-      (fieldIDs.isEmpty || fieldIDs.contains((maxFieldID + 1).toString))) {
+    val maxFieldID =
+      if (fieldName2ID.values.nonEmpty) fieldName2ID.values.max else 100L
+    if (
+      milvusCollection.schema.enableDynamicField &&
+      (fieldIDs.isEmpty || fieldIDs.contains((maxFieldID + 1).toString))
+    ) {
       fields = fields :+ StructField("$meta", StringType, true)
     }
-    if (milvusOption.extraColumns.contains(MilvusOption.MilvusExtraColumnPartition)) {
+    if (
+      milvusOption.extraColumns.contains(
+        MilvusOption.MilvusExtraColumnPartition
+      )
+    ) {
       fields = fields :+ StructField("partition", StringType, true)
     }
-    if (milvusOption.extraColumns.contains(MilvusOption.MilvusExtraColumnSegmentID)) {
+    if (
+      milvusOption.extraColumns.contains(
+        MilvusOption.MilvusExtraColumnSegmentID
+      )
+    ) {
       fields = fields :+ StructField("segment_id", LongType, false)
     }
-    if (milvusOption.extraColumns.contains(MilvusOption.MilvusExtraColumnRowOffset)) {
+    if (
+      milvusOption.extraColumns.contains(
+        MilvusOption.MilvusExtraColumnRowOffset
+      )
+    ) {
       fields = fields :+ StructField("row_offset", LongType, false)
     }
     StructType(fields)
@@ -426,9 +457,16 @@ class MilvusScanBuilder(
     }
 
     // Add vector column if vector search is enabled
-    val vectorColumn = Option(options.get(MilvusOption.VectorSearchVectorColumn)).getOrElse("vector")
-    val hasVectorSearch = Option(options.get(MilvusOption.VectorSearchQueryVector)).isDefined
-    if (hasVectorSearch && fieldName2ID.contains(vectorColumn) && !fieldNames.contains(vectorColumn)) {
+    val vectorColumn = Option(
+      options.get(MilvusOption.VectorSearchVectorColumn)
+    ).getOrElse("vector")
+    val hasVectorSearch = Option(
+      options.get(MilvusOption.VectorSearchQueryVector)
+    ).isDefined
+    if (
+      hasVectorSearch && fieldName2ID.contains(vectorColumn) && !fieldNames
+        .contains(vectorColumn)
+    ) {
       fieldNames = fieldNames :+ vectorColumn
     }
 
@@ -542,22 +580,23 @@ class MilvusScanBuilder(
     }
   }
 
-  /**
-   * Extract all column names referenced in a filter
-   */
+  /** Extract all column names referenced in a filter
+    */
   private def extractFilterColumns(filter: Filter): Seq[String] = {
     import org.apache.spark.sql.sources._
     filter match {
-      case EqualTo(attr, _) => Seq(attr)
-      case GreaterThan(attr, _) => Seq(attr)
+      case EqualTo(attr, _)            => Seq(attr)
+      case GreaterThan(attr, _)        => Seq(attr)
       case GreaterThanOrEqual(attr, _) => Seq(attr)
-      case LessThan(attr, _) => Seq(attr)
-      case LessThanOrEqual(attr, _) => Seq(attr)
-      case In(attr, _) => Seq(attr)
-      case IsNull(attr) => Seq(attr)
-      case IsNotNull(attr) => Seq(attr)
-      case And(left, right) => extractFilterColumns(left) ++ extractFilterColumns(right)
-      case Or(left, right) => extractFilterColumns(left) ++ extractFilterColumns(right)
+      case LessThan(attr, _)           => Seq(attr)
+      case LessThanOrEqual(attr, _)    => Seq(attr)
+      case In(attr, _)                 => Seq(attr)
+      case IsNull(attr)                => Seq(attr)
+      case IsNotNull(attr)             => Seq(attr)
+      case And(left, right) =>
+        extractFilterColumns(left) ++ extractFilterColumns(right)
+      case Or(left, right) =>
+        extractFilterColumns(left) ++ extractFilterColumns(right)
       case _ => Seq.empty
     }
   }
@@ -581,7 +620,9 @@ class MilvusScan(
 
   // Log vector search configuration if enabled
   vectorSearchConfig.foreach { config =>
-    logInfo(s"Vector search enabled: topK=${config.topK}, metric=${config.metricType}, column=${config.vectorColumn}")
+    logInfo(
+      s"Vector search enabled: topK=${config.topK}, metric=${config.metricType}, column=${config.vectorColumn}"
+    )
   }
 
   override def readSchema(): StructType = {
@@ -609,25 +650,39 @@ class MilvusScan(
     val client = MilvusClient(milvusOption)
 
     // Get collection schema and S3 config for manifest building
-    val collectionInfo = client.getCollectionInfo(
-      milvusOption.databaseName,
-      milvusOption.collectionName
-    ).getOrElse(
-      throw new Exception(
-        s"Collection ${milvusOption.collectionName} not found"
+    val collectionInfo = client
+      .getCollectionInfo(
+        milvusOption.databaseName,
+        milvusOption.collectionName
       )
+      .getOrElse(
+        throw new Exception(
+          s"Collection ${milvusOption.collectionName} not found"
+        )
+      )
+    val s3Bucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
     )
-    val s3Bucket = milvusOption.options.getOrElse(Properties.FsConfig.FsBucketName, "a-bucket")
-    val s3RootPath = milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
+    val s3RootPath =
+      milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
 
     // Helper function to create InputPartition from segment info
-    def createPartition(segmentID: String, partitionID: String): InputPartition = {
+    def createPartition(
+        segmentID: String,
+        partitionID: String
+    ): InputPartition = {
       // Build segment path where manifest files exist
       // V2 segments have manifest files at: rootPath/insert_log/collectionID/partitionID/segmentID/_metadata/
-      val segmentPath = s"$s3RootPath/insert_log/$collection/$partitionID/$segmentID"
-      logInfo(s"Creating V2 partition: segmentID=$segmentID, segmentPath=$segmentPath")
+      val segmentPath =
+        s"$s3RootPath/insert_log/$collection/$partitionID/$segmentID"
+      logInfo(
+        s"Creating V2 partition: segmentID=$segmentID, segmentPath=$segmentPath"
+      )
 
-      val segmentIDLong = try { segmentID.toLong } catch { case _: NumberFormatException => -1L }
+      val segmentIDLong =
+        try { segmentID.toLong }
+        catch { case _: NumberFormatException => -1L }
       MilvusStorageV2InputPartition(
         segmentPath,
         collectionInfo.schema.toByteArray,
@@ -642,72 +697,89 @@ class MilvusScan(
     }
 
     // Get all V2 segments with partition info
-    val allV2Segments = client.getSegments(
-      milvusOption.databaseName,
-      milvusOption.collectionName
-    ).getOrElse(
-      throw new Exception("Failed to get segments")
-    ).filter(_.storageVersion >= 2)
+    val allV2Segments = client
+      .getSegments(
+        milvusOption.databaseName,
+        milvusOption.collectionName
+      )
+      .getOrElse(
+        throw new Exception("Failed to get segments")
+      )
+      .filter(_.storageVersion >= 2)
 
     if (allV2Segments.isEmpty) {
       throw new IllegalArgumentException(
         s"No Storage V2 segments found in collection ${milvusOption.collectionName}. " +
-        "This connector requires Milvus 2.6+ with Storage V2. " +
-        "Please ensure the collection has been flushed and contains data."
+          "This connector requires Milvus 2.6+ with Storage V2. " +
+          "Please ensure the collection has been flushed and contains data."
       )
     }
 
-    val partitions: Array[InputPartition] = if (!partition.isEmpty() && !segment.isEmpty()) {
-      // Case 1: Specific segment specified - validate segment belongs to partition
-      val segmentInfo = allV2Segments.find(_.segmentID.toString == segment)
-      segmentInfo match {
-        case Some(seg) =>
-          if (seg.partitionID.toString != partition) {
+    val partitions: Array[InputPartition] =
+      if (!partition.isEmpty() && !segment.isEmpty()) {
+        // Case 1: Specific segment specified - validate segment belongs to partition
+        val segmentInfo = allV2Segments.find(_.segmentID.toString == segment)
+        segmentInfo match {
+          case Some(seg) =>
+            if (seg.partitionID.toString != partition) {
+              throw new IllegalArgumentException(
+                s"Segment $segment belongs to partition ${seg.partitionID}, not $partition"
+              )
+            }
+            Array(createPartition(segment, partition))
+          case None =>
             throw new IllegalArgumentException(
-              s"Segment $segment belongs to partition ${seg.partitionID}, not $partition"
+              s"Segment $segment not found or not a V2 segment (Storage V2 required)"
             )
-          }
-          Array(createPartition(segment, partition))
-        case None =>
-          throw new IllegalArgumentException(
-            s"Segment $segment not found or not a V2 segment (Storage V2 required)"
-          )
+        }
+
+      } else if (!partition.isEmpty()) {
+        // Case 2: Partition specified - only process V2 segments in this partition
+        allV2Segments
+          .filter(_.partitionID.toString == partition)
+          .map(seg => createPartition(seg.segmentID.toString, partition))
+          .toArray
+
+      } else {
+        // Case 3: No partition specified - process all V2 segments
+        allV2Segments.map { seg =>
+          createPartition(seg.segmentID.toString, seg.partitionID.toString)
+        }.toArray
       }
 
-    } else if (!partition.isEmpty()) {
-      // Case 2: Partition specified - only process V2 segments in this partition
-      allV2Segments
-        .filter(_.partitionID.toString == partition)
-        .map(seg => createPartition(seg.segmentID.toString, partition))
-        .toArray
-
-    } else {
-      // Case 3: No partition specified - process all V2 segments
-      allV2Segments.map { seg =>
-        createPartition(seg.segmentID.toString, seg.partitionID.toString)
-      }.toArray
-    }
-
-    logInfo(s"Created ${partitions.length} partitions for Storage V2 (Milvus 2.6+)")
+    logInfo(
+      s"Created ${partitions.length} partitions for Storage V2 (Milvus 2.6+)"
+    )
     client.close()
     partitions
   }
 
-  /**
-   * Plan input partitions from snapshot manifests (offline mode - no client connection)
-   * This enables reading Milvus data purely from snapshot metadata without any client calls.
-   */
-  private def planInputPartitionsFromSnapshot(manifestsJson: String): Array[InputPartition] = {
-    import com.zilliz.spark.connector.read.{MilvusSnapshotReader, StorageV2ManifestItem}
+  /** Plan input partitions from snapshot manifests (offline mode - no client
+    * connection) This enables reading Milvus data purely from snapshot metadata
+    * without any client calls.
+    */
+  private def planInputPartitionsFromSnapshot(
+      manifestsJson: String
+  ): Array[InputPartition] = {
+    import com.zilliz.spark.connector.read.{
+      MilvusSnapshotReader,
+      StorageV2ManifestItem
+    }
 
-    logInfo("Using snapshot mode for partition planning (no Milvus client connection)")
+    logInfo(
+      "Using snapshot mode for partition planning (no Milvus client connection)"
+    )
 
     // Parse manifest list from JSON
-    val manifestList = MilvusSnapshotReader.deserializeManifestList(manifestsJson) match {
-      case Right(list) => list
-      case Left(e) =>
-        throw new Exception(s"Failed to parse snapshot manifests: ${e.getMessage}", e)
-    }
+    val manifestList =
+      MilvusSnapshotReader.deserializeManifestList(manifestsJson) match {
+        case Right(list) => list
+        case Left(e) =>
+          throw new Exception(
+            s"Failed to parse snapshot manifests: ${e.getMessage}",
+            e
+          )
+      }
 
     if (manifestList.isEmpty) {
       logWarning("Snapshot manifest list is empty, returning no partitions")
@@ -726,20 +798,29 @@ class MilvusScan(
     val schemaBytes = Option(options.get(MilvusOption.SnapshotSchemaBytes))
       .map(base64 => java.util.Base64.getDecoder.decode(base64))
       .getOrElse {
-        logWarning("No schema bytes provided in snapshot mode, using empty schema")
+        logWarning(
+          "No schema bytes provided in snapshot mode, using empty schema"
+        )
         Array.empty[Byte]
       }
 
-    logInfo(s"Using schema bytes (${schemaBytes.length} bytes) for V2 partitions")
+    logInfo(
+      s"Using schema bytes (${schemaBytes.length} bytes) for V2 partitions"
+    )
 
     // Create V2 input partitions from snapshot manifests
     val v2Partitions = manifestList.map { item =>
       // Try to parse manifest as JSON to extract basePath and ver (version)
       // If parsing fails, treat the manifest string as a plain basePath (backward compatible)
-      val (basePath, readVersion) = MilvusSnapshotReader.parseManifestContent(item.manifest) match {
-        case Right(content) => (content.basePath, content.ver.toLong)
-        case Left(_) => (item.manifest, -1L)  // Backward compatible: plain basePath, latest version
-      }
+      val (basePath, readVersion) =
+        MilvusSnapshotReader.parseManifestContent(item.manifest) match {
+          case Right(content) => (content.basePath, content.ver.toLong)
+          case Left(_) =>
+            (
+              item.manifest,
+              -1L
+            ) // Backward compatible: plain basePath, latest version
+        }
 
       // Extract segmentID from manifest path if item.segmentID is 0
       // Path format: files/insert_log/{collectionID}/{partitionID}/{segmentID}
@@ -756,22 +837,26 @@ class MilvusScan(
           }
         } else 0L
       }
-      logInfo(s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion")
+      logInfo(
+        s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"
+      )
       MilvusStorageV2InputPartition(
-        basePath,                // The basePath extracted from manifest JSON
-        schemaBytes,             // Protobuf CollectionSchema bytes from snapshot
-        defaultPartitionId,      // Partition name/ID
+        basePath, // The basePath extracted from manifest JSON
+        schemaBytes, // Protobuf CollectionSchema bytes from snapshot
+        defaultPartitionId, // Partition name/ID
         milvusOption,
         vectorSearchConfig.map(_.topK),
         vectorSearchConfig.map(_.queryVector),
         vectorSearchConfig.map(_.metricType),
         vectorSearchConfig.map(_.vectorColumn),
-        segmentID,               // Segment ID extracted from path or from item
-        readVersion              // Manifest version from snapshot (-1 = latest)
+        segmentID, // Segment ID extracted from path or from item
+        readVersion // Manifest version from snapshot (-1 = latest)
       ): InputPartition
     }
 
-    logInfo(s"Created ${v2Partitions.size} V2 partitions from snapshot manifests")
+    logInfo(
+      s"Created ${v2Partitions.size} V2 partitions from snapshot manifests"
+    )
     v2Partitions.toArray
   }
 

--- a/src/main/scala/write/MilvusBatchWriter.scala
+++ b/src/main/scala/write/MilvusBatchWriter.scala
@@ -1,6 +1,5 @@
 package com.zilliz.spark.connector.write
 
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.connector.write.{
   BatchWrite,
   DataWriterFactory,
@@ -8,6 +7,8 @@ import org.apache.spark.sql.connector.write.{
   Write,
   WriterCommitMessage
 }
+import org.apache.spark.sql.types.StructType
+
 import com.zilliz.spark.connector.MilvusOption
 
 case class MilvusWrite(milvusOptions: MilvusOption, schema: StructType)

--- a/src/main/scala/write/MilvusDataWriterFactory.scala
+++ b/src/main/scala/write/MilvusDataWriterFactory.scala
@@ -3,6 +3,7 @@ package com.zilliz.spark.connector.write
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.{DataWriter, DataWriterFactory}
 import org.apache.spark.sql.types.StructType
+
 import com.zilliz.spark.connector.MilvusOption
 
 case class MilvusDataWriterFactory(

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -14,7 +14,11 @@ import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.catalog.{
+  SupportsWrite,
+  Table,
+  TableCapability
+}
 import org.apache.spark.sql.connector.write.{
   BatchWrite,
   DataWriter,
@@ -30,10 +34,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.unsafe.types.UTF8String
 
-import com.zilliz.spark.connector.{
-  MilvusOption,
-  MilvusSchemaUtil
-}
+import com.zilliz.spark.connector.{MilvusOption, MilvusSchemaUtil}
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
 import io.milvus.storage.{
@@ -44,20 +45,22 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
-/**
- * MilvusLoonWriteTable provides write support using Storage V2 FFI
- * This table is used by MilvusLoonDataSource for write operations
- */
+/** MilvusLoonWriteTable provides write support using Storage V2 FFI This table
+  * is used by MilvusLoonDataSource for write operations
+  */
 case class MilvusLoonWriteTable(
     milvusOption: MilvusOption,
     sparkSchema: StructType
-) extends Table with SupportsWrite with Logging {
+) extends Table
+    with SupportsWrite
+    with Logging {
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
     new MilvusLoonWriteBuilder(sparkSchema, milvusOption)
   }
 
-  override def name(): String = s"MilvusLoonWrite[${milvusOption.collectionName}]"
+  override def name(): String =
+    s"MilvusLoonWrite[${milvusOption.collectionName}]"
 
   override def schema(): StructType = sparkSchema
 
@@ -68,39 +71,41 @@ case class MilvusLoonWriteTable(
   }
 }
 
-/**
- * Write builder for Storage V2
- */
+/** Write builder for Storage V2
+  */
 class MilvusLoonWriteBuilder(
     schema: StructType,
     milvusOption: MilvusOption
-) extends WriteBuilder with Logging {
+) extends WriteBuilder
+    with Logging {
 
   override def build(): Write = new MilvusLoonWrite(schema, milvusOption)
 }
 
-/**
- * Write implementation for Loon
- */
+/** Write implementation for Loon
+  */
 class MilvusLoonWrite(
     schema: StructType,
     milvusOption: MilvusOption
-) extends Write with Logging {
+) extends Write
+    with Logging {
 
   override def toBatch: BatchWrite = {
     new MilvusLoonBatchWrite(schema, milvusOption)
   }
 }
 
-/**
- * Batch write implementation for Storage V2
- */
+/** Batch write implementation for Storage V2
+  */
 class MilvusLoonBatchWrite(
     schema: StructType,
     milvusOption: MilvusOption
-) extends BatchWrite with Logging {
+) extends BatchWrite
+    with Logging {
 
-  override def createBatchWriterFactory(info: PhysicalWriteInfo): DataWriterFactory = {
+  override def createBatchWriterFactory(
+      info: PhysicalWriteInfo
+  ): DataWriterFactory = {
     new MilvusLoonWriterFactory(schema, milvusOption)
   }
 
@@ -108,7 +113,9 @@ class MilvusLoonBatchWrite(
     logInfo(s"Committed ${messages.length} partitions")
     messages.foreach {
       case msg: MilvusLoonCommitMessage =>
-        logInfo(s"Partition ${msg.partitionId} wrote ${msg.recordCount} records, manifest: ${msg.manifestPath}, version: ${msg.committedVersion}")
+        logInfo(
+          s"Partition ${msg.partitionId} wrote ${msg.recordCount} records, manifest: ${msg.manifestPath}, version: ${msg.committedVersion}"
+        )
       case _ =>
         logWarning("Unknown commit message type")
     }
@@ -120,15 +127,18 @@ class MilvusLoonBatchWrite(
   }
 }
 
-/**
- * Writer factory for creating partition writers
- */
+/** Writer factory for creating partition writers
+  */
 class MilvusLoonWriterFactory(
     schema: StructType,
     milvusOption: MilvusOption
-) extends DataWriterFactory with Serializable {
+) extends DataWriterFactory
+    with Serializable {
 
-  override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
+  override def createWriter(
+      partitionId: Int,
+      taskId: Long
+  ): DataWriter[InternalRow] = {
     new MilvusLoonPartitionWriter(
       partitionId,
       taskId,
@@ -142,11 +152,10 @@ object MilvusLoonPartitionWriter {
   @volatile private var writeInitialized: Boolean = false
   private val writeLock = new Object()
 
-  /**
-   * Ensures the first write operation is serialized to avoid race conditions
-   * in native library's S3 client initialization. Once a write succeeds,
-   * subsequent writes can run in parallel.
-   */
+  /** Ensures the first write operation is serialized to avoid race conditions
+    * in native library's S3 client initialization. Once a write succeeds,
+    * subsequent writes can run in parallel.
+    */
   def synchronizedWrite(doWrite: => Unit): Unit = {
     if (!writeInitialized) {
       writeLock.synchronized {
@@ -164,23 +173,28 @@ object MilvusLoonPartitionWriter {
   }
 }
 
-/**
- * Partition writer using Storage V2 FFI
- */
+/** Partition writer using Storage V2 FFI
+  */
 class MilvusLoonPartitionWriter(
     partitionId: Int,
     taskId: Long,
     sparkSchema: StructType,
     milvusOption: MilvusOption
-) extends DataWriter[InternalRow] with Logging {
+) extends DataWriter[InternalRow]
+    with Logging {
 
   private val allocator = new RootAllocator(Long.MaxValue)
 
   // Create Arrow schema from Spark schema
   // Note: For vector fields, pass vector dimensions via milvusOption if needed
-  private val vectorDimensions = extractVectorDimensions(sparkSchema, milvusOption)
+  private val vectorDimensions =
+    extractVectorDimensions(sparkSchema, milvusOption)
   private val fieldIds = parseFieldIds(milvusOption)
-  private val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema, vectorDimensions, fieldIds)
+  private val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(
+    sparkSchema,
+    vectorDimensions,
+    fieldIds
+  )
 
   // Create VectorSchemaRoot to accumulate batches
   // IMPORTANT: root must be var because we create a new one for each flush.
@@ -236,7 +250,9 @@ class MilvusLoonPartitionWriter(
     (w, props, schemaC)
   }
 
-  logInfo(s"Created Storage V2 writer for partition $partitionId, task $taskId, basePath: $basePath")
+  logInfo(
+    s"Created Storage V2 writer for partition $partitionId, task $taskId, basePath: $basePath"
+  )
 
   override def write(record: InternalRow): Unit = {
     // Add record to current batch
@@ -259,27 +275,41 @@ class MilvusLoonPartitionWriter(
       // Close writer and get column groups pointer
       val columnGroupsPtr = writer.close()
 
-      logInfo(s"Writer closed: partition=$partitionId, records=$totalRecordCount, columnGroupsPtr=$columnGroupsPtr")
+      logInfo(
+        s"Writer closed: partition=$partitionId, records=$totalRecordCount, columnGroupsPtr=$columnGroupsPtr"
+      )
 
       // Commit column groups to manifest using Transaction
       val transaction = new MilvusStorageTransaction()
       transaction.begin(basePath, writerProperties)
 
       // Determine commit type: ADDFIELD (1) for backfill, ADDFILES (0) for normal writes
-      val commitType = milvusOption.options.get(MilvusOption.WriterCommitType.toLowerCase) match {
-        case Some("addfield") => 1  // ADDFIELD
-        case _ => 0                 // ADDFILES (default)
+      val commitType = milvusOption.options.get(
+        MilvusOption.WriterCommitType.toLowerCase
+      ) match {
+        case Some("addfield") => 1 // ADDFIELD
+        case _                => 0 // ADDFILES (default)
       }
       val committedVersion = transaction.commit(commitType, 0, columnGroupsPtr)
       transaction.destroy()
 
       if (committedVersion < 0) {
-        throw new IllegalStateException(s"Failed to commit manifest for partition $partitionId")
+        throw new IllegalStateException(
+          s"Failed to commit manifest for partition $partitionId"
+        )
       }
 
-      logInfo(s"Manifest committed: partition=$partitionId, records=$totalRecordCount, basePath=$basePath, version=$committedVersion")
+      logInfo(
+        s"Manifest committed: partition=$partitionId, records=$totalRecordCount, basePath=$basePath, version=$committedVersion"
+      )
 
-      MilvusLoonCommitMessage(partitionId, totalRecordCount, basePath, columnGroupsPtr, committedVersion)
+      MilvusLoonCommitMessage(
+        partitionId,
+        totalRecordCount,
+        basePath,
+        columnGroupsPtr,
+        committedVersion
+      )
     } finally {
       cleanup()
     }
@@ -294,17 +324,20 @@ class MilvusLoonPartitionWriter(
     cleanup()
   }
 
-  /**
-   * Add a Spark InternalRow to the current Arrow batch
-   */
+  /** Add a Spark InternalRow to the current Arrow batch
+    */
   private def addRecordToBatch(record: InternalRow): Unit = {
-    ArrowConverter.internalRowToArrow(root, currentBatchSize, record, sparkSchema)
+    ArrowConverter.internalRowToArrow(
+      root,
+      currentBatchSize,
+      record,
+      sparkSchema
+    )
     root.setRowCount(currentBatchSize + 1)
   }
 
-  /**
-   * Flush current batch to Storage V2 writer
-   */
+  /** Flush current batch to Storage V2 writer
+    */
   private def flushBatch(): Unit = {
     if (currentBatchSize == 0) {
       return
@@ -343,9 +376,8 @@ class MilvusLoonPartitionWriter(
     }
   }
 
-  /**
-   * Allocate or reallocate vectors for the current batch
-   */
+  /** Allocate or reallocate vectors for the current batch
+    */
   private def allocateVectors(): Unit = {
     import scala.collection.JavaConverters._
     import org.apache.arrow.vector.{VarCharVector, BaseVariableWidthVector}
@@ -376,29 +408,35 @@ class MilvusLoonPartitionWriter(
     root.setRowCount(0)
   }
 
-  /**
-   * Generate S3 base path for this writer
-   *
-   * For S3FileSystem, the path format should be: bucket/root_path/...
-   * Arrow S3FileSystem expects paths in the format: bucket_name/path/to/object
-   */
+  /** Generate S3 base path for this writer
+    *
+    * For S3FileSystem, the path format should be: bucket/root_path/... Arrow
+    * S3FileSystem expects paths in the format: bucket_name/path/to/object
+    */
   private def generateBasePath(): String = {
     val timestamp = System.currentTimeMillis()
-    val collectionName = if (milvusOption.collectionName.nonEmpty) milvusOption.collectionName else "default"
-    val partitionName = if (milvusOption.partitionName.nonEmpty) milvusOption.partitionName else "default"
+    val collectionName =
+      if (milvusOption.collectionName.nonEmpty) milvusOption.collectionName
+      else "default"
+    val partitionName =
+      if (milvusOption.partitionName.nonEmpty) milvusOption.partitionName
+      else "default"
 
     // Extract S3 configuration from MilvusOption
-    val bucket = milvusOption.options.getOrElse(Properties.FsConfig.FsBucketName, "a-bucket")
-    val rootPath = milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
+    val bucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
+    )
+    val rootPath =
+      milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
 
     // Include bucket name in the path for S3FileSystem
     s"$bucket/$rootPath/spark_write/$collectionName/$partitionName/$timestamp/task_${partitionId}_$taskId"
   }
 
-  /**
-   * Extract vector dimensions from MilvusOption for vector fields
-   * Vector fields are identified as Array[Float] in Spark schema
-   */
+  /** Extract vector dimensions from MilvusOption for vector fields Vector
+    * fields are identified as Array[Float] in Spark schema
+    */
   private def extractVectorDimensions(
       schema: StructType,
       option: MilvusOption
@@ -406,50 +444,56 @@ class MilvusLoonPartitionWriter(
     // Check if vector dimensions are provided in options
     // Format: vector.field_name.dim = dimension_value
     val vectorFields = schema.fields.collect {
-      case field if field.dataType.isInstanceOf[ArrayType] &&
-                    field.dataType.asInstanceOf[ArrayType].elementType == FloatType =>
+      case field
+          if field.dataType.isInstanceOf[ArrayType] &&
+            field.dataType.asInstanceOf[ArrayType].elementType == FloatType =>
         field.name
     }
 
     vectorFields.flatMap { fieldName =>
-      option.options.get(MilvusOption.vectorDimKey(fieldName)).flatMap { dimStr =>
-        Try(dimStr.toInt).toOption.map(fieldName -> _)
+      option.options.get(MilvusOption.vectorDimKey(fieldName)).flatMap {
+        dimStr =>
+          Try(dimStr.toInt).toOption.map(fieldName -> _)
       }
     }.toMap
   }
 
-  /**
-   * Parse field ID mapping from MilvusOption
-   * Format: "field_name:field_id,field_name2:field_id2"
-   */
+  /** Parse field ID mapping from MilvusOption Format:
+    * "field_name:field_id,field_name2:field_id2"
+    */
   private def parseFieldIds(option: MilvusOption): Map[String, Long] = {
-    option.options.get(MilvusOption.WriterFieldIds.toLowerCase).map { str =>
-      str.split(",").flatMap { pair =>
-        val parts = pair.split(":", 2)
-        if (parts.length == 2) {
-          Try(parts(1).trim.toLong).toOption.map(parts(0).trim -> _)
-        } else None
-      }.toMap
-    }.getOrElse(Map.empty)
+    option.options
+      .get(MilvusOption.WriterFieldIds.toLowerCase)
+      .map { str =>
+        str
+          .split(",")
+          .flatMap { pair =>
+            val parts = pair.split(":", 2)
+            if (parts.length == 2) {
+              Try(parts(1).trim.toLong).toOption.map(parts(0).trim -> _)
+            } else None
+          }
+          .toMap
+      }
+      .getOrElse(Map.empty)
   }
 
-  /**
-   * Clean up resources
-   */
+  /** Clean up resources
+    */
   private def cleanup(): Unit = {
     Try {
       if (writer != null && writer.isValid) {
         writer.destroy()
       }
-    }.recover {
-      case e: Exception => logError(s"Error destroying writer: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error destroying writer: ${e.getMessage}")
     }
 
     // Close current root (not yet exported)
     Try {
       if (root != null) root.close()
-    }.recover {
-      case e: Exception => logError(s"Error closing VectorSchemaRoot: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error closing VectorSchemaRoot: ${e.getMessage}")
     }
 
     // Close exported roots whose buffers were referenced by C++ RecordBatches.
@@ -457,33 +501,32 @@ class MilvusLoonPartitionWriter(
     Try {
       exportedRoots.forEach(r => Try(r.close()))
       exportedRoots.clear()
-    }.recover {
-      case e: Exception => logError(s"Error closing exported roots: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error closing exported roots: ${e.getMessage}")
     }
 
     Try {
       if (arrowSchemaC != null) arrowSchemaC.close()
-    }.recover {
-      case e: Exception => logError(s"Error closing ArrowSchema: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error closing ArrowSchema: ${e.getMessage}")
     }
 
     Try {
       if (writerProperties != null) writerProperties.free()
-    }.recover {
-      case e: Exception => logError(s"Error freeing properties: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error freeing properties: ${e.getMessage}")
     }
 
     Try {
       if (allocator != null) allocator.close()
-    }.recover {
-      case e: Exception => logError(s"Error closing allocator: ${e.getMessage}")
+    }.recover { case e: Exception =>
+      logError(s"Error closing allocator: ${e.getMessage}")
     }
   }
 }
 
-/**
- * Commit message containing write metadata
- */
+/** Commit message containing write metadata
+  */
 case class MilvusLoonCommitMessage(
     partitionId: Int,
     recordCount: Long,
@@ -492,29 +535,28 @@ case class MilvusLoonCommitMessage(
     committedVersion: Long
 ) extends WriterCommitMessage
 
-/**
- * Helper object for DataFrame write operations
- */
+/** Helper object for DataFrame write operations
+  */
 object MilvusLoonWriter extends Logging {
 
-  /**
-   * Write a DataFrame to S3 using Storage V2 format (FFI)
-   * This method writes directly to S3 without connecting to Milvus
-   *
-   * @param df DataFrame to write
-   * @param options S3 configuration and write options
-   *                Required options:
-   *                - fs.endpoint or fs.address: S3 endpoint (e.g., "localhost:9000")
-   *                - fs.bucket_name: S3 bucket name
-   *                - fs.access_key_id: S3 access key
-   *                - fs.access_key_value: S3 secret key
-   *                - fs.use_ssl: "true" or "false"
-   *                Optional:
-   *                - fs.root_path: Root path in bucket (default: "files")
-   *                - milvus.collection.name: Collection name for path generation
-   *                - vector.{field_name}.dim: Vector dimension for float array fields
-   * @return Try containing manifest paths on success
-   */
+  /** Write a DataFrame to S3 using Storage V2 format (FFI) This method writes
+    * directly to S3 without connecting to Milvus
+    *
+    * @param df
+    *   DataFrame to write
+    * @param options
+    *   S3 configuration and write options Required options:
+    *   - fs.endpoint or fs.address: S3 endpoint (e.g., "localhost:9000")
+    *   - fs.bucket_name: S3 bucket name
+    *   - fs.access_key_id: S3 access key
+    *   - fs.access_key_value: S3 secret key
+    *   - fs.use_ssl: "true" or "false" Optional:
+    *   - fs.root_path: Root path in bucket (default: "files")
+    *   - milvus.collection.name: Collection name for path generation
+    *   - vector.{field_name}.dim: Vector dimension for float array fields
+    * @return
+    *   Try containing manifest paths on success
+    */
   def writeDataFrame(
       df: DataFrame,
       options: Map[String, String]
@@ -536,9 +578,8 @@ object MilvusLoonWriter extends Logging {
     }
   }
 
-  /**
-   * Internal method to write using Storage V2 API
-   */
+  /** Internal method to write using Storage V2 API
+    */
   private def writeWithLoon(
       df: DataFrame,
       milvusOption: MilvusOption
@@ -551,30 +592,33 @@ object MilvusLoonWriter extends Logging {
     val writerFactory = batchWrite.createBatchWriterFactory(null)
 
     // Execute write on each partition using queryExecution to get InternalRow
-    val messages = df.queryExecution.toRdd.mapPartitionsWithIndex { (partitionId, rows) =>
-      val writer = writerFactory.createWriter(partitionId, System.currentTimeMillis())
+    val messages = df.queryExecution.toRdd
+      .mapPartitionsWithIndex { (partitionId, rows) =>
+        val writer =
+          writerFactory.createWriter(partitionId, System.currentTimeMillis())
 
-      try {
-        rows.foreach { row =>
-          writer.write(row)
+        try {
+          rows.foreach { row =>
+            writer.write(row)
+          }
+          val commitMessage = writer.commit()
+          Iterator(commitMessage)
+        } catch {
+          case e: Exception =>
+            writer.abort()
+            throw e
+        } finally {
+          writer.close()
         }
-        val commitMessage = writer.commit()
-        Iterator(commitMessage)
-      } catch {
-        case e: Exception =>
-          writer.abort()
-          throw e
-      } finally {
-        writer.close()
       }
-    }.collect()
+      .collect()
 
     // Commit all partitions
     batchWrite.commit(messages)
 
     // Extract manifest paths
-    messages.collect {
-      case msg: MilvusLoonCommitMessage => msg.manifestPath
+    messages.collect { case msg: MilvusLoonCommitMessage =>
+      msg.manifestPath
     }.toSeq
   }
 }

--- a/src/main/scala/write/MilvusWriteBuilder.scala
+++ b/src/main/scala/write/MilvusWriteBuilder.scala
@@ -1,6 +1,10 @@
 package com.zilliz.spark.connector.write
 
-import org.apache.spark.sql.connector.write.{LogicalWriteInfo, Write, WriteBuilder}
+import org.apache.spark.sql.connector.write.{
+  LogicalWriteInfo,
+  Write,
+  WriteBuilder
+}
 
 import com.zilliz.spark.connector.MilvusOption
 

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -3,9 +3,8 @@ package com.zilliz.spark.connector
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-/**
- * Unit tests for MilvusOption parsing and validation
- */
+/** Unit tests for MilvusOption parsing and validation
+  */
 class MilvusOptionTest extends AnyFunSuite with Matchers {
 
   test("Parse basic options with default values") {
@@ -129,7 +128,7 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     milvusOption.vectorSearchConfig shouldBe defined
     val config = milvusOption.vectorSearchConfig.get
-    config.metricType shouldBe "COSINE"  // Should be uppercase
+    config.metricType shouldBe "COSINE" // Should be uppercase
   }
 
   test("Vector search config is None when query vector is missing") {
@@ -165,8 +164,8 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     milvusOption.vectorSearchConfig shouldBe defined
     val config = milvusOption.vectorSearchConfig.get
-    config.metricType shouldBe "L2"  // Default metric
-    config.vectorColumn shouldBe "vector"  // Default column name
+    config.metricType shouldBe "L2" // Default metric
+    config.vectorColumn shouldBe "vector" // Default column name
   }
 
   test("isInt64PK returns true for int64 type") {
@@ -217,18 +216,19 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
   }
 }
 
-/**
- * Unit tests for MilvusS3Option
- */
+/** Unit tests for MilvusS3Option
+  */
 class MilvusS3OptionTest extends AnyFunSuite with Matchers {
 
   test("Parse S3 options with default values") {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-    val options = new CaseInsensitiveStringMap(Map(
-      MilvusOption.ReaderType -> "insert"
-    ).asJava)
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert"
+      ).asJava
+    )
 
     val s3Option = MilvusS3Option(options)
 
@@ -248,19 +248,21 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-    val options = new CaseInsensitiveStringMap(Map(
-      MilvusOption.ReaderType -> "insert",
-      MilvusOption.S3FileSystemTypeName -> "s3a://",
-      MilvusOption.S3BucketName -> "my-bucket",
-      MilvusOption.S3RootPath -> "data/milvus",
-      MilvusOption.S3Endpoint -> "s3.amazonaws.com",
-      MilvusOption.S3AccessKey -> "AKIAIOSFODNN7EXAMPLE",
-      MilvusOption.S3SecretKey -> "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-      MilvusOption.S3UseSSL -> "true",
-      MilvusOption.S3PathStyleAccess -> "false",
-      MilvusOption.S3MaxConnections -> "64",
-      MilvusOption.S3PreloadPoolSize -> "8"
-    ).asJava)
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert",
+        MilvusOption.S3FileSystemTypeName -> "s3a://",
+        MilvusOption.S3BucketName -> "my-bucket",
+        MilvusOption.S3RootPath -> "data/milvus",
+        MilvusOption.S3Endpoint -> "s3.amazonaws.com",
+        MilvusOption.S3AccessKey -> "AKIAIOSFODNN7EXAMPLE",
+        MilvusOption.S3SecretKey -> "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        MilvusOption.S3UseSSL -> "true",
+        MilvusOption.S3PathStyleAccess -> "false",
+        MilvusOption.S3MaxConnections -> "64",
+        MilvusOption.S3PreloadPoolSize -> "8"
+      ).asJava
+    )
 
     val s3Option = MilvusS3Option(options)
 
@@ -280,9 +282,11 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-    val options = new CaseInsensitiveStringMap(Map(
-      MilvusOption.ReaderType -> "insert"
-    ).asJava)
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert"
+      ).asJava
+    )
 
     val s3Option = MilvusS3Option(options)
 
@@ -297,12 +301,14 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-    val options = new CaseInsensitiveStringMap(Map(
-      MilvusOption.ReaderType -> "insert",
-      MilvusOption.S3FileSystemTypeName -> "s3a://",
-      MilvusOption.S3BucketName -> "test-bucket",
-      MilvusOption.S3RootPath -> "files"
-    ).asJava)
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert",
+        MilvusOption.S3FileSystemTypeName -> "s3a://",
+        MilvusOption.S3BucketName -> "test-bucket",
+        MilvusOption.S3RootPath -> "files"
+      ).asJava
+    )
 
     val s3Option = MilvusS3Option(options)
 
@@ -319,17 +325,19 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-    val options = new CaseInsensitiveStringMap(Map(
-      MilvusOption.ReaderType -> "insert",
-      MilvusOption.S3FileSystemTypeName -> "s3a://",
-      MilvusOption.S3BucketName -> "test-bucket",
-      MilvusOption.S3Endpoint -> "localhost:9000",
-      MilvusOption.S3AccessKey -> "test-key",
-      MilvusOption.S3SecretKey -> "test-secret",
-      MilvusOption.S3UseSSL -> "false",
-      MilvusOption.S3PathStyleAccess -> "true",
-      MilvusOption.S3MaxConnections -> "16"
-    ).asJava)
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert",
+        MilvusOption.S3FileSystemTypeName -> "s3a://",
+        MilvusOption.S3BucketName -> "test-bucket",
+        MilvusOption.S3Endpoint -> "localhost:9000",
+        MilvusOption.S3AccessKey -> "test-key",
+        MilvusOption.S3SecretKey -> "test-secret",
+        MilvusOption.S3UseSSL -> "false",
+        MilvusOption.S3PathStyleAccess -> "true",
+        MilvusOption.S3MaxConnections -> "16"
+      ).asJava
+    )
 
     val s3Option = MilvusS3Option(options)
     val conf = s3Option.getConf()

--- a/src/test/scala/filter/VectorBruteForceSearchTest.scala
+++ b/src/test/scala/filter/VectorBruteForceSearchTest.scala
@@ -1,14 +1,13 @@
 package com.zilliz.spark.connector.filter
 
+import org.apache.spark.ml.linalg.{DenseVector, Vectors}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.apache.spark.ml.linalg.{DenseVector, Vectors}
 
 import VectorBruteForceSearch.DistanceType._
 
-/**
- * Unit tests for VectorBruteForceSearch distance calculations
- */
+/** Unit tests for VectorBruteForceSearch distance calculations
+  */
 class VectorBruteForceSearchTest extends AnyFunSuite with Matchers {
 
   // Tolerance for floating point comparisons
@@ -174,7 +173,7 @@ class VectorBruteForceSearchTest extends AnyFunSuite with Matchers {
 
     l2 shouldBe 2.0 +- epsilon
     ip shouldBe 15.0 +- epsilon
-    cosine shouldBe 1.0 +- epsilon  // Same direction, magnitude doesn't matter
+    cosine shouldBe 1.0 +- epsilon // Same direction, magnitude doesn't matter
   }
 
   test("Distance calculation with high dimensional vectors") {
@@ -268,7 +267,8 @@ class VectorBruteForceSearchTest extends AnyFunSuite with Matchers {
 
     for (v1 <- vectors; v2 <- vectors) {
       if (Vectors.norm(v1, 2.0) > 0 && Vectors.norm(v2, 2.0) > 0) {
-        val similarity = VectorBruteForceSearch.calculateDistance(v1, v2, COSINE)
+        val similarity =
+          VectorBruteForceSearch.calculateDistance(v1, v2, COSINE)
         similarity should be >= -1.0 - epsilon
         similarity should be <= 1.0 + epsilon
       }

--- a/src/test/scala/loon/MilvusLoonWriterTest.scala
+++ b/src/test/scala/loon/MilvusLoonWriterTest.scala
@@ -1,16 +1,19 @@
 package com.zilliz.spark.connector.loon
 
+import scala.util.{Failure, Success}
+
 import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import com.zilliz.spark.connector.MilvusOption
+
 import com.zilliz.spark.connector.write.MilvusLoonWriter
-import scala.util.{Success, Failure}
+import com.zilliz.spark.connector.MilvusOption
 
 class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
 
   test("Write DataFrame using Loon Writer to Minio") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("LoonWriterMinioTest")
       .master("local[*]")
       .getOrCreate()
@@ -56,7 +59,8 @@ class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
   }
 
   test("Write DataFrame with vector field to Minio") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("StorageV2VectorWriterTest")
       .master("local[*]")
       .getOrCreate()
@@ -82,7 +86,7 @@ class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
         Properties.FsConfig.FsUseSSL -> "false",
         Properties.FsConfig.FsRegion -> "us-east-1",
         MilvusOption.MilvusCollectionName -> "vector_test_collection",
-        "vector.vector.dim" -> "4"  // Specify vector dimension
+        "vector.vector.dim" -> "4" // Specify vector dimension
       )
 
       // Write using MilvusLoonWriter API
@@ -90,7 +94,9 @@ class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
 
       result match {
         case Success(manifestPaths) =>
-          info(s"Successfully wrote ${testData.count()} rows with vectors to Minio")
+          info(
+            s"Successfully wrote ${testData.count()} rows with vectors to Minio"
+          )
           info(s"Manifest paths: ${manifestPaths.mkString(", ")}")
           manifestPaths should not be empty
         case Failure(exception) =>
@@ -102,4 +108,3 @@ class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
     }
   }
 }
-

--- a/src/test/scala/loon/MilvusStorageFFITest.scala
+++ b/src/test/scala/loon/MilvusStorageFFITest.scala
@@ -1,25 +1,36 @@
 package com.zilliz.spark.connector.loon
 
-import io.milvus.storage._
-import org.apache.arrow.c.{ArrowArray, ArrowArrayStream, ArrowSchema => CArrowSchema, Data}
-import org.apache.arrow.vector._
-import org.apache.arrow.vector.ipc.ArrowReader
-import org.apache.arrow.vector.complex.ListVector
-import org.apache.arrow.vector.types.pojo.{ArrowType, Field => ArrowField, FieldType, Schema => ArrowSchema}
-import java.util.{HashMap => JHashMap}
 import java.io.File
 import java.nio.file.{Files, Path}
+import java.util.{HashMap => JHashMap}
 import scala.collection.JavaConverters._
+
+import org.apache.arrow.c.{
+  ArrowArray,
+  ArrowArrayStream,
+  ArrowSchema => CArrowSchema,
+  Data
+}
+import org.apache.arrow.vector._
+import org.apache.arrow.vector.complex.ListVector
+import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.types.pojo.{
+  ArrowType,
+  Field => ArrowField,
+  FieldType,
+  Schema => ArrowSchema
+}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-/**
- * Milvus Storage FFI Test Suite (No Spark)
- *
- * This test demonstrates writing and reading Milvus storage data without Spark.
- * It uses MilvusStorageWriter to write data, then passes the column groups to reader.
- *
- */
+import io.milvus.storage._
+
+/** Milvus Storage FFI Test Suite (No Spark)
+  *
+  * This test demonstrates writing and reading Milvus storage data without
+  * Spark. It uses MilvusStorageWriter to write data, then passes the column
+  * groups to reader.
+  */
 class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
   test("Write and Read Milvus Storage data using FFI (No Spark)") {
@@ -55,13 +66,18 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
       // Create writer
       val writer = new MilvusStorageWriter()
-      writer.create(tempDir.toAbsolutePath.toString, writerSchemaPtr, properties)
+      writer.create(
+        tempDir.toAbsolutePath.toString,
+        writerSchemaPtr,
+        properties
+      )
       info("✓ Writer created\n")
 
       // Create and write test data
       val numRows = 100
       val vectorDim = 4
-      val (root, arrowArray, arrowArrayPtr) = createTestData(allocator, numRows, vectorDim)
+      val (root, arrowArray, arrowArrayPtr) =
+        createTestData(allocator, numRows, vectorDim)
 
       try {
         writer.write(arrowArrayPtr)
@@ -86,7 +102,12 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
         // Create reader with column groups from writer
         val reader = new MilvusStorageReader()
-        reader.create(columnGroupsPtr, readerSchemaPtr, neededColumns, properties)
+        reader.create(
+          columnGroupsPtr,
+          readerSchemaPtr,
+          neededColumns,
+          properties
+        )
         info("✓ Reader created\n")
 
         // Read data using Arrow C Data Interface
@@ -107,7 +128,9 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
               totalRows += rows
             }
 
-            info(s"\nSuccessfully read $totalRows rows in $batchCount batch(es)\n")
+            info(
+              s"\nSuccessfully read $totalRows rows in $batchCount batch(es)\n"
+            )
 
             totalRows should be(numRows)
             batchCount should be > 0
@@ -138,9 +161,8 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
     }
   }
 
-  /**
-  * Recursively delete a directory
-  */
+  /** Recursively delete a directory
+    */
   private def deleteDirectory(dir: File): Unit = {
     if (dir.exists()) {
       if (dir.isDirectory) {
@@ -150,23 +172,59 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
     }
   }
 
-  /**
-   * Create test data and return VectorSchemaRoot, ArrowArray object and its pointer
-   * Returns the ArrowArray object so it can be properly closed later
-   */
-  private def createTestData(allocator: org.apache.arrow.memory.BufferAllocator, numRows: Int, vectorDim: Int): (VectorSchemaRoot, ArrowArray, Long) = {
+  /** Create test data and return VectorSchemaRoot, ArrowArray object and its
+    * pointer Returns the ArrowArray object so it can be properly closed later
+    */
+  private def createTestData(
+      allocator: org.apache.arrow.memory.BufferAllocator,
+      numRows: Int,
+      vectorDim: Int
+  ): (VectorSchemaRoot, ArrowArray, Long) = {
     val metadata0 = Map("PARQUET:field_id" -> "100").asJava
     val metadata1 = Map("PARQUET:field_id" -> "101").asJava
     val metadata2 = Map("PARQUET:field_id" -> "102").asJava
     val metadata3 = Map("PARQUET:field_id" -> "103").asJava
 
     val fields = List(
-      new ArrowField("id", new FieldType(false, new ArrowType.Int(64, true), null, metadata0), null),
-      new ArrowField("name", new FieldType(false, new ArrowType.Utf8(), null, metadata1), null),
-      new ArrowField("value", new FieldType(false, new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE), null, metadata2), null),
-      new ArrowField("vector",
+      new ArrowField(
+        "id",
+        new FieldType(false, new ArrowType.Int(64, true), null, metadata0),
+        null
+      ),
+      new ArrowField(
+        "name",
+        new FieldType(false, new ArrowType.Utf8(), null, metadata1),
+        null
+      ),
+      new ArrowField(
+        "value",
+        new FieldType(
+          false,
+          new ArrowType.FloatingPoint(
+            org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE
+          ),
+          null,
+          metadata2
+        ),
+        null
+      ),
+      new ArrowField(
+        "vector",
         new FieldType(false, new ArrowType.List(), null, metadata3),
-        List(new ArrowField("element", new FieldType(false, new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE), null), null)).asJava)
+        List(
+          new ArrowField(
+            "element",
+            new FieldType(
+              false,
+              new ArrowType.FloatingPoint(
+                org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE
+              ),
+              null
+            ),
+            null
+          )
+        ).asJava
+      )
     ).asJava
 
     val schema = new ArrowSchema(fields)
@@ -209,10 +267,9 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
     (root, arrowArray, arrowArray.memoryAddress())
   }
 
-  /**
-   * Create test schema matching the test data
-   * Returns both the CArrowSchema object and its memory address for proper cleanup
-   */
+  /** Create test schema matching the test data Returns both the CArrowSchema
+    * object and its memory address for proper cleanup
+    */
   private def createTestSchema(): (CArrowSchema, Long) = {
     val allocator = ArrowUtils.getAllocator
 
@@ -224,15 +281,50 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
     // Define fields matching the test data
     // Schema from C++ test: id (int64), name (utf8), value (double), vector (list<float>)
     val fields = List(
-      new ArrowField("id", new FieldType(false, new ArrowType.Int(64, true), null, metadata0), null),
-      new ArrowField("name", new FieldType(false, new ArrowType.Utf8(), null, metadata1), null),
-      new ArrowField("value", new FieldType(false, new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE), null, metadata2), null),
-      new ArrowField("vector",
-        new FieldType(false,
+      new ArrowField(
+        "id",
+        new FieldType(false, new ArrowType.Int(64, true), null, metadata0),
+        null
+      ),
+      new ArrowField(
+        "name",
+        new FieldType(false, new ArrowType.Utf8(), null, metadata1),
+        null
+      ),
+      new ArrowField(
+        "value",
+        new FieldType(
+          false,
+          new ArrowType.FloatingPoint(
+            org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE
+          ),
+          null,
+          metadata2
+        ),
+        null
+      ),
+      new ArrowField(
+        "vector",
+        new FieldType(
+          false,
           new ArrowType.List(), // Variable-length list
           null,
-          metadata3),
-        List(new ArrowField("element", new FieldType(false, new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE), null), null)).asJava)
+          metadata3
+        ),
+        List(
+          new ArrowField(
+            "element",
+            new FieldType(
+              false,
+              new ArrowType.FloatingPoint(
+                org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE
+              ),
+              null
+            ),
+            null
+          )
+        ).asJava
+      )
     ).asJava
 
     val schema = new ArrowSchema(fields)
@@ -242,9 +334,8 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
     (arrowSchema, arrowSchema.memoryAddress())
   }
 
-  /**
-   * Display data from VectorSchemaRoot
-   */
+  /** Display data from VectorSchemaRoot
+    */
   private def displayBatchData(root: VectorSchemaRoot, batchNum: Int): Int = {
     try {
       val rowCount = root.getRowCount
@@ -254,7 +345,9 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
       val idVector = root.getVector("id").asInstanceOf[BigIntVector]
       val nameVector = root.getVector("name").asInstanceOf[VarCharVector]
       val valueVector = root.getVector("value").asInstanceOf[Float8Vector]
-      val vectorListVector = root.getVector("vector").asInstanceOf[org.apache.arrow.vector.complex.ListVector]
+      val vectorListVector = root
+        .getVector("vector")
+        .asInstanceOf[org.apache.arrow.vector.complex.ListVector]
 
       // Display first few rows
       val displayCount = Math.min(10, rowCount)
@@ -263,12 +356,16 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
       for (i <- 0 until displayCount) {
         val id = if (!idVector.isNull(i)) idVector.get(i).toString else "null"
-        val name = if (!nameVector.isNull(i)) new String(nameVector.get(i), "UTF-8") else "null"
-        val value = if (!valueVector.isNull(i)) f"${valueVector.get(i)}%.1f" else "null"
+        val name =
+          if (!nameVector.isNull(i)) new String(nameVector.get(i), "UTF-8")
+          else "null"
+        val value =
+          if (!valueVector.isNull(i)) f"${valueVector.get(i)}%.1f" else "null"
 
         // Extract vector elements (variable-length list)
         val vectorStr = if (!vectorListVector.isNull(i)) {
-          val vectorSlice = vectorListVector.getObject(i).asInstanceOf[java.util.List[Float]]
+          val vectorSlice =
+            vectorListVector.getObject(i).asInstanceOf[java.util.List[Float]]
           vectorSlice.asScala.map(v => f"$v%.1f").mkString("[", ", ", "]")
         } else {
           "null"

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -5,9 +5,8 @@ import org.scalatest.matchers.should.Matchers
 
 import com.zilliz.spark.connector.MilvusOption
 
-/**
- * Unit tests for Properties and FsConfig constants
- */
+/** Unit tests for Properties and FsConfig constants
+  */
 class PropertiesTest extends AnyFunSuite with Matchers {
 
   // ============ FsConfig Constants Tests ============
@@ -104,10 +103,16 @@ class PropertiesTest extends AnyFunSuite with Matchers {
 
     val milvusOption = MilvusOption(options)
 
-    milvusOption.options(Properties.FsConfig.FsAddress) shouldBe "localhost:9000"
-    milvusOption.options(Properties.FsConfig.FsBucketName) shouldBe "test-bucket"
+    milvusOption.options(
+      Properties.FsConfig.FsAddress
+    ) shouldBe "localhost:9000"
+    milvusOption.options(
+      Properties.FsConfig.FsBucketName
+    ) shouldBe "test-bucket"
     milvusOption.options(Properties.FsConfig.FsAccessKeyId) shouldBe "access123"
-    milvusOption.options(Properties.FsConfig.FsAccessKeyValue) shouldBe "secret456"
+    milvusOption.options(
+      Properties.FsConfig.FsAccessKeyValue
+    ) shouldBe "secret456"
     milvusOption.options(Properties.FsConfig.FsRootPath) shouldBe "data/milvus"
     milvusOption.options(Properties.FsConfig.FsUseSSL) shouldBe "true"
     milvusOption.options(Properties.FsConfig.FsRegion) shouldBe "us-west-2"
@@ -139,7 +144,9 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     milvusOption.options(Properties.FsConfig.FsLogLevel) shouldBe "info"
     milvusOption.options(Properties.FsConfig.FsUseIam) shouldBe "true"
     milvusOption.options(Properties.FsConfig.FsUseVirtualHost) shouldBe "true"
-    milvusOption.options(Properties.FsConfig.FsRequestTimeoutMs) shouldBe "30000"
+    milvusOption.options(
+      Properties.FsConfig.FsRequestTimeoutMs
+    ) shouldBe "30000"
   }
 
   test("MilvusOption handles GCP specific FsConfig options") {
@@ -158,8 +165,12 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     val milvusOption = MilvusOption(options)
 
     milvusOption.options(Properties.FsConfig.FsCloudProvider) shouldBe "gcp"
-    milvusOption.options(Properties.FsConfig.FsGcpNativeWithoutAuth) shouldBe "false"
-    milvusOption.options(Properties.FsConfig.FsGcpCredentialJson) should include("service_account")
+    milvusOption.options(
+      Properties.FsConfig.FsGcpNativeWithoutAuth
+    ) shouldBe "false"
+    milvusOption.options(
+      Properties.FsConfig.FsGcpCredentialJson
+    ) should include("service_account")
   }
 
   // ============ Consistency Tests ============

--- a/src/test/scala/operations/backfill/MilvusBackfillTest.scala
+++ b/src/test/scala/operations/backfill/MilvusBackfillTest.scala
@@ -1,28 +1,32 @@
 package com.zilliz.spark.connector.operations.backfill
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.BeforeAndAfterAll
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions._
-import scala.util.Random
+import java.io.File
 import scala.sys.process._
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
+import scala.util.Random
 
-import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusFieldData, MilvusOption}
-import com.zilliz.spark.connector.loon.Properties
-import io.milvus.grpc.schema.DataType
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
 
-import java.io.File
+import com.zilliz.spark.connector.{
+  MilvusClient,
+  MilvusConnectionParams,
+  MilvusFieldData,
+  MilvusOption
+}
+import com.zilliz.spark.connector.loon.Properties
+import io.milvus.grpc.schema.DataType
 
-/**
- * Integration test for MilvusBackfill operation
- *
- * Prerequisites:
- * - Milvus 2.6+ running at localhost:19530
- * - Minio running at localhost:9000
- */
+/** Integration test for MilvusBackfill operation
+  *
+  * Prerequisites:
+  *   - Milvus 2.6+ running at localhost:19530
+  *   - Minio running at localhost:9000
+  */
 class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
 
   var spark: SparkSession = _
@@ -41,7 +45,8 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     // Initialize Spark
-    spark = SparkSession.builder()
+    spark = SparkSession
+      .builder()
       .appName("MilvusDataSourceTest")
       .master("local[*]")
       .getOrCreate()
@@ -73,13 +78,17 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
     }
   }
 
-  /**
-   * Create a snapshot using Python script (pymilvus has snapshot API, milvus-proto doesn't yet)
-   * Returns the S3 location path
-   */
-  private def createSnapshotViaPython(collectionName: String, snapshotName: String, description: String = ""): String = {
+  /** Create a snapshot using Python script (pymilvus has snapshot API,
+    * milvus-proto doesn't yet) Returns the S3 location path
+    */
+  private def createSnapshotViaPython(
+      collectionName: String,
+      snapshotName: String,
+      description: String = ""
+  ): String = {
     val scriptPath = new File("scripts/create_snapshot.py").getAbsolutePath
-    val cmd = Seq("python3", scriptPath, collectionName, snapshotName, description)
+    val cmd =
+      Seq("python3", scriptPath, collectionName, snapshotName, description)
 
     info(s"Creating snapshot via Python: $cmd")
 
@@ -89,7 +98,9 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
     val result = mapper.readValue(output, classOf[Map[String, Any]])
 
     if (result.contains("error")) {
-      throw new RuntimeException(s"Failed to create snapshot: ${result("error")}")
+      throw new RuntimeException(
+        s"Failed to create snapshot: ${result("error")}"
+      )
     }
 
     val s3Location = result("s3_location").toString
@@ -99,13 +110,13 @@ class MilvusBackfillTest extends AnyFunSuite with BeforeAndAfterAll {
     s"s3a://$s3Bucket/$s3Location"
   }
 
-  /**
-   * Drop snapshot using Python script
-   */
+  /** Drop snapshot using Python script
+    */
   private def dropSnapshotViaPython(snapshotName: String): Unit = {
     Try {
       val cmd = Seq(
-        "python3", "-c",
+        "python3",
+        "-c",
         s"""
 from pymilvus import MilvusClient
 client = MilvusClient(uri='http://localhost:19530', token='root:Milvus')
@@ -116,7 +127,8 @@ print('Snapshot dropped')
       cmd.!!
     } match {
       case Success(_) => info(s"Snapshot $snapshotName dropped")
-      case Failure(e) => info(s"Failed to drop snapshot $snapshotName: ${e.getMessage}")
+      case Failure(e) =>
+        info(s"Failed to drop snapshot $snapshotName: ${e.getMessage}")
     }
   }
 
@@ -139,9 +151,15 @@ print('Snapshot dropped')
     info(s"\n=== Test Setup ===")
     info(s"Total records in collection: $totalRecords")
     info(s"Backfill data distribution:")
-    info(s"  Records 0-${firstRangeEnd-1}: Has backfill data ($firstRangeEnd rows)")
-    info(s"  Records $nullRangeStart-${nullRangeEnd-1}: NO backfill data - will be NULL ($expectedNullRecords rows)")
-    info(s"  Records $lastRangeStart-${totalRecords-1}: Has backfill data (${totalRecords - lastRangeStart} rows)")
+    info(
+      s"  Records 0-${firstRangeEnd - 1}: Has backfill data ($firstRangeEnd rows)"
+    )
+    info(
+      s"  Records $nullRangeStart-${nullRangeEnd - 1}: NO backfill data - will be NULL ($expectedNullRecords rows)"
+    )
+    info(
+      s"  Records $lastRangeStart-${totalRecords - 1}: Has backfill data (${totalRecords - lastRangeStart} rows)"
+    )
     info(s"Total records with data: $recordsWithData")
     info(s"Total records with NULL: $expectedNullRecords")
 
@@ -152,10 +170,14 @@ print('Snapshot dropped')
       (i.toLong, s"api_new_value_$i", i * 2)
     }
 
-    val addFieldDF = spark.createDataFrame(addFieldData).toDF("pk", "new_field1", "new_field2")
+    val addFieldDF =
+      spark.createDataFrame(addFieldData).toDF("pk", "new_field1", "new_field2")
 
     val tempDir = new File(System.getProperty("java.io.tmpdir"))
-    val parquetPath = new File(tempDir, s"new_field_data_${System.currentTimeMillis()}.parquet").getAbsolutePath
+    val parquetPath = new File(
+      tempDir,
+      s"new_field_data_${System.currentTimeMillis()}.parquet"
+    ).getAbsolutePath
     addFieldDF.write.mode("overwrite").parquet(parquetPath)
     addFieldDF.show(10, truncate = false)
 
@@ -204,19 +226,31 @@ print('Snapshot dropped')
 
           info("\n  Per-Segment Results ===")
           var totalRowsProcessed = 0L
-          success.segmentResults.toSeq.sortBy(_._1).foreach { case (segmentId, segResult) =>
-            info(s"  Segment $segmentId:")
-            info(s"    Rows: ${segResult.rowCount}")
-            info(s"    Execution time: ${segResult.executionTimeMs}ms")
-            info(s"    Output path: ${segResult.outputPath}")
-            info(s"    Manifest paths: ${segResult.manifestPaths.mkString(", ")}")
-            totalRowsProcessed += segResult.rowCount
+          success.segmentResults.toSeq.sortBy(_._1).foreach {
+            case (segmentId, segResult) =>
+              info(s"  Segment $segmentId:")
+              info(s"    Rows: ${segResult.rowCount}")
+              info(s"    Execution time: ${segResult.executionTimeMs}ms")
+              info(s"    Output path: ${segResult.outputPath}")
+              info(
+                s"    Manifest paths: ${segResult.manifestPaths.mkString(", ")}"
+              )
+              totalRowsProcessed += segResult.rowCount
           }
 
           // Assertions
-          assert(success.segmentResults.nonEmpty, "Should process at least one segment")
-          assert(success.newFieldNames.contains("new_field1"), "Should contain new_field1")
-          assert(success.newFieldNames.contains("new_field2"), "Should contain new_field2")
+          assert(
+            success.segmentResults.nonEmpty,
+            "Should process at least one segment"
+          )
+          assert(
+            success.newFieldNames.contains("new_field1"),
+            "Should contain new_field1"
+          )
+          assert(
+            success.newFieldNames.contains("new_field2"),
+            "Should contain new_field2"
+          )
 
           // Verify all rows were processed (including those with nulls)
           info(s"\n=== Null Handling Verification ===")
@@ -225,12 +259,18 @@ print('Snapshot dropped')
           info(s"  Rows with backfill data (joined): $recordsWithData")
           info(s"  Expected rows with nulls (un-joined): $expectedNullRecords")
 
-          assert(totalRowsProcessed == totalRecords,
-            s"Should process ALL rows including un-joined ones. Expected: $totalRecords, Got: $totalRowsProcessed")
+          assert(
+            totalRowsProcessed == totalRecords,
+            s"Should process ALL rows including un-joined ones. Expected: $totalRecords, Got: $totalRowsProcessed"
+          )
 
           info(s"All $totalRecords rows were processed")
-          info(s"This includes $recordsWithData rows with backfill data and $expectedNullRecords rows with NULL values")
-          info(s"NULL gap in middle range ($nullRangeStart-${nullRangeEnd-1}) handled correctly")
+          info(
+            s"This includes $recordsWithData rows with backfill data and $expectedNullRecords rows with NULL values"
+          )
+          info(
+            s"NULL gap in middle range ($nullRangeStart-${nullRangeEnd - 1}) handled correctly"
+          )
 
         case Left(error) =>
           fail(s"Backfill API failed: ${error.message}")
@@ -256,11 +296,28 @@ print('Snapshot dropped')
     milvusClient.dropCollection("", collectionName)
 
     val fields = List(
-      milvusClient.createCollectionField("id", isPrimary = true, dataType = DataType.Int64, autoID = false),
-      milvusClient.createCollectionField("int64", dataType = DataType.Int64, isClusteringKey = true),
+      milvusClient.createCollectionField(
+        "id",
+        isPrimary = true,
+        dataType = DataType.Int64,
+        autoID = false
+      ),
+      milvusClient.createCollectionField(
+        "int64",
+        dataType = DataType.Int64,
+        isClusteringKey = true
+      ),
       milvusClient.createCollectionField("float", dataType = DataType.Float),
-      milvusClient.createCollectionField("varchar", dataType = DataType.VarChar, typeParams = Map("max_length" -> "1024")),
-      milvusClient.createCollectionField("vector", dataType = DataType.FloatVector, typeParams = Map("dim" -> dim.toString))
+      milvusClient.createCollectionField(
+        "varchar",
+        dataType = DataType.VarChar,
+        typeParams = Map("max_length" -> "1024")
+      ),
+      milvusClient.createCollectionField(
+        "vector",
+        dataType = DataType.FloatVector,
+        typeParams = Map("dim" -> dim.toString)
+      )
     )
 
     val schema = milvusClient.createCollectionSchema(
@@ -279,10 +336,11 @@ print('Snapshot dropped')
       val idData = (0 until batchSize).map(j => (i * batchSize + j).toLong)
       val int64Data = (0 until batchSize).map(j => j.toLong)
       val floatData = (0 until batchSize).map(_ => random.nextFloat())
-      val varcharData = (0 until batchSize).map(j =>
-        s"test_string_${i * batchSize + j}")
+      val varcharData =
+        (0 until batchSize).map(j => s"test_string_${i * batchSize + j}")
       val vectorData = (0 until batchSize).map(_ =>
-        (0 until dim).map(_ => random.nextFloat()).toSeq)
+        (0 until dim).map(_ => random.nextFloat()).toSeq
+      )
 
       val fieldsData = Seq(
         MilvusFieldData.packInt64FieldData("id", idData),
@@ -292,7 +350,12 @@ print('Snapshot dropped')
         MilvusFieldData.packFloatVectorFieldData("vector", vectorData, dim)
       )
 
-      milvusClient.insert("", collectionName, fieldsData = fieldsData, numRows = batchSize)
+      milvusClient.insert(
+        "",
+        collectionName,
+        fieldsData = fieldsData,
+        numRows = batchSize
+      )
     }
 
     // Flush to ensure data is persisted

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -3,15 +3,15 @@ package com.zilliz.spark.connector.read
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-/**
- * Test suite for MilvusSnapshotReader
- */
+/** Test suite for MilvusSnapshotReader
+  */
 class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
 
   private val snapshotFilePath = "src/test/data/sample_snapshot.json"
 
   test("Parse complete snapshot metadata successfully") {
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
 
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
@@ -19,7 +19,9 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     // Verify snapshot info
     metadata.snapshotInfo.name shouldBe "backfill_snapshot"
     metadata.snapshotInfo.id shouldBe 462324574599774209L
-    metadata.snapshotInfo.description shouldBe Some("add field backfill snapshot")
+    metadata.snapshotInfo.description shouldBe Some(
+      "add field backfill snapshot"
+    )
     metadata.snapshotInfo.collectionId shouldBe 462324574592960519L
     metadata.snapshotInfo.partitionIds should contain(462324574592960520L)
     metadata.snapshotInfo.createTs shouldBe 462324677975474190L
@@ -45,7 +47,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
   }
 
   test("Parse collection schema successfully") {
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
 
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
@@ -64,55 +67,57 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
 
     // Verify all field names
     val fieldNames = schema.fields.map(_.name)
-    fieldNames should contain allOf("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
+    fieldNames should contain allOf ("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
 
     // Verify primary key field (id)
     val idField = schema.getFieldByName("id").get
     idField.getFieldIDAsLong shouldBe 100L
-    idField.dataType shouldBe 5  // Int64
+    idField.dataType shouldBe 5 // Int64
     idField.isPrimaryKey shouldBe Some(true)
 
     // Verify clustering key field (int64)
     val int64Field = schema.getFieldByName("int64").get
     int64Field.getFieldIDAsLong shouldBe 101L
-    int64Field.dataType shouldBe 5  // Int64
+    int64Field.dataType shouldBe 5 // Int64
     int64Field.isClusteringKey shouldBe Some(true)
 
     // Verify float field
     val floatField = schema.getFieldByName("float").get
     floatField.getFieldIDAsLong shouldBe 102L
-    floatField.dataType shouldBe 10  // Float
+    floatField.dataType shouldBe 10 // Float
 
     // Verify varchar field with type params
     val varcharField = schema.getFieldByName("varchar").get
     varcharField.getFieldIDAsLong shouldBe 103L
-    varcharField.dataType shouldBe 21  // VarChar
+    varcharField.dataType shouldBe 21 // VarChar
     varcharField.typeParams shouldBe defined
     varcharField.getTypeParam("max_length") shouldBe Some("1024")
 
     // Verify vector field with type params
     val vectorField = schema.getFieldByName("vector").get
     vectorField.getFieldIDAsLong shouldBe 104L
-    vectorField.dataType shouldBe 101  // FloatVector
+    vectorField.dataType shouldBe 101 // FloatVector
     vectorField.typeParams shouldBe defined
     vectorField.getTypeParam("dim") shouldBe Some("128")
 
     // Verify system field RowID
     val rowIdField = schema.getFieldByName("RowID").get
-    rowIdField.getFieldIDAsLong shouldBe 0L  // No fieldID specified
-    rowIdField.dataType shouldBe 5  // Int64
+    rowIdField.getFieldIDAsLong shouldBe 0L // No fieldID specified
+    rowIdField.dataType shouldBe 5 // Int64
     rowIdField.description shouldBe Some("row id")
 
     // Verify system field Timestamp
     val timestampField = schema.getFieldByName("Timestamp").get
     timestampField.getFieldIDAsLong shouldBe 1L
-    timestampField.dataType shouldBe 5  // Int64
+    timestampField.dataType shouldBe 5 // Int64
     timestampField.description shouldBe Some("timestamp")
   }
 
   test("Get primary key name from snapshot JSON") {
     val source = scala.io.Source.fromFile(snapshotFilePath)
-    val json = try source.mkString finally source.close()
+    val json =
+      try source.mkString
+      finally source.close()
 
     val result = MilvusSnapshotReader.getPkName(json)
 
@@ -150,7 +155,9 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     val result = MilvusSnapshotReader.getPkName(jsonWithoutPk)
 
     result shouldBe a[Left[_, _]]
-    result.left.toOption.get.getMessage should include("No primary key field found")
+    result.left.toOption.get.getMessage should include(
+      "No primary key field found"
+    )
   }
 
   test("Parse consistency_level from snapshot JSON") {
@@ -182,7 +189,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     }
     """
 
-    val result = MilvusSnapshotReader.parseSnapshotMetadata(jsonWithConsistencyLevel)
+    val result =
+      MilvusSnapshotReader.parseSnapshotMetadata(jsonWithConsistencyLevel)
 
     result shouldBe a[Right[_, _]]
     result.toOption.get.collection.consistencyLevel shouldBe Some(2)
@@ -218,7 +226,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     }
     """
 
-    val result = MilvusSnapshotReader.parseSnapshotMetadata(jsonWithUnknownFields)
+    val result =
+      MilvusSnapshotReader.parseSnapshotMetadata(jsonWithUnknownFields)
 
     result shouldBe a[Right[_, _]]
     result.toOption.get.snapshotInfo.name shouldBe "test"
@@ -242,22 +251,28 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     manifestMap should have size 1
   }
 
-  test("Convert snapshot schema to Spark StructType (excluding system fields)") {
+  test(
+    "Convert snapshot schema to Spark StructType (excluding system fields)"
+  ) {
     import org.apache.spark.sql.types._
 
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
 
     // Convert to Spark schema without system fields
-    val sparkSchema = MilvusSnapshotReader.toSparkSchema(metadata.collection.schema, includeSystemFields = false)
+    val sparkSchema = MilvusSnapshotReader.toSparkSchema(
+      metadata.collection.schema,
+      includeSystemFields = false
+    )
 
     // Should have 5 user fields (excluding RowID and Timestamp)
     sparkSchema.fields should have size 5
 
     // Verify field names and types
     val fieldNames = sparkSchema.fields.map(_.name)
-    fieldNames should contain allOf("id", "int64", "float", "varchar", "vector")
+    fieldNames should contain allOf ("id", "int64", "float", "varchar", "vector")
     fieldNames should not contain "RowID"
     fieldNames should not contain "Timestamp"
 
@@ -269,30 +284,38 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     sparkSchema("vector").dataType shouldBe ArrayType(FloatType)
   }
 
-  test("Convert snapshot schema to Spark StructType (including system fields)") {
+  test(
+    "Convert snapshot schema to Spark StructType (including system fields)"
+  ) {
     import org.apache.spark.sql.types._
 
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
 
     // Convert to Spark schema with system fields
-    val sparkSchema = MilvusSnapshotReader.toSparkSchema(metadata.collection.schema, includeSystemFields = true)
+    val sparkSchema = MilvusSnapshotReader.toSparkSchema(
+      metadata.collection.schema,
+      includeSystemFields = true
+    )
 
     // Should have 7 fields (including RowID and Timestamp)
     sparkSchema.fields should have size 7
 
     // Verify field names
     val fieldNames = sparkSchema.fields.map(_.name)
-    fieldNames should contain allOf("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
+    fieldNames should contain allOf ("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
   }
 
   test("Get field ID to name mapping") {
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
 
-    val fieldIdMap = MilvusSnapshotReader.getFieldIdMap(metadata.collection.schema)
+    val fieldIdMap =
+      MilvusSnapshotReader.getFieldIdMap(metadata.collection.schema)
 
     // Verify mappings
     fieldIdMap(100L) shouldBe "id"
@@ -305,11 +328,13 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
   }
 
   test("Get field name to ID mapping") {
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
 
-    val fieldNameToIdMap = MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
+    val fieldNameToIdMap =
+      MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
 
     // Verify mappings
     fieldNameToIdMap("id") shouldBe 100L
@@ -322,7 +347,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
   }
 
   test("Serialize and deserialize manifest list") {
-    val result = MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
+    val result =
+      MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
     val originalManifestList = metadata.storageV2ManifestList.get
@@ -392,18 +418,19 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     }
     """
 
-    val result = MilvusSnapshotReader.parseSnapshotMetadata(jsonWithStringDataType)
+    val result =
+      MilvusSnapshotReader.parseSnapshotMetadata(jsonWithStringDataType)
 
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
     val schema = metadata.collection.schema
 
     // Verify string data types are correctly converted to numeric codes
-    schema.getFieldByName("id").get.dataType shouldBe 5       // Int64
-    schema.getFieldByName("score").get.dataType shouldBe 10   // Float
-    schema.getFieldByName("name").get.dataType shouldBe 21    // VarChar
-    schema.getFieldByName("embedding").get.dataType shouldBe 101  // FloatVector
-    schema.getFieldByName("flag").get.dataType shouldBe 1     // Bool
+    schema.getFieldByName("id").get.dataType shouldBe 5 // Int64
+    schema.getFieldByName("score").get.dataType shouldBe 10 // Float
+    schema.getFieldByName("name").get.dataType shouldBe 21 // VarChar
+    schema.getFieldByName("embedding").get.dataType shouldBe 101 // FloatVector
+    schema.getFieldByName("flag").get.dataType shouldBe 1 // Bool
   }
 
   test("Parse data_type with mixed formats (some int, some string)") {
@@ -439,14 +466,15 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     }
     """
 
-    val result = MilvusSnapshotReader.parseSnapshotMetadata(jsonWithMixedDataType)
+    val result =
+      MilvusSnapshotReader.parseSnapshotMetadata(jsonWithMixedDataType)
 
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
     val schema = metadata.collection.schema
 
     // Verify both formats work correctly
-    schema.getFieldByName("id").get.dataType shouldBe 5       // Int format
-    schema.getFieldByName("score").get.dataType shouldBe 10   // String format
+    schema.getFieldByName("id").get.dataType shouldBe 5 // Int format
+    schema.getFieldByName("score").get.dataType shouldBe 10 // String format
   }
 }

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -1,16 +1,15 @@
 package com.zilliz.spark.connector
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.types.DataTypes
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.spark.sql.types.DataTypes
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
-/**
- * Unit tests for DataTypeUtil type conversions
- */
+/** Unit tests for DataTypeUtil type conversions
+  */
 class DataTypeUtilTest extends AnyFunSuite with Matchers {
 
   // ============ toArrowType tests ============
@@ -48,13 +47,17 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
   test("toArrowType converts Float to Arrow FloatingPoint SINGLE") {
     val result = DataTypeUtil.toArrowType(0, MilvusDataType.Float)
     result shouldBe a[ArrowType.FloatingPoint]
-    result.asInstanceOf[ArrowType.FloatingPoint].getPrecision shouldBe FloatingPointPrecision.SINGLE
+    result
+      .asInstanceOf[ArrowType.FloatingPoint]
+      .getPrecision shouldBe FloatingPointPrecision.SINGLE
   }
 
   test("toArrowType converts Double to Arrow FloatingPoint DOUBLE") {
     val result = DataTypeUtil.toArrowType(0, MilvusDataType.Double)
     result shouldBe a[ArrowType.FloatingPoint]
-    result.asInstanceOf[ArrowType.FloatingPoint].getPrecision shouldBe FloatingPointPrecision.DOUBLE
+    result
+      .asInstanceOf[ArrowType.FloatingPoint]
+      .getPrecision shouldBe FloatingPointPrecision.DOUBLE
   }
 
   test("toArrowType converts VarChar to Arrow Utf8") {
@@ -72,33 +75,49 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     result shouldBe a[ArrowType.Binary]
   }
 
-  test("toArrowType converts FloatVector to FixedSizeBinary with correct size") {
+  test(
+    "toArrowType converts FloatVector to FixedSizeBinary with correct size"
+  ) {
     val dim = 128
     val result = DataTypeUtil.toArrowType(dim, MilvusDataType.FloatVector)
     result shouldBe a[ArrowType.FixedSizeBinary]
-    result.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth shouldBe (dim * 4)
+    result
+      .asInstanceOf[ArrowType.FixedSizeBinary]
+      .getByteWidth shouldBe (dim * 4)
   }
 
-  test("toArrowType converts BinaryVector to FixedSizeBinary with correct size") {
+  test(
+    "toArrowType converts BinaryVector to FixedSizeBinary with correct size"
+  ) {
     val dim = 128
     val result = DataTypeUtil.toArrowType(dim, MilvusDataType.BinaryVector)
     result shouldBe a[ArrowType.FixedSizeBinary]
     // Binary vector: (dim + 7) / 8 bytes
-    result.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth shouldBe ((dim + 7) / 8)
+    result
+      .asInstanceOf[ArrowType.FixedSizeBinary]
+      .getByteWidth shouldBe ((dim + 7) / 8)
   }
 
-  test("toArrowType converts Float16Vector to FixedSizeBinary with correct size") {
+  test(
+    "toArrowType converts Float16Vector to FixedSizeBinary with correct size"
+  ) {
     val dim = 64
     val result = DataTypeUtil.toArrowType(dim, MilvusDataType.Float16Vector)
     result shouldBe a[ArrowType.FixedSizeBinary]
-    result.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth shouldBe (dim * 2)
+    result
+      .asInstanceOf[ArrowType.FixedSizeBinary]
+      .getByteWidth shouldBe (dim * 2)
   }
 
-  test("toArrowType converts BFloat16Vector to FixedSizeBinary with correct size") {
+  test(
+    "toArrowType converts BFloat16Vector to FixedSizeBinary with correct size"
+  ) {
     val dim = 64
     val result = DataTypeUtil.toArrowType(dim, MilvusDataType.BFloat16Vector)
     result shouldBe a[ArrowType.FixedSizeBinary]
-    result.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth shouldBe (dim * 2)
+    result
+      .asInstanceOf[ArrowType.FixedSizeBinary]
+      .getByteWidth shouldBe (dim * 2)
   }
 
   test("toArrowType converts Int8Vector to FixedSizeBinary with correct size") {
@@ -202,7 +221,10 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
   test("toDataType converts SparseFloatVector to Spark Map[Long, Float]") {
     val fieldSchema = FieldSchema(dataType = MilvusDataType.SparseFloatVector)
     val result = DataTypeUtil.toDataType(fieldSchema)
-    result shouldBe DataTypes.createMapType(DataTypes.LongType, DataTypes.FloatType)
+    result shouldBe DataTypes.createMapType(
+      DataTypes.LongType,
+      DataTypes.FloatType
+    )
   }
 
   test("toDataType converts Array with Int64 element to Spark Array[Long]") {
@@ -223,7 +245,9 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     result shouldBe DataTypes.createArrayType(DataTypes.FloatType)
   }
 
-  test("toDataType converts Array with VarChar element to Spark Array[String]") {
+  test(
+    "toDataType converts Array with VarChar element to Spark Array[String]"
+  ) {
     val fieldSchema = FieldSchema(
       dataType = MilvusDataType.Array,
       elementType = MilvusDataType.VarChar
@@ -252,7 +276,8 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
   test("toDataType throws exception for unsupported array element type") {
     val fieldSchema = FieldSchema(
       dataType = MilvusDataType.Array,
-      elementType = MilvusDataType.FloatVector  // Vectors are not valid array elements
+      elementType =
+        MilvusDataType.FloatVector // Vectors are not valid array elements
     )
 
     an[DataParseException] should be thrownBy {

--- a/src/test/scala/serde/SchemaUtilTest.scala
+++ b/src/test/scala/serde/SchemaUtilTest.scala
@@ -1,18 +1,18 @@
 package serde
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
-
-/**
- * Test suite for MilvusSchemaUtil
- */
+/** Test suite for MilvusSchemaUtil
+  */
 class SchemaUtilTest extends AnyFunSuite with Matchers {
 
   test("Convert DataFrame schema to Arrow schema correctly") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("SchemaConversionTest")
       .master("local[*]")
       .getOrCreate()
@@ -23,56 +23,99 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
 
       // Test with various data types
       val df = Seq(
-        (1L, 100, "name1", 3.14f, 2.718, true, Array(1, 2, 3), Array(0.1f, 0.2f, 0.3f)),
-        (2L, 200, "name2", 1.41f, 1.732, false, Array(4, 5, 6), Array(0.4f, 0.5f, 0.6f))
-      ).toDF("id", "age", "name", "score", "rating", "active", "tags", "embedding")
+        (
+          1L,
+          100,
+          "name1",
+          3.14f,
+          2.718,
+          true,
+          Array(1, 2, 3),
+          Array(0.1f, 0.2f, 0.3f)
+        ),
+        (
+          2L,
+          200,
+          "name2",
+          1.41f,
+          1.732,
+          false,
+          Array(4, 5, 6),
+          Array(0.4f, 0.5f, 0.6f)
+        )
+      ).toDF(
+        "id",
+        "age",
+        "name",
+        "score",
+        "rating",
+        "active",
+        "tags",
+        "embedding"
+      )
 
       // Convert without vector dimensions (embedding will be List)
-      val arrowSchemaNoVec = MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema)
+      val arrowSchemaNoVec =
+        MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema)
 
       arrowSchemaNoVec should not be null
       arrowSchemaNoVec.getFields.size() shouldBe 8
 
       val fieldNames = arrowSchemaNoVec.getFields.asScala.map(_.getName)
-      fieldNames should contain allOf("id", "age", "name", "score", "rating", "active", "tags", "embedding")
+      fieldNames should contain allOf ("id", "age", "name", "score", "rating", "active", "tags", "embedding")
 
-      info(s"Successfully converted schema with ${arrowSchemaNoVec.getFields.size()} fields")
+      info(
+        s"Successfully converted schema with ${arrowSchemaNoVec.getFields.size()} fields"
+      )
       arrowSchemaNoVec.getFields.asScala.foreach { field =>
         info(s"  - ${field.getName}: ${field.getType}")
       }
 
       // Verify types
-      val idField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "id").get
+      val idField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "id").get
       idField.getType.toString should include("Int(64")
 
-      val ageField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "age").get
+      val ageField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "age").get
       ageField.getType.toString should include("Int(32")
 
-      val nameField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "name").get
+      val nameField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "name").get
       nameField.getType.toString should be("Utf8")
 
-      val scoreField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "score").get
+      val scoreField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "score").get
       scoreField.getType.toString should include("FloatingPoint")
 
-      val ratingField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "rating").get
+      val ratingField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "rating").get
       ratingField.getType.toString should include("FloatingPoint")
 
-      val activeField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "active").get
+      val activeField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "active").get
       activeField.getType.toString should be("Bool")
 
-      val tagsField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "tags").get
+      val tagsField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "tags").get
       tagsField.getType.toString should be("List")
 
-      val embeddingField = arrowSchemaNoVec.getFields.asScala.find(_.getName == "embedding").get
-      embeddingField.getType.toString should be("List") // Without vector dimension config
+      val embeddingField =
+        arrowSchemaNoVec.getFields.asScala.find(_.getName == "embedding").get
+      embeddingField.getType.toString should be(
+        "List"
+      ) // Without vector dimension config
 
     } finally {
       spark.stop()
     }
   }
 
-  test("Convert float arrays to FixedSizeBinary when vector dimensions provided") {
-    val spark = SparkSession.builder()
+  test(
+    "Convert float arrays to FixedSizeBinary when vector dimensions provided"
+  ) {
+    val spark = SparkSession
+      .builder()
       .appName("VectorSchemaTest")
       .master("local[*]")
       .getOrCreate()
@@ -88,12 +131,14 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
 
       // Convert with vector dimensions
       val vectorDimensions = Map("embedding" -> 3)
-      val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema, vectorDimensions)
+      val arrowSchema =
+        MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema, vectorDimensions)
 
       arrowSchema should not be null
       arrowSchema.getFields.size() shouldBe 3
 
-      val embeddingField = arrowSchema.getFields.asScala.find(_.getName == "embedding").get
+      val embeddingField =
+        arrowSchema.getFields.asScala.find(_.getName == "embedding").get
       embeddingField.getType.toString should include("FixedSizeBinary")
       embeddingField.getType.toString should include("12") // 3 floats * 4 bytes
 
@@ -105,7 +150,8 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
   }
 
   test("Handle multiple vector fields with different dimensions") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("MultiVectorTest")
       .master("local[*]")
       .getOrCreate()
@@ -123,15 +169,22 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
         "vec2d" -> 2,
         "vec4d" -> 4
       )
-      val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema, vectorDimensions)
+      val arrowSchema =
+        MilvusSchemaUtil.convertSparkSchemaToArrow(df.schema, vectorDimensions)
 
       arrowSchema.getFields.size() shouldBe 3
 
-      val vec2dField = arrowSchema.getFields.asScala.find(_.getName == "vec2d").get
-      vec2dField.getType.toString should include("FixedSizeBinary(8)") // 2 * 4 bytes
+      val vec2dField =
+        arrowSchema.getFields.asScala.find(_.getName == "vec2d").get
+      vec2dField.getType.toString should include(
+        "FixedSizeBinary(8)"
+      ) // 2 * 4 bytes
 
-      val vec4dField = arrowSchema.getFields.asScala.find(_.getName == "vec4d").get
-      vec4dField.getType.toString should include("FixedSizeBinary(16)") // 4 * 4 bytes
+      val vec4dField =
+        arrowSchema.getFields.asScala.find(_.getName == "vec4d").get
+      vec4dField.getType.toString should include(
+        "FixedSizeBinary(16)"
+      ) // 4 * 4 bytes
 
       info(s"Multiple vector fields converted correctly")
       info(s"  - vec2d: ${vec2dField.getType}")
@@ -143,7 +196,8 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
   }
 
   test("Handle complex types (Map and Struct)") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("ComplexTypesTest")
       .master("local[*]")
       .getOrCreate()
@@ -154,16 +208,23 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
       import org.apache.spark.sql.types._
 
       // Create DataFrame with Map type
-      val schema = StructType(Seq(
-        StructField("id", LongType, nullable = true),
-        StructField("properties", MapType(StringType, IntegerType), nullable = true)
-      ))
+      val schema = StructType(
+        Seq(
+          StructField("id", LongType, nullable = true),
+          StructField(
+            "properties",
+            MapType(StringType, IntegerType),
+            nullable = true
+          )
+        )
+      )
 
       val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
 
       arrowSchema.getFields.size() shouldBe 2
 
-      val propertiesField = arrowSchema.getFields.asScala.find(_.getName == "properties").get
+      val propertiesField =
+        arrowSchema.getFields.asScala.find(_.getName == "properties").get
       propertiesField.getType.toString should include("Map")
 
       info(s"Map type converted to: ${propertiesField.getType}")
@@ -174,7 +235,8 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
   }
 
   test("Handle all basic Spark types") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("AllTypesTest")
       .master("local[*]")
       .getOrCreate()
@@ -184,28 +246,32 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
       import com.zilliz.spark.connector.MilvusSchemaUtil
       import org.apache.spark.sql.types._
 
-      val schema = StructType(Seq(
-        StructField("long_field", LongType),
-        StructField("int_field", IntegerType),
-        StructField("short_field", ShortType),
-        StructField("byte_field", ByteType),
-        StructField("float_field", FloatType),
-        StructField("double_field", DoubleType),
-        StructField("bool_field", BooleanType),
-        StructField("string_field", StringType),
-        StructField("binary_field", BinaryType),
-        StructField("int_array", ArrayType(IntegerType)),
-        StructField("long_array", ArrayType(LongType)),
-        StructField("double_array", ArrayType(DoubleType)),
-        StructField("string_array", ArrayType(StringType))
-      ))
+      val schema = StructType(
+        Seq(
+          StructField("long_field", LongType),
+          StructField("int_field", IntegerType),
+          StructField("short_field", ShortType),
+          StructField("byte_field", ByteType),
+          StructField("float_field", FloatType),
+          StructField("double_field", DoubleType),
+          StructField("bool_field", BooleanType),
+          StructField("string_field", StringType),
+          StructField("binary_field", BinaryType),
+          StructField("int_array", ArrayType(IntegerType)),
+          StructField("long_array", ArrayType(LongType)),
+          StructField("double_array", ArrayType(DoubleType)),
+          StructField("string_array", ArrayType(StringType))
+        )
+      )
 
       val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
 
       arrowSchema.getFields.size() shouldBe 13
 
       // Verify each type
-      val typeMap = arrowSchema.getFields.asScala.map(f => f.getName -> f.getType.toString).toMap
+      val typeMap = arrowSchema.getFields.asScala
+        .map(f => f.getName -> f.getType.toString)
+        .toMap
 
       typeMap("long_field") should include("Int(64")
       typeMap("int_field") should include("Int(32")
@@ -232,7 +298,8 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
   }
 
   test("Handle nullable fields correctly") {
-    val spark = SparkSession.builder()
+    val spark = SparkSession
+      .builder()
       .appName("NullableTest")
       .master("local[*]")
       .getOrCreate()
@@ -241,20 +308,24 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
       import com.zilliz.spark.connector.MilvusSchemaUtil
       import org.apache.spark.sql.types._
 
-      val schema = StructType(Seq(
-        StructField("required_field", LongType, nullable = false),
-        StructField("optional_field", StringType, nullable = true)
-      ))
+      val schema = StructType(
+        Seq(
+          StructField("required_field", LongType, nullable = false),
+          StructField("optional_field", StringType, nullable = true)
+        )
+      )
 
       val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
 
       arrowSchema.getFields.size() shouldBe 2
 
       // All Arrow fields are created as nullable=true by design
-      val requiredField = arrowSchema.getFields.asScala.find(_.getName == "required_field").get
+      val requiredField =
+        arrowSchema.getFields.asScala.find(_.getName == "required_field").get
       requiredField.isNullable shouldBe true
 
-      val optionalField = arrowSchema.getFields.asScala.find(_.getName == "optional_field").get
+      val optionalField =
+        arrowSchema.getFields.asScala.find(_.getName == "optional_field").get
       optionalField.isNullable shouldBe true
 
       info(s"✓ Nullable fields handled correctly")

--- a/src/test/scala/sources/MilvusDataSourceTest.scala
+++ b/src/test/scala/sources/MilvusDataSourceTest.scala
@@ -1,34 +1,41 @@
 package com.zilliz.spark.connector.sources
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.BeforeAndAfterAll
-import org.apache.spark.sql.SparkSession
 import scala.util.Random
 
-import com.zilliz.spark.connector.{MilvusClient, MilvusConnectionParams, MilvusFieldData, MilvusOption}
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterAll
+
+import com.zilliz.spark.connector.{
+  MilvusClient,
+  MilvusConnectionParams,
+  MilvusFieldData,
+  MilvusOption
+}
 import com.zilliz.spark.connector.loon.Properties
 import io.milvus.grpc.schema.DataType
 
-/**
- * Integration test for MilvusDataSource
- *
- * Prerequisites:
- * - Milvus 2.6+ running at localhost:19530
- * - Minio running at localhost:9000
- */
+/** Integration test for MilvusDataSource
+  *
+  * Prerequisites:
+  *   - Milvus 2.6+ running at localhost:19530
+  *   - Minio running at localhost:9000
+  */
 class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
 
   var spark: SparkSession = _
   var milvusClient: MilvusClient = _
 
-  val collectionName = s"test_storagev2_collection_${System.currentTimeMillis()}"
+  val collectionName =
+    s"test_storagev2_collection_${System.currentTimeMillis()}"
   val dim = 128
   val batchSize = 10
   val batchCount = 3
 
   override def beforeAll(): Unit = {
     // Initialize Spark
-    spark = SparkSession.builder()
+    spark = SparkSession
+      .builder()
       .appName("MilvusDataSourceTest")
       .master("local[*]")
       .getOrCreate()
@@ -83,8 +90,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     val actualCount = df.count()
     val expectedCount = batchSize * batchCount
 
-    assert(actualCount == expectedCount,
-      s"Expected $expectedCount rows but got $actualCount")
+    assert(
+      actualCount == expectedCount,
+      s"Expected $expectedCount rows but got $actualCount"
+    )
   }
 
   test("Read specific fields using ReaderFieldIDs") {
@@ -94,7 +103,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
       .option(MilvusOption.MilvusToken, "root:Milvus")
       .option(MilvusOption.MilvusCollectionName, collectionName)
       .option(MilvusOption.MilvusDatabaseName, "default")
-      .option(MilvusOption.ReaderFieldIDs, "100,102")  // read only id and float fields
+      .option(
+        MilvusOption.ReaderFieldIDs,
+        "100,102"
+      ) // read only id and float fields
       .option(Properties.FsConfig.FsAddress, "localhost:9000")
       .option(Properties.FsConfig.FsBucketName, "a-bucket")
       .option(Properties.FsConfig.FsRootPath, "files")
@@ -126,20 +138,23 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
       .option(Properties.FsConfig.FsAccessKeyId, "minioadmin")
       .option(Properties.FsConfig.FsAccessKeyValue, "minioadmin")
       .option(Properties.FsConfig.FsUseSSL, "false")
-      .load()     
+      .load()
 
     // Register as temp view
     df.createOrReplaceTempView("milvus_data")
 
     // Run SQL queries
     info("\n=== SQL Query: Filter by int64 < 5 ===")
-    val filtered = spark.sql("SELECT id, int64, float FROM milvus_data WHERE int64 < 5")
+    val filtered =
+      spark.sql("SELECT id, int64, float FROM milvus_data WHERE int64 < 5")
     filtered.show()
 
     assert(filtered.count() > 0, "Filtered query should return results")
 
     info("\n=== SQL Query: Aggregation ===")
-    val agg = spark.sql("SELECT COUNT(*) as total, AVG(float) as avg_float FROM milvus_data")
+    val agg = spark.sql(
+      "SELECT COUNT(*) as total, AVG(float) as avg_float FROM milvus_data"
+    )
     agg.show()
 
     info("\nSuccessfully executed Spark SQL queries")
@@ -184,7 +199,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
       .option(MilvusOption.MilvusToken, "root:Milvus")
       .option(MilvusOption.MilvusCollectionName, collectionName)
       .option(MilvusOption.MilvusDatabaseName, "default")
-      .option(MilvusOption.ReaderFieldIDs, "100,101,102")  // Only read id, int64, float
+      .option(
+        MilvusOption.ReaderFieldIDs,
+        "100,101,102"
+      ) // Only read id, int64, float
       .option(Properties.FsConfig.FsAddress, "localhost:9000")
       .option(Properties.FsConfig.FsBucketName, "a-bucket")
       .option(Properties.FsConfig.FsRootPath, "files")
@@ -212,7 +230,9 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     val queryVector = Array.fill(dim)(random.nextFloat())
     val queryVectorJson = queryVector.mkString("[", ",", "]")
 
-    info(s"Query vector (first 5 elements): [${queryVector.take(5).mkString(", ")}, ...]")
+    info(
+      s"Query vector (first 5 elements): [${queryVector.take(5).mkString(", ")}, ...]"
+    )
 
     val topK = 5
 
@@ -245,7 +265,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
         .load()
 
       results.show()
-      assert(results.count() == topK, s"No results returned from vector search with $metric metric")
+      assert(
+        results.count() == topK,
+        s"No results returned from vector search with $metric metric"
+      )
     }
   }
 
@@ -321,8 +344,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     val count = filtered.count()
     // Each batch has int64 from 0 to batchSize-1, so value 3 should appear in each batch
     val expectedCount = if (3 < batchSize) batchCount else 0
-    assert(count == expectedCount,
-      s"Expected $expectedCount rows with int64=3, but got $count")
+    assert(
+      count == expectedCount,
+      s"Expected $expectedCount rows with int64=3, but got $count"
+    )
   }
 
   test("Filter pushdown - range filter on int64") {
@@ -347,8 +372,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     val count = filtered.count()
     // int64 range [5, 8) = values 5, 6, 7 (3 values per batch)
     val expectedCount = if (batchSize > 7) batchCount * 3 else 0
-    assert(count == expectedCount,
-      s"Expected $expectedCount rows with int64 in [5,8), but got $count")
+    assert(
+      count == expectedCount,
+      s"Expected $expectedCount rows with int64 in [5,8), but got $count"
+    )
   }
 
   test("Filter pushdown - IN filter on int64") {
@@ -373,8 +400,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     val count = filtered.count()
     // Each batch has values 1, 3, 5 if batchSize > 5
     val expectedCount = if (batchSize > 5) batchCount * 3 else 0
-    assert(count == expectedCount,
-      s"Expected $expectedCount rows with int64 in (1,3,5), but got $count")
+    assert(
+      count == expectedCount,
+      s"Expected $expectedCount rows with int64 in (1,3,5), but got $count"
+    )
   }
 
   test("Filter pushdown - combined with column pruning") {
@@ -392,21 +421,28 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
       .option(Properties.FsConfig.FsUseSSL, "false")
       .load()
 
-    info("\n=== Filter pushdown + column pruning: select id, int64 where int64 < 5 ===")
+    info(
+      "\n=== Filter pushdown + column pruning: select id, int64 where int64 < 5 ==="
+    )
     val result = df.select("id", "int64").filter("int64 < 5")
     result.show()
 
     // Verify schema
     val fieldNames = result.schema.fieldNames.toSet
     assert(fieldNames.size == 2, "Should only have 2 columns")
-    assert(fieldNames.contains("id") && fieldNames.contains("int64"),
-      "Should have id and int64 columns")
+    assert(
+      fieldNames.contains("id") && fieldNames.contains("int64"),
+      "Should have id and int64 columns"
+    )
 
     // Verify filter worked
     val count = result.count()
-    val expectedCount = if (batchSize > 5) batchCount * 5 else batchCount * batchSize
-    assert(count == expectedCount,
-      s"Expected $expectedCount rows with int64 < 5, but got $count")
+    val expectedCount =
+      if (batchSize > 5) batchCount * 5 else batchCount * batchSize
+    assert(
+      count == expectedCount,
+      s"Expected $expectedCount rows with int64 < 5, but got $count"
+    )
   }
 
   test("Filter pushdown - IS NULL and IS NOT NULL") {
@@ -431,8 +467,10 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     // All int64 values are non-null in test data
     val count = notNullFiltered.count()
     val expectedCount = batchSize * batchCount
-    assert(count == expectedCount,
-      s"Expected all $expectedCount rows (int64 IS NOT NULL), but got $count")
+    assert(
+      count == expectedCount,
+      s"Expected all $expectedCount rows (int64 IS NOT NULL), but got $count"
+    )
   }
 
   // Helper method to prepare test collection
@@ -441,11 +479,28 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
     milvusClient.dropCollection("", collectionName)
 
     val fields = List(
-      milvusClient.createCollectionField("id", isPrimary = true, dataType = DataType.Int64, autoID = false),
-      milvusClient.createCollectionField("int64", dataType = DataType.Int64, isClusteringKey = true),
+      milvusClient.createCollectionField(
+        "id",
+        isPrimary = true,
+        dataType = DataType.Int64,
+        autoID = false
+      ),
+      milvusClient.createCollectionField(
+        "int64",
+        dataType = DataType.Int64,
+        isClusteringKey = true
+      ),
       milvusClient.createCollectionField("float", dataType = DataType.Float),
-      milvusClient.createCollectionField("varchar", dataType = DataType.VarChar, typeParams = Map("max_length" -> "1024")),
-      milvusClient.createCollectionField("vector", dataType = DataType.FloatVector, typeParams = Map("dim" -> dim.toString))
+      milvusClient.createCollectionField(
+        "varchar",
+        dataType = DataType.VarChar,
+        typeParams = Map("max_length" -> "1024")
+      ),
+      milvusClient.createCollectionField(
+        "vector",
+        dataType = DataType.FloatVector,
+        typeParams = Map("dim" -> dim.toString)
+      )
     )
 
     val schema = milvusClient.createCollectionSchema(
@@ -464,10 +519,11 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
       val idData = (0 until batchSize).map(j => (i * batchSize + j).toLong)
       val int64Data = (0 until batchSize).map(j => j.toLong)
       val floatData = (0 until batchSize).map(_ => random.nextFloat())
-      val varcharData = (0 until batchSize).map(j =>
-        s"test_string_${i * batchSize + j}")
+      val varcharData =
+        (0 until batchSize).map(j => s"test_string_${i * batchSize + j}")
       val vectorData = (0 until batchSize).map(_ =>
-        (0 until dim).map(_ => random.nextFloat()).toSeq)
+        (0 until dim).map(_ => random.nextFloat()).toSeq
+      )
 
       val fieldsData = Seq(
         MilvusFieldData.packInt64FieldData("id", idData),
@@ -477,7 +533,12 @@ class MilvusDataSourceTest extends AnyFunSuite with BeforeAndAfterAll {
         MilvusFieldData.packFloatVectorFieldData("vector", vectorData, dim)
       )
 
-      milvusClient.insert("", collectionName, fieldsData = fieldsData, numRows = batchSize)
+      milvusClient.insert(
+        "",
+        collectionName,
+        fieldsData = fieldsData,
+        numRows = batchSize
+      )
     }
 
     // Flush to ensure data is persisted


### PR DESCRIPTION
Add sbt-scalafmt plugin and exclude generated code under target/ from formatting. Run scalafmtAll to standardize code style across all Scala source files.