### PR TITLE
fix: [backfill] bound V2 writer direct memory by releasing VectorSchemaRoot right after export

### DIFF
--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -217,7 +217,7 @@ class MilvusLoonPartitionWriter(
   private var totalRecordCount = 0L
 
   // Allocate initial capacity for vectors
-  allocateVectors()
+  allocateVectors(root)
 
   // Base path for writing - use custom path if provided, otherwise generate
   private val basePath = {
@@ -390,25 +390,39 @@ class MilvusLoonPartitionWriter(
       arrowArrayC.close()
     }
 
+    // Fully build + allocate the replacement root BEFORE swapping `root`, so
+    // that if allocation throws, the field still points at the old root and
+    // cleanup() can release it. Otherwise an allocation failure mid-swap would
+    // leak the half-allocated newRoot and forget the old one.
+    //
     // Old root's buffers are referenced only by C++ via the export's retained
-    // ref. Closing here drops the JVM ref — buffers stay alive until C++
-    // flushes its cached shared_ptr. Swap in a fresh root before closing so
-    // that if close() misbehaves, cleanup() still has a valid `root` handle.
+    // ref, so closing `oldRoot` at the end just drops the JVM ref — buffers
+    // stay alive until C++ flushes its cached shared_ptr.
+    val newRoot = VectorSchemaRoot.create(arrowSchema, allocator)
+    try {
+      allocateVectors(newRoot)
+    } catch {
+      case t: Throwable =>
+        try newRoot.close()
+        catch { case _: Throwable => /* swallow secondary cleanup error */ }
+        throw t
+    }
     val oldRoot = root
-    root = VectorSchemaRoot.create(arrowSchema, allocator)
-    allocateVectors()
+    root = newRoot
     currentBatchSize = 0
     oldRoot.close()
   }
 
-  /** Allocate or reallocate vectors for the current batch
+  /** Allocate or reallocate vectors for the given root. Takes the root as a
+    * parameter so callers can fully prepare a fresh VectorSchemaRoot before
+    * committing it to the `root` field.
     */
-  private def allocateVectors(): Unit = {
+  private def allocateVectors(r: VectorSchemaRoot): Unit = {
     import scala.collection.JavaConverters._
     import org.apache.arrow.vector.{VarCharVector, BaseVariableWidthVector}
 
     // For each vector, set appropriate initial capacity
-    root.getFieldVectors.asScala.foreach { vector =>
+    r.getFieldVectors.asScala.foreach { vector =>
       vector match {
         case varCharVector: VarCharVector =>
           // For VarChar vectors, allocate both row capacity and byte capacity
@@ -429,8 +443,8 @@ class MilvusLoonPartitionWriter(
       }
     }
 
-    root.allocateNew()
-    root.setRowCount(0)
+    r.allocateNew()
+    r.setRowCount(0)
   }
 
   /** Generate S3 base path for this writer

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -403,14 +403,25 @@ class MilvusLoonPartitionWriter(
       allocateVectors(newRoot)
     } catch {
       case t: Throwable =>
-        try newRoot.close()
-        catch { case _: Throwable => /* swallow secondary cleanup error */ }
+        Try(newRoot.close()).recover { case e: Exception =>
+          logError(
+            s"Error closing newRoot after allocation failure: ${e.getMessage}"
+          )
+        }
         throw t
     }
     val oldRoot = root
     root = newRoot
     currentBatchSize = 0
-    oldRoot.close()
+    // Best-effort: the native write already succeeded and the batch is durable.
+    // Throwing out of flushBatch here would escape to Spark, trigger task retry,
+    // and duplicate the write. Log and continue — the allocator will still
+    // reclaim buffers once the C++ writer flushes its cached shared_ptrs.
+    Try(oldRoot.close()).recover { case e: Exception =>
+      logError(
+        s"Error closing old VectorSchemaRoot after flush: ${e.getMessage}"
+      )
+    }
   }
 
   /** Allocate or reallocate vectors for the given root. Takes the root as a

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -196,16 +196,20 @@ class MilvusLoonPartitionWriter(
     fieldIds
   )
 
-  // Create VectorSchemaRoot to accumulate batches
+  // Create VectorSchemaRoot to accumulate batches.
   // IMPORTANT: root must be var because we create a new one for each flush.
-  // The C++ writer caches RecordBatch shared_ptrs that reference Java-owned buffers
-  // via Arrow C Data Interface (zero-copy). Reusing the same root would overwrite
-  // buffer contents that C++ still references, causing data corruption.
+  // The C++ writer caches RecordBatch shared_ptrs that reference Java-owned
+  // buffers via Arrow C Data Interface (zero-copy). Reusing the same root
+  // would overwrite buffer contents that C++ still references, causing data
+  // corruption — so we swap in a fresh root per flush.
+  //
+  // After export, the source root is closed immediately. `exportVectorSchemaRoot`
+  // independently retains each buffer (verified in ArrowCDataRefcountTest for
+  // every backfill-relevant field type), and C++'s ImportRecordBatch moves
+  // that release callback into the cached shared_ptr, so the buffers stay
+  // alive until C++ drops its ref. This caps per-writer direct memory at
+  // ~16 MB × numGroups instead of growing linearly with the segment's row count.
   private var root = VectorSchemaRoot.create(arrowSchema, allocator)
-
-  // Track exported roots whose buffers are still referenced by C++ RecordBatches.
-  // These must stay alive until the C++ writer is closed.
-  private val exportedRoots = new java.util.ArrayList[VectorSchemaRoot]()
 
   // Batch size configuration
   private val batchSize = milvusOption.insertMaxBatchSize
@@ -369,32 +373,32 @@ class MilvusLoonPartitionWriter(
 
     // Export Arrow array to C interface
     val arrowArrayC = ArrowArray.allocateNew(allocator)
-    Data.exportVectorSchemaRoot(allocator, root, null, arrowArrayC)
-
     try {
+      Data.exportVectorSchemaRoot(allocator, root, null, arrowArrayC)
       // Use synchronized write for the first operation to avoid race conditions
       // in native library's S3 client initialization
       MilvusLoonPartitionWriter.synchronizedWrite {
         writer.write(arrowArrayC.memoryAddress())
         writer.flush()
       }
-
       totalRecordCount += currentBatchSize
-
-      // CRITICAL: Do NOT reuse the same root for the next batch!
-      // The C++ ParquetFileWriter caches RecordBatch shared_ptrs that wrap pointers
-      // to this root's buffers (via Arrow C Data Interface zero-copy import).
-      // If we reuse the same root, writing new data overwrites the buffer memory
-      // that C++ cached batches still reference, causing data corruption.
-      // Instead, keep the old root alive and create a fresh one with new buffers.
-      exportedRoots.add(root)
-      root = VectorSchemaRoot.create(arrowSchema, allocator)
-      allocateVectors()
-      currentBatchSize = 0
-
     } finally {
+      // On success, C++'s ImportRecordBatch already moved the release out of
+      // the struct; close() is a struct-memory cleanup only. On failure, the
+      // release is still here and firing it drops the export-side ref (source
+      // root still has one ref, so buffers remain alive for cleanup to free).
       arrowArrayC.close()
     }
+
+    // Old root's buffers are referenced only by C++ via the export's retained
+    // ref. Closing here drops the JVM ref — buffers stay alive until C++
+    // flushes its cached shared_ptr. Swap in a fresh root before closing so
+    // that if close() misbehaves, cleanup() still has a valid `root` handle.
+    val oldRoot = root
+    root = VectorSchemaRoot.create(arrowSchema, allocator)
+    allocateVectors()
+    currentBatchSize = 0
+    oldRoot.close()
   }
 
   /** Allocate or reallocate vectors for the current batch
@@ -510,20 +514,15 @@ class MilvusLoonPartitionWriter(
       logError(s"Error destroying writer: ${e.getMessage}")
     }
 
-    // Close current root (not yet exported)
+    // Close current root (not yet exported). Previously-exported roots were
+    // already closed inside flushBatch right after export — the export-side
+    // refcount keeps their buffers alive until C++ drops the cached shared_ptr,
+    // and `writer.destroy()` above already fired every remaining release
+    // callback, returning those buffers to the allocator.
     Try {
       if (root != null) root.close()
     }.recover { case e: Exception =>
       logError(s"Error closing VectorSchemaRoot: ${e.getMessage}")
-    }
-
-    // Close exported roots whose buffers were referenced by C++ RecordBatches.
-    // By this point the C++ writer is destroyed, so all release callbacks have fired.
-    Try {
-      exportedRoots.forEach(r => Try(r.close()))
-      exportedRoots.clear()
-    }.recover { case e: Exception =>
-      logError(s"Error closing exported roots: ${e.getMessage}")
     }
 
     Try {

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -259,14 +259,25 @@ class MilvusV2BinlogWriter(
       allocateVectors(newRoot)
     } catch {
       case t: Throwable =>
-        try newRoot.close()
-        catch { case _: Throwable => /* swallow secondary cleanup error */ }
+        Try(newRoot.close()).failed.foreach(e =>
+          logError(
+            s"error closing newRoot after allocation failure: ${e.getMessage}"
+          )
+        )
         throw t
     }
     val oldRoot = root
     root = newRoot
     currentBatchSize = 0
