### PR TITLE
enhance: support parquet column mapping for backfill

### DIFF
--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -143,7 +143,7 @@ object BackfillApp {
         "--column-mapping cannot be empty"
       )
     }
-    trimmed
+    val pairs = trimmed
       .split(",")
       .map(_.trim)
       .filter(_.nonEmpty)
@@ -157,7 +157,19 @@ object BackfillApp {
             )
         }
       }
-      .toMap
+      .toSeq
+    // Duplicate sources silently collapse under `.toMap`; fail fast, mirroring
+    // how applyColumnMapping rejects duplicate targets.
+    val dupSrc = pairs
+      .groupBy(_._1)
+      .collect { case (k, vs) if vs.size > 1 => k }
+      .toSeq
+    if (dupSrc.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"--column-mapping has duplicate source columns: ${dupSrc.mkString(", ")}"
+      )
+    }
+    pairs.toMap
   }
 
   private[backfill] def parseArgs(args: Array[String]): Map[String, String] = {

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -67,7 +67,8 @@ object BackfillApp {
         if (parsed.contains("source-s3-use-ssl")) Some(true) else None,
       sourceS3UseIam = sourceUseIamFlag,
       sourceS3Region = parsed.get("source-s3-region"),
-      batchSize = parsed.getOrElse("batch-size", "1024").toInt
+      batchSize = parsed.getOrElse("batch-size", "1024").toInt,
+      columnMapping = parsed.get("column-mapping").map(parseColumnMapping)
     )
 
     val spark = SparkSession.builder
@@ -127,10 +128,37 @@ object BackfillApp {
     "source-s3-secret-key",
     "source-s3-region",
     "batch-size",
-    "output-result"
+    "output-result",
+    "column-mapping"
   )
 
   private[backfill] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
+
+  // Parse `src1:tgt1,src2:tgt2,...` into a map. Empty segments and malformed
+  // entries raise a clear error rather than silently dropping bindings.
+  private[backfill] def parseColumnMapping(raw: String): Map[String, String] = {
+    val trimmed = raw.trim
+    if (trimmed.isEmpty) {
+      throw new IllegalArgumentException(
+        "--column-mapping cannot be empty"
+      )
+    }
+    trimmed
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map { entry =>
+        entry.split(":", 2) match {
+          case Array(src, tgt) if src.nonEmpty && tgt.nonEmpty =>
+            src.trim -> tgt.trim
+          case _ =>
+            throw new IllegalArgumentException(
+              s"--column-mapping entry '$entry' must be of the form 'src:tgt'"
+            )
+        }
+      }
+      .toMap
+  }
 
   private[backfill] def parseArgs(args: Array[String]): Map[String, String] = {
     var map = Map.empty[String, String]

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -65,7 +65,16 @@ case class BackfillConfig(
 
     // Writer configuration
     batchSize: Int = 1024,
-    customOutputPath: Option[String] = None
+    customOutputPath: Option[String] = None,
+
+    // Optional mapping: parquet column name -> Milvus field name.
+    // When set, the backfill parquet is reprojected through this map before
+    // join/write: parquet columns not listed as keys are dropped, and each
+    // listed column is renamed to its target. The value set MUST contain the
+    // Milvus primary key field name so the pk column can be identified after
+    // renaming. When None (default), legacy behavior applies: the parquet
+    // must contain a literal "pk" column plus one or more field columns.
+    columnMapping: Option[Map[String, String]] = None
 ) {
 
   /** Validate S3 and writer configuration (always required)

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -122,7 +122,20 @@ object MilvusBackfill {
       }
 
       // Read backfill data from Parquet
-      val backfillDF = readBackfillData(spark, backfillDataPath, config) match {
+      val rawBackfillDF =
+        readBackfillData(spark, backfillDataPath, config) match {
+          case Left(error) => return Left(error)
+          case Right(df)   => df
+        }
+
+      // Reproject via the column mapping (or legacy implicit mapping) so that
+      // downstream code can assume the DataFrame's column names match the
+      // Milvus schema exactly — in particular, the pk column is named pkName.
+      val backfillDF = applyColumnMapping(
+        rawBackfillDF,
+        pkName,
+        config.columnMapping
+      ) match {
         case Left(error) => return Left(error)
         case Right(df)   => df
       }
@@ -161,10 +174,10 @@ object MilvusBackfill {
             (colId, segPartMap, Map.empty[Long, String])
         }
 
-      // Extract new field names
+      // Extract new field names (all post-mapping columns except the PK)
       val newFieldNames = backfillDF.schema.fields
         .map(_.name)
-        .filterNot(_ == "pk")
+        .filterNot(_ == pkName)
         .toSeq
 
       // Build field name -> field ID mapping from collection schema
@@ -256,23 +269,13 @@ object MilvusBackfill {
       configureHadoopS3ForPath(spark, path, config, isSource = true)
       val df = spark.read.parquet(path)
 
-      // Validate that it has a 'pk' column
-      if (!df.columns.contains("pk")) {
+      // Minimum shape check; pk presence and field-count checks are enforced
+      // after column mapping is applied (see applyColumnMapping).
+      if (df.columns.isEmpty) {
         return Left(
           DataReadError(
             path = path,
-            message = "Backfill data must contain a 'pk' column"
-          )
-        )
-      }
-
-      // Validate that it has at least one other column
-      if (df.columns.length < 2) {
-        return Left(
-          DataReadError(
-            path = path,
-            message =
-              "New field data must contain at least one field besides 'pk'"
+            message = "Backfill parquet is empty (no columns)"
           )
         )
       }
@@ -289,6 +292,93 @@ object MilvusBackfill {
           )
         )
     }
+  }
+
+  /** Project the raw backfill DataFrame through a parquet-column → Milvus-field
+    * mapping so downstream code sees column names that match the Milvus schema
+    * exactly (including the PK, which must be named `pkName`).
+    *
+    * When `userMapping` is None, a legacy implicit mapping is synthesized: the
+    * literal `"pk"` column is renamed to `pkName`, every other column is kept
+    * as-is. This preserves the pre-existing contract (parquet must have a `pk`
+    * column plus one or more field columns).
+    */
+  private[backfill] def applyColumnMapping(
+      df: DataFrame,
+      pkName: String,
+      userMapping: Option[Map[String, String]]
+  ): Either[BackfillError, DataFrame] = {
+    val cols = df.columns.toSeq
+    val colSet = cols.toSet
+
+    val mapping: Map[String, String] = userMapping match {
+      case Some(m) => m
+      case None    =>
+        // Legacy: require a literal "pk" column; transparently rename it to pkName.
+        if (!colSet.contains("pk")) {
+          return Left(
+            DataReadError(
+              path = "",
+              message =
+                "Backfill parquet must contain a 'pk' column (or supply --column-mapping to rename the PK column)"
+            )
+          )
+        }
+        cols.map(c => if (c == "pk") c -> pkName else c -> c).toMap
+    }
+
+    // Mapping keys must all exist in the parquet.
+    val missingSrc = mapping.keySet.diff(colSet)
+    if (missingSrc.nonEmpty) {
+      return Left(
+        SchemaValidationError(
+          s"column mapping references parquet columns that don't exist: " +
+            s"${missingSrc.mkString(", ")}. Available: ${cols.mkString(", ")}"
+        )
+      )
+    }
+
+    // Mapping values must be unique; two parquet columns cannot both point at
+    // the same Milvus field.
+    val dupTargets = mapping.values.groupBy(identity).collect {
+      case (k, v) if v.size > 1 => k
+    }
+    if (dupTargets.nonEmpty) {
+      return Left(
+        SchemaValidationError(
+          s"column mapping has duplicate targets: ${dupTargets.mkString(", ")}"
+        )
+      )
+    }
+
+    // The PK field must appear as a target so we can locate it after renaming.
+    if (!mapping.values.toSet.contains(pkName)) {
+      return Left(
+        SchemaValidationError(
+          s"column mapping must include the primary key field '$pkName' as a target"
+        )
+      )
+    }
+
+    // At least one non-pk field must remain.
+    val newFieldTargets = mapping.values.toSet - pkName
+    if (newFieldTargets.isEmpty) {
+      return Left(
+        SchemaValidationError(
+          "column mapping must include at least one non-PK field to backfill"
+        )
+      )
+    }
+
+    // Project, then rename. Use the mapping key order from the original parquet
+    // schema to keep the output stable / deterministic.
+    val orderedKeys = cols.filter(mapping.contains)
+    val projected = df.select(orderedKeys.map(df.col): _*)
+    val renamed = orderedKeys.foldLeft(projected) { (acc, src) =>
+      val tgt = mapping(src)
+      if (src == tgt) acc else acc.withColumnRenamed(src, tgt)
+    }
+    Right(renamed)
   }
 
   /** Read collection data with segment_id and row_offset metadata segment_id
@@ -448,12 +538,14 @@ object MilvusBackfill {
           )
         }
 
-      // Find the pk field in new field data
+      // Find the pk field in new field data (post-mapping column name = pkName)
       val newPkField = backfillDF.schema.fields
-        .find(_.name == "pk")
+        .find(_.name == pkName)
         .getOrElse {
           return Left(
-            SchemaValidationError("New field data must have 'pk' field")
+            SchemaValidationError(
+              s"Backfill data must have PK field '$pkName' (after column mapping)"
+            )
           )
         }
 
@@ -486,7 +578,10 @@ object MilvusBackfill {
       backfillDF: DataFrame,
       pkName: String
   ): DataFrame = {
-    originalDF.join(backfillDF, originalDF(pkName) === backfillDF("pk"), "left")
+    // Use the using-column join form: both sides share the pkName column
+    // (guaranteed by applyColumnMapping), so Spark collapses it into one,
+    // avoiding ambiguous-reference errors downstream.
+    originalDF.join(backfillDF, Seq(pkName), "left")
   }
 
   /** Retrieve Milvus metadata (collection ID and segment-to-partition mapping)

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -324,6 +324,19 @@ object MilvusBackfill {
             )
           )
         }
+        // If the parquet already has a column named pkName, the implicit
+        // {pk→pkName} rename would collide with it. Surface a dedicated error
+        // rather than letting the generic duplicate-target check fire and
+        // reference "column mapping" — users in the legacy path never passed
+        // --column-mapping.
+        if (pkName != "pk" && colSet.contains(pkName)) {
+          return Left(
+            SchemaValidationError(
+              s"Backfill parquet contains both a 'pk' column and a column named '$pkName' " +
+                s"(the collection's primary-key field). Remove one, or supply --column-mapping to disambiguate."
+            )
+          )
+        }
         cols.map(c => if (c == "pk") c -> pkName else c -> c).toMap
     }
 
@@ -370,14 +383,13 @@ object MilvusBackfill {
       )
     }
 
-    // Project, then rename. Use the mapping key order from the original parquet
-    // schema to keep the output stable / deterministic.
+    // Single-pass aliased select. A foldLeft of withColumnRenamed would rename
+    // sequentially and corrupt chains like {a→b, b→c} (the second rename would
+    // hit the already-renamed column) and swaps like {a→b, b→a}.
     val orderedKeys = cols.filter(mapping.contains)
-    val projected = df.select(orderedKeys.map(df.col): _*)
-    val renamed = orderedKeys.foldLeft(projected) { (acc, src) =>
-      val tgt = mapping(src)
-      if (src == tgt) acc else acc.withColumnRenamed(src, tgt)
-    }
+    val renamed = df.select(
+      orderedKeys.map(src => df.col(src).as(mapping(src))): _*
+    )
     Right(renamed)
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -317,10 +317,8 @@ object MilvusBackfill {
         // Legacy: require a literal "pk" column; transparently rename it to pkName.
         if (!colSet.contains("pk")) {
           return Left(
-            DataReadError(
-              path = "",
-              message =
-                "Backfill parquet must contain a 'pk' column (or supply --column-mapping to rename the PK column)"
+            SchemaValidationError(
+              "Backfill parquet must contain a 'pk' column (or supply --column-mapping to rename the PK column)"
             )
           )
         }

--- a/src/test/scala/operations/backfill/ColumnMappingTest.scala
+++ b/src/test/scala/operations/backfill/ColumnMappingTest.scala
@@ -158,7 +158,7 @@ class ColumnMappingTest
     val df = buildDf(Seq("id", "vec"), Seq(Seq(1, "v1")))
     val result = MilvusBackfill.applyColumnMapping(df, "id", None)
     result.isLeft shouldBe true
-    result.left.toOption.get shouldBe a[DataReadError]
+    result.left.toOption.get shouldBe a[SchemaValidationError]
     result.left.toOption.get.message should include("'pk' column")
   }
 

--- a/src/test/scala/operations/backfill/ColumnMappingTest.scala
+++ b/src/test/scala/operations/backfill/ColumnMappingTest.scala
@@ -1,0 +1,219 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{
+  IntegerType,
+  StringType,
+  StructField,
+  StructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/** Unit tests for BackfillApp.parseColumnMapping and
+  * MilvusBackfill.applyColumnMapping — the column-mapping helpers introduced
+  * for backfill parquet schema translation.
+  */
+class ColumnMappingTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("ColumnMappingTest")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  // ============ parseColumnMapping ============
+
+  test("parseColumnMapping parses a simple mapping") {
+    BackfillApp.parseColumnMapping("a:x,b:y") shouldBe Map(
+      "a" -> "x",
+      "b" -> "y"
+    )
+  }
+
+  test("parseColumnMapping tolerates whitespace around tokens") {
+    BackfillApp.parseColumnMapping(" a : x , b:y ") shouldBe Map(
+      "a" -> "x",
+      "b" -> "y"
+    )
+  }
+
+  test("parseColumnMapping tolerates trailing comma and empty segments") {
+    BackfillApp.parseColumnMapping("a:x,,b:y,") shouldBe Map(
+      "a" -> "x",
+      "b" -> "y"
+    )
+  }
+
+  test("parseColumnMapping rejects empty input") {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseColumnMapping("   ")
+    }
+    ex.getMessage should include("cannot be empty")
+  }
+
+  test("parseColumnMapping rejects malformed entries") {
+    intercept[IllegalArgumentException](BackfillApp.parseColumnMapping("a"))
+    intercept[IllegalArgumentException](BackfillApp.parseColumnMapping(":x"))
+    intercept[IllegalArgumentException](BackfillApp.parseColumnMapping("a:"))
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseColumnMapping("a:x,bogus")
+    }
+    ex.getMessage should include("bogus")
+  }
+
+  test("parseColumnMapping rejects duplicate source columns") {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseColumnMapping("a:x,a:y")
+    }
+    ex.getMessage should include("duplicate source")
+    ex.getMessage should include("a")
+  }
+
+  // ============ applyColumnMapping ============
+
+  private def buildDf(cols: Seq[String], rows: Seq[Seq[Any]]): DataFrame = {
+    val schema = StructType(
+      cols.map(c =>
+        StructField(c, if (c == "pk" || c == "id") IntegerType else StringType)
+      )
+    )
+    val javaRows = rows.map(r => Row.fromSeq(r))
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(javaRows),
+      schema
+    )
+  }
+
+  test("applyColumnMapping: explicit mapping renames, drops unlisted columns") {
+    val df = buildDf(
+      Seq("pk", "vec", "extra"),
+      Seq(Seq(1, "v1", "drop-me"), Seq(2, "v2", "drop-me-2"))
+    )
+    val mapping = Some(Map("pk" -> "id", "vec" -> "embedding"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isRight shouldBe true
+    val out = result.toOption.get
+    out.columns.toSeq should contain theSameElementsAs Seq("id", "embedding")
+    val collected =
+      out.orderBy("id").collect().map(r => (r.getInt(0), r.getString(1))).toSeq
+    collected shouldBe Seq((1, "v1"), (2, "v2"))
+  }
+
+  test("applyColumnMapping: chain-rename {a→b, b→c} preserves data pairing") {
+    val df = buildDf(
+      Seq("a", "b", "pk"),
+      Seq(Seq("A1", "B1", 1), Seq("A2", "B2", 2))
+    )
+    val mapping = Some(Map("a" -> "b", "b" -> "c", "pk" -> "id"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isRight shouldBe true
+    val out = result.toOption.get
+    out.columns.toSet shouldBe Set("b", "c", "id")
+    val rows = out.orderBy("id").collect()
+    // Column "b" must contain the original "a" values; column "c" must
+    // contain the original "b" values. The buggy foldLeft would mix these.
+    rows.map(r => r.getAs[String]("b")).toSeq shouldBe Seq("A1", "A2")
+    rows.map(r => r.getAs[String]("c")).toSeq shouldBe Seq("B1", "B2")
+  }
+
+  test("applyColumnMapping: swap {a→b, b→a} preserves data pairing") {
+    val df = buildDf(
+      Seq("a", "b", "pk"),
+      Seq(Seq("A1", "B1", 1))
+    )
+    val mapping = Some(Map("a" -> "b", "b" -> "a", "pk" -> "id"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isRight shouldBe true
+    val out = result.toOption.get
+    out.columns.toSet shouldBe Set("a", "b", "id")
+    val row = out.collect().head
+    row.getAs[String]("b") shouldBe "A1" // original a
+    row.getAs[String]("a") shouldBe "B1" // original b
+  }
+
+  test("applyColumnMapping: legacy path renames 'pk' to pkName") {
+    val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", None)
+    result.isRight shouldBe true
+    val out = result.toOption.get
+    out.columns.toSeq should contain theSameElementsAs Seq("id", "vec")
+  }
+
+  test("applyColumnMapping: legacy path errors when 'pk' column missing") {
+    val df = buildDf(Seq("id", "vec"), Seq(Seq(1, "v1")))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", None)
+    result.isLeft shouldBe true
+    result.left.toOption.get shouldBe a[DataReadError]
+    result.left.toOption.get.message should include("'pk' column")
+  }
+
+  test(
+    "applyColumnMapping: legacy path errors when both 'pk' and pkName exist"
+  ) {
+    val df = buildDf(Seq("pk", "id", "vec"), Seq(Seq(1, 2, "v1")))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", None)
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("'pk'")
+    err.message should include("'id'")
+    err.message should include("--column-mapping")
+  }
+
+  test(
+    "applyColumnMapping: explicit mapping with missing source column errors"
+  ) {
+    val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
+    val mapping = Some(Map("pk" -> "id", "missing" -> "x"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("missing")
+  }
+
+  test("applyColumnMapping: explicit mapping with duplicate targets errors") {
+    val df = buildDf(Seq("pk", "a", "b"), Seq(Seq(1, "a1", "b1")))
+    val mapping = Some(Map("pk" -> "id", "a" -> "x", "b" -> "x"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("duplicate targets")
+  }
+
+  test("applyColumnMapping: explicit mapping missing pkName as target errors") {
+    val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
+    val mapping = Some(Map("pk" -> "wrong_pk", "vec" -> "embedding"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("primary key")
+  }
+
+  test("applyColumnMapping: explicit mapping with only pkName target errors") {
+    val df = buildDf(Seq("pk"), Seq(Seq(1)))
+    val mapping = Some(Map("pk" -> "id"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isLeft shouldBe true
+    val err = result.left.toOption.get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("non-PK")
+  }
+}


### PR DESCRIPTION
Add --column-mapping CLI flag (parquet_col:milvus_field,...) so backfill parquets no longer need a literal "pk" column and can carry extra or renamed columns. The mapping is the single source of truth: listed parquet columns are selected and renamed to their Milvus field names, unlisted columns are dropped, and the PK is auto-detected as the entry whose target matches the collection's primary key name.

Internally MilvusBackfill applies the mapping once (via a new applyColumnMapping helper) right after reading the parquet, which lets us drop the 4 hardcoded "pk" string references and switch performJoin to the using-column form. When --column-mapping is omitted, a legacy implicit mapping ({"pk" -> pkName} plus identity for other columns) is synthesized, so existing callers and scripts keep working unchanged.