### PR TITLE
enhance: add --mode coalesce to backfill for fill-if-null semantics

### DIFF
--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -119,6 +119,11 @@ object MilvusOption {
   val WriterFieldIds =
     "milvus.writer.fieldIds" // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
 
+  // Backfill merge mode
+  val BackfillMode = "milvus.backfill.mode"
+  val BackfillModeOverwrite = "overwrite"
+  val BackfillModeCoalesce = "coalesce"
+
   // Snapshot-based reading options (for offline/client-free mode)
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
   val SnapshotManifests =

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -2,6 +2,8 @@ package com.zilliz.spark.connector.operations.backfill
 
 import org.apache.spark.sql.SparkSession
 
+import com.zilliz.spark.connector.MilvusOption
+
 /** Spark application entry point for running backfill via spark-submit.
   *
   * Usage: spark-submit --class
@@ -9,7 +11,8 @@ import org.apache.spark.sql.SparkSession
   * spark-connector-assembly.jar \ --parquet <path> --snapshot <path> \
   * --s3-endpoint <endpoint> --s3-bucket <bucket> \ --s3-access-key <key>
   * --s3-secret-key <secret> \ [--s3-root-path <path>] [--s3-region <region>]
-  * [--s3-use-ssl] \ [--batch-size <n>] [--output-result <path>]
+  * [--s3-use-ssl] \ [--batch-size <n>] [--output-result <path>] \ [--mode
+  * overwrite|coalesce]
   */
 object BackfillApp {
 
@@ -68,7 +71,8 @@ object BackfillApp {
       sourceS3UseIam = sourceUseIamFlag,
       sourceS3Region = parsed.get("source-s3-region"),
       batchSize = parsed.getOrElse("batch-size", "1024").toInt,
-      columnMapping = parsed.get("column-mapping").map(parseColumnMapping)
+      columnMapping = parsed.get("column-mapping").map(parseColumnMapping),
+      mode = parsed.getOrElse("mode", MilvusOption.BackfillModeOverwrite)
     )
 
     val spark = SparkSession.builder
@@ -129,7 +133,8 @@ object BackfillApp {
     "source-s3-region",
     "batch-size",
     "output-result",
-    "column-mapping"
+    "column-mapping",
+    "mode"
   )
 
   private[backfill] val KnownFlags: Set[String] = BoolFlags ++ KvFlags

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -1,5 +1,7 @@
 package com.zilliz.spark.connector.operations.backfill
 
+import com.zilliz.spark.connector.MilvusOption
+
 /** Configuration for backfill operation
   *
   * @param milvusUri
@@ -74,7 +76,15 @@ case class BackfillConfig(
     // Milvus primary key field name so the pk column can be identified after
     // renaming. When None (default), legacy behavior applies: the parquet
     // must contain a literal "pk" column plus one or more field columns.
-    columnMapping: Option[Map[String, String]] = None
+    columnMapping: Option[Map[String, String]] = None,
+
+    // Merge mode for backfill values:
+    //   "overwrite" (default) — parquet is the source of truth; for every row
+    //     in the collection, write the parquet value (null included).
+    //   "coalesce" — read the target field's current value from source and
+    //     only write the parquet value where the source value is null.
+    //     Per-field: each target field is decided independently.
+    mode: String = MilvusOption.BackfillModeOverwrite
 ) {
 
   /** Validate S3 and writer configuration (always required)
@@ -86,6 +96,14 @@ case class BackfillConfig(
       Left("s3BucketName cannot be empty")
     } else if (batchSize <= 0) {
       Left("batchSize must be positive")
+    } else if (
+      mode != MilvusOption.BackfillModeOverwrite &&
+      mode != MilvusOption.BackfillModeCoalesce
+    ) {
+      Left(
+        s"mode must be '${MilvusOption.BackfillModeOverwrite}' or " +
+          s"'${MilvusOption.BackfillModeCoalesce}' (got '$mode')"
+      )
     } else if (!s3UseIam && (s3AccessKey.isEmpty || s3SecretKey.isEmpty)) {
       // Hard invariant: must use IAM or supply both AK and SK. Half-set
       // static credentials are never valid — they would silently fall back

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -66,6 +66,8 @@ object MilvusBackfill {
       case Right(_) => // Continue
     }
 
+    logger.info(s"Backfill mode: ${config.mode}")
+
     // Step 1: Try to load snapshot metadata
     val snapshotMetadataOpt =
       loadSnapshotMetadata(spark, snapshotPath, config) match {
@@ -140,12 +142,81 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
+      // Extract new field names (all post-mapping columns except the PK).
+      val newFieldNames = backfillDF.schema.fields
+        .map(_.name)
+        .filterNot(_ == pkName)
+        .toSeq
+
+      // Build field name -> field ID mapping from collection schema. Resolved
+      // early (was post-join) so coalesce mode can ask the reader to also
+      // materialize the target fields from source.
+      val fieldNameToId: Map[String, Long] = snapshotMetadataOpt match {
+        case Some(metadata) =>
+          MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
+        case None =>
+          return Left(
+            SchemaValidationError(
+              "ADDFIELD backfill requires field ID mapping from snapshot. " +
+                "Please provide a snapshot path to resolve correct field IDs."
+            )
+          )
+      }
+
+      val missing = newFieldNames.filterNot(fieldNameToId.contains)
+      if (missing.nonEmpty) {
+        return Left(
+          SchemaValidationError(
+            s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
+              s"Available fields: ${fieldNameToId.keys.mkString(", ")}"
+          )
+        )
+      }
+      val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
+
+      // In coalesce mode, also read each target field from source so
+      // `coalesce(src, backfill)` can keep the existing value when non-null.
+      // Requires a snapshot — we need the field's Spark type.
+      val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+      val extraReadFields
+          : Seq[(String, Long, org.apache.spark.sql.types.StructField)] =
+        if (isCoalesceMode) {
+          val metadata = snapshotMetadataOpt.getOrElse {
+            return Left(
+              SchemaValidationError(
+                s"--mode=${MilvusOption.BackfillModeCoalesce} requires a " +
+                  "snapshot path so source field values can be read"
+              )
+            )
+          }
+          newFieldNames.map { n =>
+            val fid = newFieldNameToId(n)
+            val field = metadata.collection.schema.fields
+              .find(_.getFieldIDAsLong == fid)
+              .getOrElse(
+                return Left(
+                  SchemaValidationError(
+                    s"Field '$n' (id=$fid) not found in snapshot schema"
+                  )
+                )
+              )
+            val sparkType = MilvusSnapshotReader.fieldToSparkType(field)
+            (
+              n,
+              fid,
+              org.apache.spark.sql.types
+                .StructField(n, sparkType, nullable = true)
+            )
+          }
+        } else Seq.empty
+
       // Read original collection data with segment metadata
       val originalDF = readCollectionWithMetadata(
         spark,
         config,
         pkFieldId,
-        snapshotMetadataOpt
+        snapshotMetadataOpt,
+        extraReadFields
       ) match {
         case Left(error) => return Left(error)
         case Right(df)   => df
@@ -157,8 +228,14 @@ object MilvusBackfill {
         case Right(_)    => // Continue
       }
 
-      // Perform Sort Merge Join
-      val joinedDF = performJoin(originalDF, backfillDF, pkName)
+      // Merge original and backfill DataFrames according to mode.
+      val joinedDF = performJoin(
+        originalDF,
+        backfillDF,
+        pkName,
+        newFieldNames,
+        config.mode
+      )
 
       // Step 4: Get collection metadata (collectionID, segment-to-partition mapping, base paths)
       val (collectionID, segmentToPartitionMap, segmentBasePathMap) =
@@ -173,37 +250,6 @@ object MilvusBackfill {
               }
             (colId, segPartMap, Map.empty[Long, String])
         }
-
-      // Extract new field names (all post-mapping columns except the PK)
-      val newFieldNames = backfillDF.schema.fields
-        .map(_.name)
-        .filterNot(_ == pkName)
-        .toSeq
-
-      // Build field name -> field ID mapping from collection schema
-      val fieldNameToId: Map[String, Long] = snapshotMetadataOpt match {
-        case Some(metadata) =>
-          MilvusSnapshotReader.getFieldNameToIdMap(metadata.collection.schema)
-        case None =>
-          return Left(
-            SchemaValidationError(
-              "ADDFIELD backfill requires field ID mapping from snapshot. " +
-                "Please provide a snapshot path to resolve correct field IDs."
-            )
-          )
-      }
-
-      // Filter to only the new fields being backfilled, fail fast if any field is missing from snapshot schema
-      val missing = newFieldNames.filterNot(fieldNameToId.contains)
-      if (missing.nonEmpty) {
-        return Left(
-          SchemaValidationError(
-            s"Fields not found in snapshot schema: ${missing.mkString(", ")}. " +
-              s"Available fields: ${fieldNameToId.keys.mkString(", ")}"
-          )
-        )
-      }
-      val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
 
       // Process each segment
       val segmentResults = processSegments(
@@ -404,11 +450,16 @@ object MilvusBackfill {
       spark: SparkSession,
       config: BackfillConfig,
       pkFieldId: Long,
-      snapshotMetadata: Option[SnapshotMetadata]
+      snapshotMetadata: Option[SnapshotMetadata],
+      extraReadFields: Seq[
+        (String, Long, org.apache.spark.sql.types.StructField)
+      ] = Seq.empty
   ): Either[BackfillError, DataFrame] = {
     try {
       var options = config.getMilvusReadOptions
-      options = options + (MilvusOption.ReaderFieldIDs -> pkFieldId.toString)
+      val allFieldIds = pkFieldId +: extraReadFields.map(_._2)
+      options =
+        options + (MilvusOption.ReaderFieldIDs -> allFieldIds.mkString(","))
 
       // If snapshot metadata is available, use snapshot-based reading (no client calls)
       snapshotMetadata.foreach { metadata =>
@@ -476,8 +527,14 @@ object MilvusBackfill {
               )
           }
 
+          // Extend with any extra fields requested (coalesce mode). Field
+          // order in the schema must match the ReaderFieldIDs order.
+          val withExtras = extraReadFields.foldLeft(pkSchema) {
+            case (acc, (_, _, field)) => acc.add(field)
+          }
+
           // Add extra columns for segment tracking
-          val fullSchema = pkSchema
+          val fullSchema = withExtras
             .add("segment_id", org.apache.spark.sql.types.LongType, false)
             .add("row_offset", org.apache.spark.sql.types.LongType, false)
 
@@ -581,17 +638,41 @@ object MilvusBackfill {
     }
   }
 
-  /** Perform left join between original and new field data
+  /** Merge original (source) rows with backfill rows per `mode`.
+    *
+    *   - overwrite: left join on PK; backfill value replaces source (source
+    *     only contributes PK + segment tracking columns).
+    *   - coalesce: original side carries source values for each target field;
+    *     after the left join, compute `coalesce(src, backfill)` per field (keep
+    *     source when non-null, otherwise use backfill).
     */
-  private def performJoin(
+  private[backfill] def performJoin(
       originalDF: DataFrame,
       backfillDF: DataFrame,
-      pkName: String
+      pkName: String,
+      newFieldNames: Seq[String],
+      mode: String
   ): DataFrame = {
-    // Use the using-column join form: both sides share the pkName column
-    // (guaranteed by applyColumnMapping), so Spark collapses it into one,
-    // avoiding ambiguous-reference errors downstream.
-    originalDF.join(backfillDF, Seq(pkName), "left")
+    mode match {
+      case MilvusOption.BackfillModeCoalesce =>
+        // Rename backfill-side target columns to avoid name collisions with
+        // source-side columns now present on originalDF.
+        val suffix = "__bf__"
+        val renamedBackfill = newFieldNames.foldLeft(backfillDF) { (df, n) =>
+          df.withColumnRenamed(n, n + suffix)
+        }
+        val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
+        newFieldNames.foldLeft(joined) { (df, n) =>
+          df.withColumn(n, coalesce(df.col(n), df.col(n + suffix)))
+            .drop(n + suffix)
+        }
+
+      case _ =>
+        // Use the using-column join form: both sides share the pkName column
+        // (guaranteed by applyColumnMapping), so Spark collapses it into one,
+        // avoiding ambiguous-reference errors downstream.
+        originalDF.join(backfillDF, Seq(pkName), "left")
+    }
   }
 
   /** Retrieve Milvus metadata (collection ID and segment-to-partition mapping)

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -210,6 +210,15 @@ object MilvusBackfill {
           }
         } else Seq.empty
 
+      // In coalesce mode, parquet column types must match snapshot field
+      // types exactly (see validateCoalesceTypes for rationale).
+      if (isCoalesceMode) {
+        validateCoalesceTypes(backfillDF.schema, extraReadFields) match {
+          case Left(error) => return Left(error)
+          case Right(_)    => // Continue
+        }
+      }
+
       // Read original collection data with segment metadata
       val originalDF = readCollectionWithMetadata(
         spark,
@@ -583,6 +592,41 @@ object MilvusBackfill {
             cause = Some(e)
           )
         )
+    }
+  }
+
+  /** Coalesce mode requires parquet column types to match snapshot field types
+    * exactly. Spark's `coalesce(src, bf)` would otherwise widen to a common
+    * supertype (e.g. Int + Long → Long) and the writer would emit binlogs whose
+    * Arrow type no longer matches the Milvus field — Milvus would later misread
+    * them.
+    */
+  private[backfill] def validateCoalesceTypes(
+      backfillSchema: org.apache.spark.sql.types.StructType,
+      extraReadFields: Seq[
+        (String, Long, org.apache.spark.sql.types.StructField)
+      ]
+  ): Either[BackfillError, Unit] = {
+    val backfillTypes =
+      backfillSchema.fields.map(f => f.name -> f.dataType).toMap
+    val mismatches = extraReadFields.collect {
+      case (name, _, srcField)
+          if backfillTypes
+            .get(name)
+            .exists(_ != srcField.dataType) =>
+        s"$name (snapshot=${srcField.dataType.simpleString}, " +
+          s"parquet=${backfillTypes(name).simpleString})"
+    }
+    if (mismatches.nonEmpty) {
+      Left(
+        SchemaValidationError(
+          s"--mode=${MilvusOption.BackfillModeCoalesce} requires backfill " +
+            s"parquet column types to match snapshot field types exactly. " +
+            s"Mismatched: ${mismatches.mkString(", ")}"
+        )
+      )
+    } else {
+      Right(())
     }
   }
 

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -248,6 +248,66 @@ class BackfillModeTest
     )
   }
 
+  // ============ validateCoalesceTypes ============
+
+  test("validateCoalesceTypes: matching types pass") {
+    val backfillSchema = StructType(
+      Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("f1", IntegerType, nullable = true),
+        StructField("f2", StringType, nullable = true)
+      )
+    )
+    val extras = Seq(
+      ("f1", 101L, StructField("f1", IntegerType, nullable = true)),
+      ("f2", 102L, StructField("f2", StringType, nullable = true))
+    )
+    MilvusBackfill.validateCoalesceTypes(backfillSchema, extras) shouldBe Right(
+      ()
+    )
+  }
+
+  test("validateCoalesceTypes: mismatched type rejected with clear message") {
+    // parquet sees IntegerType but snapshot says LongType — Spark's coalesce
+    // would silently widen and produce a Long binlog, breaking Milvus reads.
+    val backfillSchema = StructType(
+      Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("f1", IntegerType, nullable = true)
+      )
+    )
+    val extras = Seq(
+      ("f1", 101L, StructField("f1", LongType, nullable = true))
+    )
+    val err = MilvusBackfill
+      .validateCoalesceTypes(backfillSchema, extras)
+      .left
+      .toOption
+      .get
+    err shouldBe a[SchemaValidationError]
+    err.message should include("to match snapshot field types")
+    err.message should include("f1")
+    err.message should include("snapshot=bigint")
+    err.message should include("parquet=int")
+  }
+
+  test(
+    "validateCoalesceTypes: backfill missing the field is not flagged here"
+  ) {
+    // performJoin/processSegments handles missing columns via the left join.
+    // The type validator only complains when both sides have the column AND
+    // the types disagree.
+    val backfillSchema = StructType(
+      Seq(StructField("pk", IntegerType, nullable = false))
+    )
+    val extras = Seq(
+      ("f1", 101L, StructField("f1", LongType, nullable = true))
+    )
+    MilvusBackfill.validateCoalesceTypes(backfillSchema, extras) shouldBe Right(
+      ()
+    )
+  }
+
   test("coalesce mode: empty source columns degrade to full overwrite") {
     // Simulates a just-added field with no prior data: source returns null
     // everywhere, so coalesce naturally falls back to the backfill value.

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -1,0 +1,283 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{
+  IntegerType,
+  LongType,
+  StringType,
+  StructField,
+  StructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+import com.zilliz.spark.connector.MilvusOption
+
+/** Tests for the new `--mode` backfill parameter: CLI/config validation and the
+  * `performJoin` merge semantics (overwrite vs coalesce).
+  */
+class BackfillModeTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("BackfillModeTest")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  // ============ Config / CLI parsing ============
+
+  test("BackfillConfig defaults to overwrite mode") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "a-bucket",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk"
+    )
+    config.mode shouldBe MilvusOption.BackfillModeOverwrite
+    config.validate() shouldBe Right(())
+  }
+
+  test("BackfillConfig accepts coalesce mode") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "a-bucket",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk",
+      mode = MilvusOption.BackfillModeCoalesce
+    )
+    config.validate() shouldBe Right(())
+  }
+
+  test("BackfillConfig rejects unknown mode") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "a-bucket",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk",
+      mode = "bogus"
+    )
+    val err = config.validate().left.toOption.get
+    err should include("mode must be")
+    err should include("bogus")
+  }
+
+  test("parseArgs accepts --mode coalesce") {
+    val parsed = BackfillApp.parseArgs(
+      Array(
+        "--parquet",
+        "/x",
+        "--snapshot",
+        "/y",
+        "--s3-endpoint",
+        "m:9000",
+        "--s3-bucket",
+        "b",
+        "--s3-access-key",
+        "ak",
+        "--s3-secret-key",
+        "sk",
+        "--mode",
+        "coalesce"
+      )
+    )
+    parsed("mode") shouldBe "coalesce"
+  }
+
+  test("parseArgs rejects typo'd --modes") {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseArgs(Array("--modes", "coalesce"))
+    }
+    ex.getMessage should include("Unknown argument")
+  }
+
+  // ============ performJoin semantics ============
+
+  private def buildOriginal(
+      rows: Seq[(Int, java.lang.Integer, java.lang.String, Long, Long)]
+  ): DataFrame = {
+    // columns: pk, f1 (nullable Int), f2 (nullable String), segment_id, row_offset
+    val schema = StructType(
+      Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("f1", IntegerType, nullable = true),
+        StructField("f2", StringType, nullable = true),
+        StructField("segment_id", LongType, nullable = false),
+        StructField("row_offset", LongType, nullable = false)
+      )
+    )
+    val javaRows = rows.map { case (pk, f1, f2, seg, off) =>
+      Row(pk, f1, f2, seg, off)
+    }
+    spark.createDataFrame(spark.sparkContext.parallelize(javaRows), schema)
+  }
+
+  private def buildBackfill(
+      rows: Seq[(Int, java.lang.Integer, java.lang.String)]
+  ): DataFrame = {
+    val schema = StructType(
+      Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("f1", IntegerType, nullable = true),
+        StructField("f2", StringType, nullable = true)
+      )
+    )
+    val javaRows = rows.map { case (pk, f1, f2) => Row(pk, f1, f2) }
+    spark.createDataFrame(spark.sparkContext.parallelize(javaRows), schema)
+  }
+
+  test("overwrite mode: source has only PK, backfill values win") {
+    val originalSchema = StructType(
+      Seq(
+        StructField("pk", IntegerType, nullable = false),
+        StructField("segment_id", LongType, nullable = false),
+        StructField("row_offset", LongType, nullable = false)
+      )
+    )
+    val originalRows = Seq(Row(1, 10L, 0L), Row(2, 10L, 1L), Row(3, 10L, 2L))
+    val original = spark.createDataFrame(
+      spark.sparkContext.parallelize(originalRows),
+      originalSchema
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(100), "A"),
+        (2, null, "B")
+        // pk=3 missing from backfill → left join produces nulls
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeOverwrite
+    )
+
+    val byPk = joined
+      .orderBy("pk")
+      .collect()
+      .map(r =>
+        (
+          r.getAs[Int]("pk"),
+          Option(r.get(r.fieldIndex("f1"))).map(_.asInstanceOf[Int]),
+          Option(r.getAs[String]("f2"))
+        )
+      )
+      .toSeq
+
+    byPk shouldBe Seq(
+      (1, Some(100), Some("A")),
+      (2, None, Some("B")),
+      (3, None, None)
+    )
+  }
+
+  test(
+    "coalesce mode: per-field independent, source-null filled from backfill"
+  ) {
+    // pk=1 — both source fields non-null; keep source values, ignore backfill.
+    // pk=2 — f1 null in source, f2 non-null; fill f1 from backfill, keep f2.
+    // pk=3 — both source fields null; fill both from backfill.
+    // pk=4 — no backfill row; keep whatever source has.
+    val original = buildOriginal(
+      Seq(
+        (1, Int.box(1), "src1", 10L, 0L),
+        (2, null, "src2", 10L, 1L),
+        (3, null, null, 10L, 2L),
+        (4, Int.box(4), null, 10L, 3L)
+      )
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(100), "BF1"),
+        (2, Int.box(200), "BF2"),
+        (3, Int.box(300), "BF3")
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeCoalesce
+    )
+
+    // The join should have the same columns as the source side plus nothing
+    // else (the backfill-side target columns are dropped after coalesce).
+    joined.columns.toSet shouldBe Set(
+      "pk",
+      "f1",
+      "f2",
+      "segment_id",
+      "row_offset"
+    )
+
+    val byPk = joined
+      .orderBy("pk")
+      .collect()
+      .map(r =>
+        (
+          r.getAs[Int]("pk"),
+          Option(r.get(r.fieldIndex("f1"))).map(_.asInstanceOf[Int]),
+          Option(r.getAs[String]("f2"))
+        )
+      )
+      .toSeq
+
+    byPk shouldBe Seq(
+      (1, Some(1), Some("src1")), // source wins on both
+      (2, Some(200), Some("src2")), // f1 filled, f2 kept
+      (3, Some(300), Some("BF3")), // both filled
+      (4, Some(4), None) // no backfill row, f2 stays null
+    )
+  }
+
+  test("coalesce mode: empty source columns degrade to full overwrite") {
+    // Simulates a just-added field with no prior data: source returns null
+    // everywhere, so coalesce naturally falls back to the backfill value.
+    val original = buildOriginal(
+      Seq(
+        (1, null, null, 10L, 0L),
+        (2, null, null, 10L, 1L)
+      )
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(10), "A"),
+        (2, Int.box(20), "B")
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeCoalesce
+    )
+
+    val byPk = joined
+      .orderBy("pk")
+      .collect()
+      .map(r => (r.getAs[Int]("pk"), r.getAs[Int]("f1"), r.getAs[String]("f2")))
+      .toSeq
+
+    byPk shouldBe Seq((1, 10, "A"), (2, 20, "B"))
+  }
+}