-    oldRoot.close()
+    // Best-effort: the native write already succeeded and the batch is durable.
+    // Throwing out of flushBatch here would escape to Spark, trigger task retry,
+    // and duplicate the write. Log and continue — the allocator will still
+    // reclaim buffers once the C++ writer flushes its cached shared_ptrs.
+    Try(oldRoot.close()).failed.foreach(e =>
+      logError(
+        s"error closing old VectorSchemaRoot after flush: ${e.getMessage}"
+      )
+    )
   }
 
   private def allocateVectors(r: VectorSchemaRoot): Unit = {

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -157,10 +157,14 @@ class MilvusV2BinlogWriter(
   )
 
   // Batch accumulation. The current `root` collects rows; each flush exports
-  // it via the Arrow C Data Interface. The C++ writer caches RecordBatch
-  // shared_ptrs that wrap the JVM-owned buffers (zero-copy), so we MUST
-  // keep flushed roots alive until the writer is closed — same trap
-  // documented in MilvusLoonPartitionWriter.
+  // it via Arrow C Data Interface, hands the cArray to the C++ writer, then
+  // immediately closes the source root. The export retains each buffer on
+  // its own (verified in ArrowCDataRefcountTest across every backfill-
+  // relevant field type), so closing the source only drops the JVM-side ref —
+  // C++'s cached RecordBatch shared_ptr keeps the buffers alive and fires the
+  // release callback when it drops. This bounds per-writer direct memory to
+  // ~16 MB × numGroups, down from O(segment rows) that the old "retain every
+  // root until writer.close()" strategy incurred.
   private val batchSize: Int =
     if (milvusOption.insertMaxBatchSize > 0) milvusOption.insertMaxBatchSize
     else 5000
@@ -169,7 +173,6 @@ class MilvusV2BinlogWriter(
   allocateVectors(root)
   private var currentBatchSize: Int = 0
   private var totalRows: Long = 0L
-  private val exportedRoots = new java.util.ArrayList[VectorSchemaRoot]()
   private var closed: Boolean = false
 
   /** Consume one Spark row. Each field in `row` must be at the same positional
@@ -235,17 +238,24 @@ class MilvusV2BinlogWriter(
       Data.exportVectorSchemaRoot(allocator, root, null, cArray)
       writer.write(cArray.memoryAddress())
       totalRows += currentBatchSize
-
-      // CRITICAL: do NOT reuse `root`. C++ caches RecordBatch ptrs into
-      // these buffers. Hand the old root off to `exportedRoots` (closed
-      // after writer.close()) and create a fresh one for subsequent rows.
-      exportedRoots.add(root)
-      root = VectorSchemaRoot.create(arrowSchema, allocator)
-      allocateVectors(root)
-      currentBatchSize = 0
     } finally {
+      // The C++ writer's ImportRecordBatch moves the release callback out of
+      // this struct on success; on failure the release is still here and
+      // closing will fire it, dropping the export-side ref (source root still
+      // holds one ref, so buffers remain alive until abort/cleanup runs).
       cArray.close()
     }
+
+    // Old root's buffers are now referenced only by C++ via the export's
+    // retained ref. Closing here just drops the JVM ref — buffers stay alive
+    // until C++ flushes the cached shared_ptr. Swap in a fresh root before
+    // closing so that if close() misbehaves, cleanup() still operates on a
+    // valid `root` handle.
+    val oldRoot = root
+    root = VectorSchemaRoot.create(arrowSchema, allocator)
+    allocateVectors(root)
+    currentBatchSize = 0
+    oldRoot.close()
   }
 
   private def allocateVectors(r: VectorSchemaRoot): Unit = {
@@ -263,17 +273,15 @@ class MilvusV2BinlogWriter(
   }
 
   private def cleanup(): Unit = {
+    // Destroying the writer first drops all C++-cached RecordBatch shared_ptrs,
+    // which fires every outstanding release callback and returns the buffers
+    // they were pinning to the allocator. Only then is it safe to close the
+    // allocator.
     Try(writer.destroy()).failed.foreach(e =>
       logError(s"error destroying packed writer: ${e.getMessage}")
     )
     Try(if (root != null) root.close()).failed.foreach(e =>
       logError(s"error closing current root: ${e.getMessage}")
-    )
-    Try {
-      exportedRoots.forEach(r => Try(r.close()))
-      exportedRoots.clear()
-    }.failed.foreach(e =>
-      logError(s"error closing exported roots: ${e.getMessage}")
     )
     Try(if (arrowSchemaC != null) arrowSchemaC.close()).failed.foreach(e =>
       logError(s"error closing ArrowSchema: ${e.getMessage}")

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -246,14 +246,25 @@ class MilvusV2BinlogWriter(
       cArray.close()
     }
 
+    // Fully build + allocate the replacement root BEFORE swapping `root`, so
+    // that if allocation throws, the field still points at the old root and
+    // cleanup() can release it. Otherwise an allocation failure mid-swap would
+    // leak the half-allocated newRoot and forget the old one.
+    //
     // Old root's buffers are now referenced only by C++ via the export's
-    // retained ref. Closing here just drops the JVM ref — buffers stay alive
-    // until C++ flushes the cached shared_ptr. Swap in a fresh root before
-    // closing so that if close() misbehaves, cleanup() still operates on a
-    // valid `root` handle.
+    // retained ref, so closing `oldRoot` at the end just drops the JVM ref —
+    // buffers stay alive until C++ flushes the cached shared_ptr.
+    val newRoot = VectorSchemaRoot.create(arrowSchema, allocator)
+    try {
+      allocateVectors(newRoot)
+    } catch {
+      case t: Throwable =>
+        try newRoot.close()
+        catch { case _: Throwable => /* swallow secondary cleanup error */ }
+        throw t
+    }
     val oldRoot = root
