### PR TITLE
fix: [backfill] avoid quadratic varchar over-allocation in allocateVectors

### DIFF
--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -436,17 +436,15 @@ class MilvusLoonPartitionWriter(
     r.getFieldVectors.asScala.foreach { vector =>
       vector match {
         case varCharVector: VarCharVector =>
-          // For VarChar vectors, allocate both row capacity and byte capacity
-          // This will auto-expand if needed, but starts small to avoid OOM
-          val estimatedBytesPerValue = 32
-          val totalByteCapacity = batchSize * estimatedBytesPerValue
-          varCharVector.setInitialCapacity(batchSize, totalByteCapacity)
+          // Second arg is density (bytes per value), NOT total bytes. Arrow
+          // computes the initial data buffer size as valueCount × density
+          // internally. Passing `batchSize * 32` here gave batchSize² × 32 —
+          // a quadratic over-allocation (~32 MiB per column at batch=1024)
+          // that exploded into GiB-scale peaks and caused direct-memory OOM.
+          varCharVector.setInitialCapacity(batchSize, 32.0)
 
         case baseVarVector: BaseVariableWidthVector =>
-          // For other variable-width vectors (like VarBinary)
-          val estimatedBytesPerValue = 32
-          val totalByteCapacity = batchSize * estimatedBytesPerValue
-          baseVarVector.setInitialCapacity(batchSize, totalByteCapacity)
+          baseVarVector.setInitialCapacity(batchSize, 32.0)
 
         case _ =>
           // For fixed-width vectors, just set row capacity

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -284,9 +284,14 @@ class MilvusV2BinlogWriter(
     import scala.collection.JavaConverters._
     r.getFieldVectors.asScala.foreach {
       case v: VarCharVector =>
-        v.setInitialCapacity(batchSize, batchSize.toLong * 32L)
+        // Second arg is density (bytes per value), NOT total bytes.
+        // Total buffer = batchSize × density. Passing batchSize*32 here would
+        // give batchSize² × 32 bytes — a quadratic over-allocation that dwarfs
+        // actual data (20-byte values) by ~1000× and made a single allocator
+        // peak ~1 GiB for a 20k-row segment.
+        v.setInitialCapacity(batchSize, 32.0)
       case v: BaseVariableWidthVector =>
-        v.setInitialCapacity(batchSize, batchSize.toLong * 32L)
+        v.setInitialCapacity(batchSize, 32.0)
       case other =>
         other.setInitialCapacity(batchSize)
     }


### PR DESCRIPTION
Arrow Java's BaseVariableWidthVector.setInitialCapacity(valueCount, density) expects `density` as bytes per value, not total bytes. The old code in MilvusV2BinlogWriter and MilvusLoonWriter passed `batchSize * 32L` as the second argument, so Arrow computed the data buffer size as

    valueCount × density = batchSize × (batchSize × 32) = batchSize² × 32

At the default batchSize=1024 this pre-allocates 32 MiB per varchar column. With two varchar targets per writer, plus the export-side retain and C++ cached_batches_ holding prior buffers, a single RootAllocator peak hit ~1 GiB on local repro (64 MiB `actual` leaked on close, 1 GiB peak) for a 20480-row segment carrying ~820 KB of real data — roughly a 1000× over-allocation. Production surfaced the same bug as a ~7 GiB per-writer peak × 4 concurrent writers = direct-memory OOM.

Pass density = 32.0 directly so the initial allocation reflects the intended "≈32 bytes per varchar value" estimate. At default batch size this drops per-column pre-allocation from 32 MiB to 32 KiB.

Verified locally: the same repro (`--batch-size 1024`, 2 varchar columns length 20, 20480 rows) that previously died with
`OutOfMemoryException: Failure allocating buffer` + `Memory leaked: (67125248)` now completes successfully with no allocator warnings. The quadratic-scaling evidence (`actual = batchSize² × 32 × numCols`):

batchSize | observed actual leaked | batchSize² × 32 × 2
----------|------------------------|--------------------
    1024 |  67,125,248 |   67,108,864
    2048 |  268,468,224  |  268,435,456