### PR DESCRIPTION
Backfill previously always overwrote the target field with the user-provided parquet values (including nulls), which is correct for a fresh AddField but wrong as a repair tool: re-running backfill to plug null rows would also clobber non-null values written by an earlier run.

Add a --mode CLI parameter with two values:

    overwrite (default) — unchanged; parquet is the source of truth.
    coalesce            — read each target field from source and write the
                        parquet value only where the source value is null.
                        Per-field, per-row judgment.

Implementation:
- New constants BackfillMode{,Overwrite,Coalesce} in MilvusOption.
- BackfillConfig.mode with validator rejecting unknown values.
- BackfillApp wires --mode through KvFlags/parseArgs and updates usage.
- MilvusBackfill.run resolves newFieldNameToId earlier so readCollection WithMetadata can be asked to materialize target fields from source via an additional extraReadFields parameter (ReaderFieldIDs + snapshot schema extension).
- performJoin branches on mode: overwrite keeps the left-join; coalesce renames the backfill side with a __bf__ suffix, left-joins, then coalesce(src, bf) per field and drops the suffixed columns.
- Writer path is unchanged — the joined DF has the same shape in both modes.

A field with no prior binlogs reads as all-null and degrades naturally to overwrite semantics; no special branch.

Tests: 8 new cases in BackfillModeTest covering config/CLI validation, per-field independence (pk=1 keeps both src, pk=2 fills f1 keeps f2, pk=3 fills both, pk=4 no backfill row → src preserved), and the all-null degradation case. Full backfill unit suite (67 tests) passes.