-    root = VectorSchemaRoot.create(arrowSchema, allocator)
-    allocateVectors(root)
+    root = newRoot
     currentBatchSize = 0
     oldRoot.close()
   }

--- a/src/test/scala/write/ArrowCDataRefcountTest.scala
+++ b/src/test/scala/write/ArrowCDataRefcountTest.scala
@@ -1,0 +1,720 @@
+package com.zilliz.spark.connector.write
+
+import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.c.{
+  ArrowArray,
+  ArrowSchema,
+  CDataDictionaryProvider,
+  Data
+}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.{
+  BigIntVector,
+  BitVector,
+  FixedSizeBinaryVector,
+  Float4Vector,
+  IntVector,
+  VarBinaryVector,
+  VarCharVector,
+  VectorSchemaRoot
+}
+import org.apache.arrow.vector.complex.{FixedSizeListVector, ListVector}
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Verifies Arrow Java 17's C Data Interface refcount semantics:
+  * `Data.exportVectorSchemaRoot` must retain each buffer independently of the
+  * source root, so that closing the source root immediately after export does
+  * not invalidate the exported buffers.
+  *
+  * This is the correctness precondition for the aggressive memory strategy in
+  * [[MilvusV2BinlogWriter]] / [[MilvusLoonWriter]]: close each
+  * `VectorSchemaRoot` right after exporting it to the C++ writer, instead of
+  * retaining every root until the writer closes (which caused per-segment
+  * direct-memory growth proportional to row count).
+  *
+  * The tests cover the field types the backfill V2 path emits:
+  *   - fixed-width primitive (Int32, Int64, Float32)
+  *   - boolean (bit-packed validity + value)
+  *   - variable-width (Utf8, Binary)
+  *   - fixed-size binary
+  *   - FixedSizeList<Float> (embedded vectors)
+  *   - List<Int> (variable-length array)
+  *   - nullable columns (validity bitmap must survive close + import)
+  *
+  * Each test round-trips data through export → close(source) → import and
+  * verifies byte-for-byte equality.
+  */
+class ArrowCDataRefcountTest extends AnyFunSuite with Matchers {
+
+  /** Populate + export + close source + import-back, verify `check` on the
+    * imported root.
+    */
+  private def roundTrip(
+      field: Field,
+      populate: VectorSchemaRoot => Unit,
+      rowCount: Int
+  )(check: VectorSchemaRoot => Unit): Unit = {
+    val parent = new RootAllocator(Long.MaxValue)
+    try {
+      val alloc = parent.newChildAllocator("test", 0, Long.MaxValue)
+      val schema = new Schema(java.util.List.of(field))
+      val root = VectorSchemaRoot.create(schema, alloc)
+
+      populate(root)
+      root.setRowCount(rowCount)
+      val bytesBeforeExport = alloc.getAllocatedMemory
+      bytesBeforeExport should be > 0L
+
+      val cSchema = ArrowSchema.allocateNew(alloc)
+      val cArray = ArrowArray.allocateNew(alloc)
+      try {
+        Data.exportSchema(alloc, schema, null, cSchema)
+        Data.exportVectorSchemaRoot(alloc, root, null, cArray)
+
+        // THE invariant under test: the source root can be closed immediately
+        // because `exportVectorSchemaRoot` retained each buffer on its own.
+        root.close()
+
+        // If retain semantics were broken, the underlying buffers would be freed
+        // by root.close() and the subsequent import would either crash (SIGSEGV)
+        // or observe garbage. A live allocated-byte count proves buffers survive.
+        alloc.getAllocatedMemory should be > 0L
+
+        val provider = new CDataDictionaryProvider()
+        val imported =
+          Data.importVectorSchemaRoot(alloc, cArray, cSchema, provider)
+        try {
+          imported.getRowCount shouldBe rowCount
+          check(imported)
+        } finally {
+          imported.close()
+          provider.close()
+        }
+
+        // After the imported root closes, the release callback fires and drops
+        // the last refcount — allocator should be empty again.
+        alloc.getAllocatedMemory shouldBe 0L
+      } finally {
+        cArray.close()
+        cSchema.close()
+        alloc.close()
+      }
+    } finally parent.close()
+  }
+
+  // ---------------------------------------------------------------- primitives
+
+  test(
+    "Int32 nullable: export → close source → import preserves values and nulls"
+  ) {
+    val field =
+      new Field("i32", FieldType.nullable(new ArrowType.Int(32, true)), null)
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("i32").asInstanceOf[IntVector]
+        v.allocateNew(5)
+        v.setSafe(0, 42)
+        v.setSafe(1, -7)
+        v.setNull(2)
+        v.setSafe(3, Int.MaxValue)
+        v.setSafe(4, Int.MinValue)
+        v.setValueCount(5)
+      },
+      rowCount = 5
+    ) { root =>
+      val v = root.getVector("i32").asInstanceOf[IntVector]
+      v.get(0) shouldBe 42
+      v.get(1) shouldBe -7
+      v.isNull(2) shouldBe true
+      v.get(3) shouldBe Int.MaxValue
+      v.get(4) shouldBe Int.MinValue
+    }
+  }
+
+  test("Int64 non-nullable: all values round-trip") {
+    val field =
+      new Field("i64", FieldType.notNullable(new ArrowType.Int(64, true)), null)
+    val values = Array[Long](0L, 1L, -1L, Long.MaxValue, Long.MinValue, 42L)
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("i64").asInstanceOf[BigIntVector]
+        v.allocateNew(values.length)
+        values.zipWithIndex.foreach { case (x, i) => v.setSafe(i, x) }
+        v.setValueCount(values.length)
+      },
+      rowCount = values.length
+    ) { root =>
+      val v = root.getVector("i64").asInstanceOf[BigIntVector]
+      values.zipWithIndex.foreach { case (x, i) => v.get(i) shouldBe x }
+    }
+  }
+
+  test("Float32 with alternating nulls: validity bitmap survives") {
+    val field = new Field(
+      "f32",
+      FieldType.nullable(
+        new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+      ),
+      null
+    )
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("f32").asInstanceOf[Float4Vector]
+        v.allocateNew(6)
+        v.setSafe(0, 1.5f)
+        v.setNull(1)
+        v.setSafe(2, -3.25f)
+        v.setNull(3)
+        v.setSafe(4, Float.PositiveInfinity)
+        v.setSafe(5, Float.NaN)
+        v.setValueCount(6)
+      },
+      rowCount = 6
+    ) { root =>
+      val v = root.getVector("f32").asInstanceOf[Float4Vector]
+      v.get(0) shouldBe 1.5f
+      v.isNull(1) shouldBe true
+      v.get(2) shouldBe -3.25f
+      v.isNull(3) shouldBe true
+      v.get(4) shouldBe Float.PositiveInfinity
+      java.lang.Float.isNaN(v.get(5)) shouldBe true
+    }
+  }
+
+  test("Boolean: bit-packed buffer round-trips") {
+    val field =
+      new Field("b", FieldType.nullable(new ArrowType.Bool()), null)
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("b").asInstanceOf[BitVector]
+        v.allocateNew(8)
+        v.setSafe(0, 1)
+        v.setSafe(1, 0)
+        v.setNull(2)
+        v.setSafe(3, 1)
+        v.setSafe(4, 1)
+        v.setSafe(5, 0)
+        v.setSafe(6, 0)
+        v.setSafe(7, 1)
+        v.setValueCount(8)
+      },
+      rowCount = 8
+    ) { root =>
+      val v = root.getVector("b").asInstanceOf[BitVector]
+      v.get(0) shouldBe 1
+      v.get(1) shouldBe 0
+      v.isNull(2) shouldBe true
+      v.get(3) shouldBe 1
+      v.get(4) shouldBe 1
+      v.get(5) shouldBe 0
+      v.get(6) shouldBe 0
+      v.get(7) shouldBe 1
+    }
+  }
+
+  // --------------------------------------------------------------- var-width
+
+  test(
+    "Utf8 VarChar with empty / null / multi-byte values: offsets + data survive"
+  ) {
+    val field = new Field("s", FieldType.nullable(new ArrowType.Utf8()), null)
+    val payloads =
+      Seq("foo", "", "日本語", null, "a longer string used to grow the buffer")
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("s").asInstanceOf[VarCharVector]
+        v.allocateNew(1024L, payloads.size)
+        payloads.zipWithIndex.foreach {
+          case (null, i) => v.setNull(i)
+          case (s, i) =>
+            v.setSafe(i, s.getBytes(StandardCharsets.UTF_8))
+        }
+        v.setValueCount(payloads.size)
+      },
+      rowCount = payloads.size
+    ) { root =>
+      val v = root.getVector("s").asInstanceOf[VarCharVector]
+      payloads.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (s, i) =>
+          new String(v.get(i), StandardCharsets.UTF_8) shouldBe s
+      }
+    }
+  }
+
+  test("Binary VarBinary preserves byte payloads including empty") {
+    val field =
+      new Field("bin", FieldType.nullable(new ArrowType.Binary()), null)
+    val payloads: Seq[Array[Byte]] = Seq(
+      Array[Byte](1, 2, 3),
+      Array[Byte](),
+      null,
+      Array.fill[Byte](256)(0x7f.toByte),
+      Array[Byte](0, 0, 0, 1)
+    )
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("bin").asInstanceOf[VarBinaryVector]
+        v.allocateNew(1024L, payloads.size)
+        payloads.zipWithIndex.foreach {
+          case (null, i)  => v.setNull(i)
+          case (bytes, i) => v.setSafe(i, bytes)
+        }
+        v.setValueCount(payloads.size)
+      },
+      rowCount = payloads.size
+    ) { root =>
+      val v = root.getVector("bin").asInstanceOf[VarBinaryVector]
+      payloads.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (bytes, i) =>
+          v.get(i) shouldBe bytes
+      }
+    }
+  }
+
+  test("FixedSizeBinary: fixed-length byte payloads round-trip") {
+    val field =
+      new Field(
+        "fsb",
+        FieldType.nullable(new ArrowType.FixedSizeBinary(8)),
+        null
+      )
+    val payloads: Seq[Array[Byte]] = Seq(
+      Array[Byte](0, 1, 2, 3, 4, 5, 6, 7),
+      null,
+      Array.fill[Byte](8)(0xff.toByte),
+      Array[Byte](8, 7, 6, 5, 4, 3, 2, 1)
+    )
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("fsb").asInstanceOf[FixedSizeBinaryVector]
+        v.allocateNew(payloads.size)
+        payloads.zipWithIndex.foreach {
+          case (null, i)  => v.setNull(i)
+          case (bytes, i) => v.setSafe(i, bytes)
+        }
+        v.setValueCount(payloads.size)
+      },
+      rowCount = payloads.size
+    ) { root =>
+      val v = root.getVector("fsb").asInstanceOf[FixedSizeBinaryVector]
+      payloads.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (bytes, i) =>
+          v.getObject(i) shouldBe bytes
+      }
+    }
+  }
+
+  // --------------------------------------------------------------- containers
+
+  test("FixedSizeList<Float> (vector embedding) round-trips") {
+    val listType = new ArrowType.FixedSizeList(4)
+    val child = new Field(
+      "$data$",
+      FieldType.nullable(
+        new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+      ),
+      null
+    )
+    val field =
+      new Field("vec", FieldType.nullable(listType), java.util.List.of(child))
+
+    val rows: Seq[Array[Float]] = Seq(
+      Array(1.0f, 2.0f, 3.0f, 4.0f),
+      Array(Float.NaN, 0.0f, -0.0f, Float.MinValue),
+      null,
+      Array(1e10f, 1e-10f, -1e10f, 1.5f)
+    )
+
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("vec").asInstanceOf[FixedSizeListVector]
+        val inner = v.getDataVector.asInstanceOf[Float4Vector]
+        v.allocateNew()
+        inner.allocateNew(rows.length * 4)
+        rows.zipWithIndex.foreach {
+          case (null, i) => v.setNull(i)
+          case (arr, i) =>
+            v.setNotNull(i)
+            (0 until 4).foreach { k =>
+              inner.setSafe(i * 4 + k, arr(k))
+            }
+        }
+        inner.setValueCount(rows.length * 4)
+        v.setValueCount(rows.length)
+      },
+      rowCount = rows.length
+    ) { root =>
+      val v = root.getVector("vec").asInstanceOf[FixedSizeListVector]
+      val inner = v.getDataVector.asInstanceOf[Float4Vector]
+      rows.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (arr, i) =>
+          (0 until 4).foreach { k =>
+            val got = inner.get(i * 4 + k)
+            if (java.lang.Float.isNaN(arr(k)))
+              java.lang.Float.isNaN(got) shouldBe true
+            else got shouldBe arr(k)
+          }
+      }
+    }
+  }
+
+  test(
+    "List<Int> (variable-length array) round-trips with nulls and empty lists"
+  ) {
+    val listType = new ArrowType.List()
+    val child = new Field(
+      "$data$",
+      FieldType.nullable(new ArrowType.Int(32, true)),
+      null
+    )
+    val field =
+      new Field("xs", FieldType.nullable(listType), java.util.List.of(child))
+
+    val rows: Seq[Seq[Int]] =
+      Seq(Seq(1, 2, 3), Seq.empty, null, Seq(42), Seq(-1, -2, -3, -4, -5))
+
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("xs").asInstanceOf[ListVector]
+        val inner = v.getDataVector.asInstanceOf[IntVector]
+        inner.allocateNew(64)
+        v.allocateNew()
+
+        var flat = 0
+        rows.zipWithIndex.foreach {
+          case (null, i) =>
+            v.setNull(i)
+          case (xs, i) =>
+            v.startNewValue(i)
+            xs.foreach { x =>
+              inner.setSafe(flat, x)
+              flat += 1
+            }
+            v.endValue(i, xs.length)
+        }
+        inner.setValueCount(flat)
+        v.setValueCount(rows.length)
+      },
+      rowCount = rows.length
+    ) { root =>
+      val v = root.getVector("xs").asInstanceOf[ListVector]
+      val inner = v.getDataVector.asInstanceOf[IntVector]
+      rows.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (xs, i) =>
+          v.isNull(i) shouldBe false
+          val start = v.getOffsetBuffer.getInt(i.toLong * 4)
+          val end = v.getOffsetBuffer.getInt((i.toLong + 1) * 4)
+          (end - start) shouldBe xs.length
+          (0 until xs.length).foreach { k =>
+            inner.get(start + k) shouldBe xs(k)
+          }
+      }
+    }
+  }
+
+  // --------------------------------------------------------- multi-batch path
+
+  test(
+    "multi-batch: close each source root immediately — all exports remain readable"
+  ) {
+    // Mirrors the writer's flushBatch loop: export batch, close source root,
+    // verify the exported cArray still imports cleanly and data is intact.
+    // Running sequentially (export + close + import per batch) matches the
+    // sub-batch flush semantics in the real writer and keeps the test's own
+    // resource management trivial.
+    val parent = new RootAllocator(Long.MaxValue)
+    try {
+      val alloc = parent.newChildAllocator("multi", 0, Long.MaxValue)
+      val field =
+        new Field("v", FieldType.nullable(new ArrowType.Int(64, true)), null)
+      val schema = new Schema(java.util.List.of(field))
+
+      val numBatches = 20
+      val rowsPerBatch = 32
+
+      (0 until numBatches).foreach { b =>
+        val root = VectorSchemaRoot.create(schema, alloc)
+        val v = root.getVector("v").asInstanceOf[BigIntVector]
+        v.allocateNew(rowsPerBatch)
+        (0 until rowsPerBatch).foreach { i =>
+          v.setSafe(i, (b * rowsPerBatch + i).toLong)
+        }
+        v.setValueCount(rowsPerBatch)
+        root.setRowCount(rowsPerBatch)
+
+        val cSchema = ArrowSchema.allocateNew(alloc)
+        val cArray = ArrowArray.allocateNew(alloc)
+        try {
+          Data.exportSchema(alloc, schema, null, cSchema)
+          Data.exportVectorSchemaRoot(alloc, root, null, cArray)
+          // Aggressive close: source root goes away immediately. If the export
+          // did not retain buffers, the subsequent import would see garbage or
+          // SIGSEGV.
+          root.close()
+          alloc.getAllocatedMemory should be > 0L
+
+          val provider = new CDataDictionaryProvider()
+          val imported =
+            Data.importVectorSchemaRoot(alloc, cArray, cSchema, provider)
+          try {
+            val iv = imported.getVector("v").asInstanceOf[BigIntVector]
+            (0 until rowsPerBatch).foreach { i =>
+              iv.get(i) shouldBe (b * rowsPerBatch + i).toLong
+            }
+          } finally {
+            imported.close()
+            provider.close()
+          }
+        } finally {
+          cArray.close()
+          cSchema.close()
+        }
+
+        alloc.getAllocatedMemory shouldBe 0L
+      }
+
+      alloc.close()
+    } finally parent.close()
+  }
+
+  test(
+    "concurrent holders: multiple imports outlive source — all see intact data"
+  ) {
+    // Simulates the real writer scenario more precisely: source root closes
+    // immediately; the exported cArray is NOT imported right away. Multiple
+    // batches' exports coexist in memory simultaneously (bounded by the C++
+    // writer's 16 MB threshold, not by the source roots' lifetimes).
+    val parent = new RootAllocator(Long.MaxValue)
+    try {
+      val alloc = parent.newChildAllocator("concurrent", 0, Long.MaxValue)
+      val field =
+        new Field("v", FieldType.nullable(new ArrowType.Int(64, true)), null)
+      val schema = new Schema(java.util.List.of(field))
+
+      val numBatches = 8
+      val rowsPerBatch = 16
+
+      case class Held(cSchema: ArrowSchema, cArray: ArrowArray)
+
+      // Export every batch; close each source root right after export.
+      val held = (0 until numBatches).map { b =>
+        val root = VectorSchemaRoot.create(schema, alloc)
+        val v = root.getVector("v").asInstanceOf[BigIntVector]
+        v.allocateNew(rowsPerBatch)
+        (0 until rowsPerBatch).foreach(i =>
+          v.setSafe(i, (b * rowsPerBatch + i).toLong)
+        )
+        v.setValueCount(rowsPerBatch)
+        root.setRowCount(rowsPerBatch)
+
+        val cSchema = ArrowSchema.allocateNew(alloc)
+        val cArray = ArrowArray.allocateNew(alloc)
+        Data.exportSchema(alloc, schema, null, cSchema)
+        Data.exportVectorSchemaRoot(alloc, root, null, cArray)
+        root.close()
+        Held(cSchema, cArray)
+      }
+
+      // All sources closed; exports keep buffers alive independently.
+      alloc.getAllocatedMemory should be > 0L
+
+      // Import every batch in order and verify — proves each export's refcount
+      // independently survived the source root's close.
+      held.zipWithIndex.foreach { case (h, b) =>
+        val provider = new CDataDictionaryProvider()
+        try {
+          val imported =
+            Data.importVectorSchemaRoot(alloc, h.cArray, h.cSchema, provider)
+          try {
+            val iv = imported.getVector("v").asInstanceOf[BigIntVector]
+            (0 until rowsPerBatch).foreach(i =>
+              iv.get(i) shouldBe (b * rowsPerBatch + i).toLong
+            )
+          } finally imported.close()
+        } finally {
+          provider.close()
+          h.cArray.close()
+          h.cSchema.close()
+        }
+      }
+
+      alloc.getAllocatedMemory shouldBe 0L
+      alloc.close()
+    } finally parent.close()
+  }
+
+  // -------------------------------------------------- combined row all-types
+
+  test(
+    "combined schema with all backfill-relevant types round-trips in one export"
+  ) {
+    val fields = java.util.List.of(
+      new Field(
+        "pk",
+        FieldType.notNullable(new ArrowType.Int(64, true)),
+        null
+      ),
+      new Field("name", FieldType.nullable(new ArrowType.Utf8()), null),
+      new Field("blob", FieldType.nullable(new ArrowType.Binary()), null),
+      new Field(
+        "hash",
+        FieldType.nullable(new ArrowType.FixedSizeBinary(4)),
+        null
+      ),
+      new Field(
+        "flag",
+        FieldType.nullable(new ArrowType.Bool()),
+        null
+      ),
+      new Field(
+        "vec",
+        FieldType.nullable(new ArrowType.FixedSizeList(2)),
+        java.util.List.of(
+          new Field(
+            "$data$",
+            FieldType.nullable(
+              new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+            ),
+            null
+          )
+        )
+      )
+    )
+    val schema = new Schema(fields)
+    val parent = new RootAllocator(Long.MaxValue)
+    try {
+      val alloc = parent.newChildAllocator("mixed", 0, Long.MaxValue)
+      val root = VectorSchemaRoot.create(schema, alloc)
+
+      val pk = root.getVector("pk").asInstanceOf[BigIntVector]
+      val name = root.getVector("name").asInstanceOf[VarCharVector]
+      val blob = root.getVector("blob").asInstanceOf[VarBinaryVector]
+      val hash = root.getVector("hash").asInstanceOf[FixedSizeBinaryVector]
+      val flag = root.getVector("flag").asInstanceOf[BitVector]
+      val vec = root.getVector("vec").asInstanceOf[FixedSizeListVector]
+      val vecInner = vec.getDataVector.asInstanceOf[Float4Vector]
+
+      val n = 3
+      pk.allocateNew(n)
+      name.allocateNew(1024L, n)
+      blob.allocateNew(1024L, n)
+      hash.allocateNew(n)
+      flag.allocateNew(n)
+      vec.allocateNew()
+      vecInner.allocateNew(n * 2)
+
+      pk.setSafe(0, 100L); pk.setSafe(1, 200L); pk.setSafe(2, 300L)
+      name.setSafe(0, "a".getBytes(StandardCharsets.UTF_8))
+      name.setNull(1)
+      name.setSafe(2, "xyz".getBytes(StandardCharsets.UTF_8))
+      blob.setSafe(0, Array[Byte](0x01.toByte, 0x02.toByte))
+      blob.setNull(1)
+      blob.setSafe(2, Array[Byte]())
+      hash.setSafe(
+        0,
+        Array[Byte](0x00.toByte, 0x11.toByte, 0x22.toByte, 0x33.toByte)
+      )
+      hash.setSafe(
+        1,
+        Array[Byte](0xaa.toByte, 0xbb.toByte, 0xcc.toByte, 0xdd.toByte)
+      )
+      hash.setNull(2)
+      flag.setSafe(0, 1); flag.setNull(1); flag.setSafe(2, 0)
+      (0 until n).foreach { i =>
+        vec.setNotNull(i)
+        vecInner.setSafe(i * 2, i.toFloat)
+        vecInner.setSafe(i * 2 + 1, (i + 0.5).toFloat)
+      }
+
+      pk.setValueCount(n)
+      name.setValueCount(n)
+      blob.setValueCount(n)
+      hash.setValueCount(n)
+      flag.setValueCount(n)
+      vecInner.setValueCount(n * 2)
+      vec.setValueCount(n)
+      root.setRowCount(n)
+
+      val cSchema = ArrowSchema.allocateNew(alloc)
+      val cArray = ArrowArray.allocateNew(alloc)
+      try {
+        Data.exportSchema(alloc, schema, null, cSchema)
+        Data.exportVectorSchemaRoot(alloc, root, null, cArray)
+
+        root.close()
+        alloc.getAllocatedMemory should be > 0L
+
+        val provider = new CDataDictionaryProvider()
+        val imported =
+          Data.importVectorSchemaRoot(alloc, cArray, cSchema, provider)
+        try {
+          val ipk = imported.getVector("pk").asInstanceOf[BigIntVector]
+          val iname = imported.getVector("name").asInstanceOf[VarCharVector]
+          val iblob = imported.getVector("blob").asInstanceOf[VarBinaryVector]
+          val ihash =
+            imported.getVector("hash").asInstanceOf[FixedSizeBinaryVector]
+          val iflag = imported.getVector("flag").asInstanceOf[BitVector]
+          val ivec = imported.getVector("vec").asInstanceOf[FixedSizeListVector]
+          val ivecInner = ivec.getDataVector.asInstanceOf[Float4Vector]
+
+          ipk.get(0) shouldBe 100L
+          ipk.get(1) shouldBe 200L
+          ipk.get(2) shouldBe 300L
+          new String(iname.get(0), StandardCharsets.UTF_8) shouldBe "a"
+          iname.isNull(1) shouldBe true
+          new String(iname.get(2), StandardCharsets.UTF_8) shouldBe "xyz"
+          iblob.get(0) shouldBe Array[Byte](0x01.toByte, 0x02.toByte)
+          iblob.isNull(1) shouldBe true
+          iblob.get(2).length shouldBe 0
+          ihash.getObject(0) shouldBe Array[Byte](
+            0x00.toByte,
+            0x11.toByte,
+            0x22.toByte,
+            0x33.toByte
+          )
+          ihash.getObject(1) shouldBe Array[Byte](
+            0xaa.toByte,
+            0xbb.toByte,
+            0xcc.toByte,
+            0xdd.toByte
+          )
+          ihash.isNull(2) shouldBe true
+          iflag.get(0) shouldBe 1
+          iflag.isNull(1) shouldBe true
+          iflag.get(2) shouldBe 0
+          (0 until n).foreach { i =>
+            ivecInner.get(i * 2) shouldBe i.toFloat
+            ivecInner.get(i * 2 + 1) shouldBe (i + 0.5).toFloat
+          }
+        } finally {
+          imported.close()
+          provider.close()
+        }
+        alloc.getAllocatedMemory shouldBe 0L
+      } finally {
+        cArray.close()
+        cSchema.close()
+        alloc.close()
+      }
+    } finally parent.close()
+  }
+}

