### PR TITLE
enhance: adapt to new milvus-storage Transaction API with dropColumn for backfill column replacement

### DIFF
--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -281,23 +281,38 @@ class MilvusLoonPartitionWriter(
 
       // Commit column groups to manifest using Transaction
       val transaction = new MilvusStorageTransaction()
-      transaction.begin(basePath, writerProperties)
+      val committedVersion =
+        try {
+          transaction.begin(basePath, writerProperties)
 
-      milvusOption.options.get(
-        MilvusOption.WriterCommitType.toLowerCase
-      ) match {
-        case Some("addfield") =>
-          // Backfill = column replacement: drop each target column (noop if
-          // absent) then add the new column groups in the same transaction.
-          // Native commit orders DropColumn before AddColumnGroup validation,
-          // so this is atomic per-column overwrite.
-          sparkSchema.fields.foreach(f => transaction.dropColumn(f.name))
-          transaction.addColumnGroups(columnGroupsPtr)
-        case _ =>
-          transaction.appendFiles(columnGroupsPtr)
-      }
-      val committedVersion = transaction.commit()
-      transaction.destroy()
+          milvusOption.options.get(
+            MilvusOption.WriterCommitType.toLowerCase
+          ) match {
+            case Some("addfield") =>
+              // Backfill = column replacement: drop each target column (noop if
+              // absent) then add the new column groups in the same transaction.
+              // Native commit orders DropColumn before AddColumnGroup validation,
+              // so this is atomic per-column overwrite.
+              // Columns in the manifest are keyed by Milvus field ID (the Arrow
+              // schema uses fieldId.toString as the column name), so dropColumn
+              // must be called with the field ID, not the logical Spark name.
+              sparkSchema.fields.foreach { f =>
+                val fieldId = fieldIds.getOrElse(
+                  f.name,
+                  throw new IllegalStateException(
+                    s"Missing field ID for backfill column '${f.name}'"
+                  )
+                )
+                transaction.dropColumn(fieldId.toString)
+              }
+              transaction.addColumnGroups(columnGroupsPtr)
+            case _ =>
+              transaction.appendFiles(columnGroupsPtr)
+          }
+          transaction.commit()
+        } finally {
+          transaction.destroy()
+        }
 
       if (committedVersion < 0) {
         throw new IllegalStateException(

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -283,14 +283,20 @@ class MilvusLoonPartitionWriter(
       val transaction = new MilvusStorageTransaction()
       transaction.begin(basePath, writerProperties)
 
-      // Determine commit type: ADDFIELD (1) for backfill, ADDFILES (0) for normal writes
-      val commitType = milvusOption.options.get(
+      milvusOption.options.get(
         MilvusOption.WriterCommitType.toLowerCase
       ) match {
-        case Some("addfield") => 1 // ADDFIELD
-        case _                => 0 // ADDFILES (default)
+        case Some("addfield") =>
+          // Backfill = column replacement: drop each target column (noop if
+          // absent) then add the new column groups in the same transaction.
+          // Native commit orders DropColumn before AddColumnGroup validation,
+          // so this is atomic per-column overwrite.
+          sparkSchema.fields.foreach(f => transaction.dropColumn(f.name))
+          transaction.addColumnGroups(columnGroupsPtr)
+        case _ =>
+          transaction.appendFiles(columnGroupsPtr)
       }
-      val committedVersion = transaction.commit(commitType, 0, columnGroupsPtr)
+      val committedVersion = transaction.commit()
       transaction.destroy()
 
       if (committedVersion < 0) {


### PR DESCRIPTION
Bumps milvus-storage submodule to 6796b60, which refactors the Transaction JNI API: staging ops are now dedicated methods (appendFiles / addColumnGroups / dropColumn) and the old commit(updateId, resolveId, ptr) overload is gone.

Migrates MilvusLoonWriter.commit to the new API. The backfill (addfield) path now stages dropColumn for each target field before addColumnGroups, giving an atomic column-replace: first-time backfill is a noop drop plus an add (idempotent, matches prior behavior), while re-running backfill against the same manifest cleanly overwrites the previous column group instead of failing the schema-evolution validation. Normal writes take the appendFiles branch.