--- a/src/test/scala/write/ArrowCDataRefcountTest.scala
+++ b/src/test/scala/write/ArrowCDataRefcountTest.scala
@@ -15,12 +15,19 @@ import org.apache.arrow.vector.{
   BitVector,
   FixedSizeBinaryVector,
   Float4Vector,
+  Float8Vector,
   IntVector,
+  SmallIntVector,
+  TinyIntVector,
   VarBinaryVector,
   VarCharVector,
   VectorSchemaRoot
 }
-import org.apache.arrow.vector.complex.{FixedSizeListVector, ListVector}
+import org.apache.arrow.vector.complex.{
+  FixedSizeListVector,
+  ListVector,
+  StructVector
+}
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.scalatest.funsuite.AnyFunSuite
@@ -37,14 +44,23 @@ import org.scalatest.matchers.should.Matchers
   * retaining every root until the writer closes (which caused per-segment
   * direct-memory growth proportional to row count).
   *
-  * The tests cover the field types the backfill V2 path emits:
-  *   - fixed-width primitive (Int32, Int64, Float32)
+  * The tests cover the Arrow types emitted by `MilvusSchemaUtil
+  * .convertSparkSchemaToArrow` (the schema converter used by both writers):
+  *   - fixed-width primitives: Int8, Int16, Int32, Int64, Float32, Float64
   *   - boolean (bit-packed validity + value)
-  *   - variable-width (Utf8, Binary)
-  *   - fixed-size binary
-  *   - FixedSizeList<Float> (embedded vectors)
-  *   - List<Int> (variable-length array)
-  *   - nullable columns (validity bitmap must survive close + import)
+  *   - variable-width: Utf8, Binary
+  *   - FixedSizeBinary (the backfill path's representation of dense float
+  *     vectors)
+  *   - FixedSizeList<Float> (alternative embedded-vector representation)
+  *   - List<Int>, List<Utf8> (variable-length arrays with both fixed- and
+  *     variable-width children)
+  *   - Struct<Int64, Utf8> (nested fields with independent buffers)
+  *   - nullable validity bitmaps across all of the above
+  *
+  * Arrow's Map type is not exercised directly because it is physically encoded
+  * as `List<Struct<key, value>>`; the refcount property for Map follows from
+  * the List and Struct cases combined with Arrow C Data Interface's uniform
+  * buffer-ownership model.
   *
   * Each test round-trips data through export → close(source) → import and
   * verifies byte-for-byte equality.
@@ -186,6 +202,90 @@ class ArrowCDataRefcountTest extends AnyFunSuite with Matchers {
       v.isNull(3) shouldBe true
       v.get(4) shouldBe Float.PositiveInfinity
       java.lang.Float.isNaN(v.get(5)) shouldBe true
+    }
+  }
+
+  test("Float64 with NaN / infinities and nulls: round-trip preserves bits") {
+    val field = new Field(
+      "f64",
+      FieldType.nullable(
+        new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+      ),
+      null
+    )
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("f64").asInstanceOf[Float8Vector]
+        v.allocateNew(6)
+        v.setSafe(0, 1.25)
+        v.setNull(1)
+        v.setSafe(2, -0.0)
+        v.setSafe(3, Double.PositiveInfinity)
+        v.setSafe(4, Double.NegativeInfinity)
+        v.setSafe(5, Double.NaN)
+        v.setValueCount(6)
+      },
+      rowCount = 6
+    ) { root =>
+      val v = root.getVector("f64").asInstanceOf[Float8Vector]
+      v.get(0) shouldBe 1.25
+      v.isNull(1) shouldBe true
+      java.lang.Double.doubleToRawLongBits(v.get(2)) shouldBe
+        java.lang.Double.doubleToRawLongBits(-0.0)
+      v.get(3) shouldBe Double.PositiveInfinity
+      v.get(4) shouldBe Double.NegativeInfinity
+      java.lang.Double.isNaN(v.get(5)) shouldBe true
+    }
+  }
+
+  test("Int16 (ShortType) boundary values round-trip") {
+    val field =
+      new Field("i16", FieldType.nullable(new ArrowType.Int(16, true)), null)
+    val values: Seq[java.lang.Short] =
+      Seq[Short](0, 1, -1, Short.MaxValue, Short.MinValue, 42).map(
+        java.lang.Short.valueOf
+      )
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("i16").asInstanceOf[SmallIntVector]
+        v.allocateNew(values.length + 1)
+        values.zipWithIndex.foreach { case (x, i) =>
+          v.setSafe(i, x.shortValue)
+        }
+        v.setNull(values.length)
+        v.setValueCount(values.length + 1)
+      },
+      rowCount = values.length + 1
+    ) { root =>
+      val v = root.getVector("i16").asInstanceOf[SmallIntVector]
+      values.zipWithIndex.foreach { case (x, i) =>
+        v.get(i) shouldBe x.shortValue
+      }
+      v.isNull(values.length) shouldBe true
+    }
+  }
+
+  test("Int8 (ByteType) boundary values round-trip") {
+    val field =
+      new Field("i8", FieldType.nullable(new ArrowType.Int(8, true)), null)
+    val values: Seq[Byte] =
+      Seq[Byte](0, 1, -1, Byte.MaxValue, Byte.MinValue, 42)
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("i8").asInstanceOf[TinyIntVector]
+        v.allocateNew(values.length + 1)
+        values.zipWithIndex.foreach { case (x, i) => v.setSafe(i, x) }
+        v.setNull(values.length)
+        v.setValueCount(values.length + 1)
+      },
+      rowCount = values.length + 1
+    ) { root =>
+      val v = root.getVector("i8").asInstanceOf[TinyIntVector]
+      values.zipWithIndex.foreach { case (x, i) => v.get(i) shouldBe x }
+      v.isNull(values.length) shouldBe true
     }
   }
 
@@ -427,6 +527,113 @@ class ArrowCDataRefcountTest extends AnyFunSuite with Matchers {
           (0 until xs.length).foreach { k =>
             inner.get(start + k) shouldBe xs(k)
           }
+      }
+    }
+  }
+
+  test(
+    "List<Utf8>: list with a variable-width child preserves offsets and data"
+  ) {
+    val listType = new ArrowType.List()
+    val child =
+      new Field("$data$", FieldType.nullable(new ArrowType.Utf8()), null)
+    val field =
+      new Field("ls", FieldType.nullable(listType), java.util.List.of(child))
+
+    val rows: Seq[Seq[String]] = Seq(
+      Seq("a", "bb", "ccc"),
+      Seq.empty,
+      null,
+      Seq("日本語", ""),
+      Seq("a longer string used to grow the child buffer")
+    )
+
+    roundTrip(
+      field,
+      populate = { root =>
+        val v = root.getVector("ls").asInstanceOf[ListVector]
+        val inner = v.getDataVector.asInstanceOf[VarCharVector]
+        inner.allocateNew(1024L, 16)
+        v.allocateNew()
+
+        var flat = 0
+        rows.zipWithIndex.foreach {
+          case (null, i) =>
+            v.setNull(i)
+          case (xs, i) =>
+            v.startNewValue(i)
+            xs.foreach { s =>
+              inner.setSafe(flat, s.getBytes(StandardCharsets.UTF_8))
+              flat += 1
+            }
+            v.endValue(i, xs.length)
+        }
+        inner.setValueCount(flat)
+        v.setValueCount(rows.length)
+      },
+      rowCount = rows.length
+    ) { root =>
+      val v = root.getVector("ls").asInstanceOf[ListVector]
+      val inner = v.getDataVector.asInstanceOf[VarCharVector]
+      rows.zipWithIndex.foreach {
+        case (null, i) => v.isNull(i) shouldBe true
+        case (xs, i) =>
+          v.isNull(i) shouldBe false
+          val start = v.getOffsetBuffer.getInt(i.toLong * 4)
+          val end = v.getOffsetBuffer.getInt((i.toLong + 1) * 4)
+          (end - start) shouldBe xs.length
+          xs.zipWithIndex.foreach { case (s, k) =>
+            new String(inner.get(start + k), StandardCharsets.UTF_8) shouldBe s
+          }
+      }
+    }
+  }
+
+  test(
+    "Struct<Int64, Utf8>: nested fields preserve buffers independently"
+  ) {
+    val children = java.util.List.of(
+      new Field("k", FieldType.notNullable(new ArrowType.Int(64, true)), null),
+      new Field("v", FieldType.nullable(new ArrowType.Utf8()), null)
+    )
+    val field =
+      new Field("s", FieldType.nullable(new ArrowType.Struct()), children)
+
+    val rows: Seq[(Long, String)] = Seq(
+      (100L, "alpha"),
+      (200L, null),
+      (300L, "日本語"),
+      (400L, "")
+    )
+
+    roundTrip(
+      field,
+      populate = { root =>
+        val sv = root.getVector("s").asInstanceOf[StructVector]
+        sv.allocateNew()
+        val kv = sv.getChild("k", classOf[BigIntVector])
+        val vv = sv.getChild("v", classOf[VarCharVector])
+
+        rows.zipWithIndex.foreach { case ((k, s), i) =>
+          sv.setIndexDefined(i)
+          kv.setSafe(i, k)
+          if (s == null) vv.setNull(i)
+          else vv.setSafe(i, s.getBytes(StandardCharsets.UTF_8))
+        }
+        kv.setValueCount(rows.length)
+        vv.setValueCount(rows.length)
+        sv.setValueCount(rows.length)
+      },
+      rowCount = rows.length
+    ) { root =>
+      val sv = root.getVector("s").asInstanceOf[StructVector]
+      val kv = sv.getChild("k", classOf[BigIntVector])
+      val vv = sv.getChild("v", classOf[VarCharVector])
+      rows.zipWithIndex.foreach { case ((k, s), i) =>
+        sv.isNull(i) shouldBe false
+        kv.get(i) shouldBe k
+        if (s == null) vv.isNull(i) shouldBe true
+        else new String(vv.get(i), StandardCharsets.UTF_8) shouldBe s
       }
     }
   }


### PR DESCRIPTION
MilvusV2BinlogWriter and MilvusLoonWriter previously retained every flushed VectorSchemaRoot in `exportedRoots` until the native writer closed, because Arrow C Data Interface's zero-copy export shares buffer pointers with the C++ PackedRecordBatchWriter's cached RecordBatch shared_ptrs. Per-writer direct memory grew as O(totalRows × avgRowBytes), causing executors to OOM with `org.apache.arrow.memory.OutOfMemoryException: Failure allocating buffer` on large V2 segments.

Arrow 17's `Data.exportVectorSchemaRoot` retains each buffer independently of the source root, and C++'s `ImportRecordBatch` moves the release callback into its shared_ptr — so closing the source root right after export drops only the JVM-side ref while the buffer stays alive until C++ drops the cached batch. Direct memory is now bounded to roughly 16 MB × numGroups (the packed writer's buffer_size × column groups) regardless of segment size.

Verified via the new ArrowCDataRefcountTest: 12 round-trip cases covering Int32 / Int64 / Float32 / Bool / Utf8 / Binary / FixedSizeBinary / FixedSizeList<Float> / List<Int>, combined multi-type schema, sequential multi-batch, and concurrent-holders scenarios (all exported batches close their source roots immediately and are imported afterwards with intact data). All 12 tests pass on Arrow 17.0.0; allocator is empty after every import closes, proving no leak.