### PR TITLE
enhance: [backfill] report source / data-file / matched row counts in result and logs

### DIFF
--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -37,7 +37,16 @@ case class SegmentBackfillResult(
       * above; for V2 there is no manifest, so consumers should read this
       * artifact to patch the snapshot.
       */
-    v2Artifact: Option[V2SegmentArtifact] = None
+    v2Artifact: Option[V2SegmentArtifact] = None,
+    /** Source (snapshot) row count for this segment — equal to `rowCount` on
+      * the success path because the left join preserves every source row, but
+      * kept separate so consumers don't have to rely on that invariant.
+      */
+    sourceRowCount: Long = 0L,
+    /** Source rows whose PK was matched in the backfill parquet. Derived from a
+      * `__bf_matched__` marker column injected before the left join.
+      */
+    matchedRowCount: Long = 0L
 )
 
 /** Comprehensive result of backfill operation
@@ -51,16 +60,28 @@ case class BackfillResult(
     executionTimeMs: Long,
     collectionId: Long,
     partitionId: Long,
-    newFieldNames: Seq[String]
+    newFieldNames: Seq[String],
+    totalSourceRows: Long = 0L,
+    totalBackfillDataRows: Long = 0L,
+    totalMatchedRows: Long = 0L
 ) {
+
+  private def matchRateStr(matched: Long, total: Long): String =
+    if (total <= 0) "n/a" else f"${matched.toDouble / total * 100}%.2f%%"
 
   /** Get a summary string of the backfill operation
     */
   def summary: String = {
     val v2Count = segmentResults.count(_._2.v2Artifact.isDefined)
+    val sourceRate = matchRateStr(totalMatchedRows, totalSourceRows)
+    val dataFileRate = matchRateStr(totalMatchedRows, totalBackfillDataRows)
     s"""Backfill Summary:
-       |  Status: ${if (success) "SUCCESS" else "FAILED"}
+       |  Status: ${if (success) "SUCCESS"
+      else "FAILED"}
        |  Segments Processed: $segmentsProcessed
+       |  Total Source Rows: $totalSourceRows
+       |  Total Backfill Data File Rows: $totalBackfillDataRows
+       |  Total Matched Rows: $totalMatchedRows (of source: $sourceRate, of data file: $dataFileRate)
        |  Total Rows Written: $totalRowsWritten
        |  Execution Time: ${executionTimeMs}ms
        |  Collection ID: $collectionId
@@ -77,7 +98,8 @@ case class BackfillResult(
     val segmentLines =
       segmentResults.toSeq.sortBy(_._1).map { case (segId, result) =>
         val tag = if (result.v2Artifact.isDefined) "[v2]" else "[v3]"
-        s"    Segment $segId $tag: ${result.rowCount} rows, version=${result.committedVersion}, ${result.executionTimeMs}ms, path=${result.outputPath}"
+        val rate = matchRateStr(result.matchedRowCount, result.sourceRowCount)
+        s"    Segment $segId $tag: source=${result.sourceRowCount}, matched=${result.matchedRowCount} ($rate), written=${result.rowCount}, version=${result.committedVersion}, ${result.executionTimeMs}ms, path=${result.outputPath}"
       }
     s"Segment Details:\n${segmentLines.mkString("\n")}"
   }
@@ -99,6 +121,8 @@ case class BackfillResult(
         val base = scala.collection.mutable.LinkedHashMap[String, Any](
           "version" -> r.committedVersion,
           "rowCount" -> r.rowCount,
+          "sourceRowCount" -> r.sourceRowCount,
+          "matchedRowCount" -> r.matchedRowCount,
           "executionTimeMs" -> r.executionTimeMs,
           "outputPath" -> r.outputPath,
           "manifestPaths" -> r.manifestPaths
@@ -117,11 +141,14 @@ case class BackfillResult(
       }
       .toMap
 
-    val result = Map(
+    val result = scala.collection.mutable.LinkedHashMap[String, Any](
       "success" -> success,
       "collectionId" -> collectionId,
       "partitionId" -> partitionId,
       "segmentsProcessed" -> segmentsProcessed,
+      "totalSourceRows" -> totalSourceRows,
+      "totalBackfillDataRows" -> totalBackfillDataRows,
+      "totalMatchedRows" -> totalMatchedRows,
       "totalRowsWritten" -> totalRowsWritten,
       "executionTimeMs" -> executionTimeMs,
       "newFieldNames" -> newFieldNames,
@@ -150,9 +177,12 @@ object BackfillResult {
       executionTimeMs: Long,
       collectionId: Long,
       partitionId: Long,
-      newFieldNames: Seq[String]
+      newFieldNames: Seq[String],
+      totalBackfillDataRows: Long = 0L
   ): BackfillResult = {
     val totalRows = segmentResults.values.map(_.rowCount).sum
+    val totalSource = segmentResults.values.map(_.sourceRowCount).sum
+    val totalMatched = segmentResults.values.map(_.matchedRowCount).sum
     val allManifests = segmentResults.values.flatMap(_.manifestPaths).toSeq
 
     BackfillResult(
@@ -164,7 +194,10 @@ object BackfillResult {
       executionTimeMs = executionTimeMs,
       collectionId = collectionId,
       partitionId = partitionId,
-      newFieldNames = newFieldNames
+      newFieldNames = newFieldNames,
+      totalSourceRows = totalSource,
+      totalBackfillDataRows = totalBackfillDataRows,
+      totalMatchedRows = totalMatched
     )
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -36,6 +36,13 @@ object MilvusBackfill {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
+  /** Marker column added to the backfill side before the left join so we can
+    * count how many source rows found a PK match (non-null marker → matched).
+    * Kept on the DataFrame all the way down to the per-segment partition
+    * function, and stripped from the projection written to parquet.
+    */
+  private[backfill] val MatchFlagCol = "__bf_matched__"
+
   /** Backfill new fields into a Milvus collection
     *
     * @param spark
@@ -155,6 +162,13 @@ object MilvusBackfill {
         case Left(error) => return Left(error)
         case Right(df)   => df
       }
+
+      // One extra parquet scan so the result can report the raw input row
+      // count alongside snapshot / matched counts — useful when debugging
+      // low join-match rates (e.g. data file has keys that aren't in the
+      // collection).
+      val backfillRowCount = backfillDF.count()
+      logger.info(s"Backfill data file rows: $backfillRowCount")
 
       // Extract new field names (all post-mapping columns except the PK).
       val newFieldNames = backfillDF.schema.fields
@@ -304,7 +318,8 @@ object MilvusBackfill {
         executionTimeMs = executionTime,
         collectionId = collectionID,
         partitionId = if (partitionIDs.size == 1) partitionIDs.head else -1,
-        newFieldNames = newFieldNames
+        newFieldNames = newFieldNames,
+        totalBackfillDataRows = backfillRowCount
       )
 
       Right(result)
@@ -730,13 +745,16 @@ object MilvusBackfill {
       newFieldNames: Seq[String],
       mode: String
   ): DataFrame = {
+    val backfillWithFlag =
+      backfillDF.withColumn(MatchFlagCol, lit(true))
     mode match {
       case MilvusOption.BackfillModeCoalesce =>
         // Rename backfill-side target columns to avoid name collisions with
         // source-side columns now present on originalDF.
         val suffix = "__bf__"
-        val renamedBackfill = newFieldNames.foldLeft(backfillDF) { (df, n) =>
-          df.withColumnRenamed(n, n + suffix)
+        val renamedBackfill = newFieldNames.foldLeft(backfillWithFlag) {
+          (df, n) =>
+            df.withColumnRenamed(n, n + suffix)
         }
         val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
         newFieldNames.foldLeft(joined) { (df, n) =>
@@ -748,7 +766,7 @@ object MilvusBackfill {
         // Use the using-column join form: both sides share the pkName column
         // (guaranteed by applyColumnMapping), so Spark collapses it into one,
         // avoiding ambiguous-reference errors downstream.
-        originalDF.join(backfillDF, Seq(pkName), "left")
+        originalDF.join(backfillWithFlag, Seq(pkName), "left")
     }
   }
 
@@ -821,11 +839,19 @@ object MilvusBackfill {
   ): Either[BackfillError, Map[Long, SegmentBackfillResult]] = {
 
     try {
-      // Prepare data: select only needed columns and add segment_id for partitioning
+      // Prepare data: select only needed columns and add segment_id for
+      // partitioning. Trailing column is the backfill match flag — retained
+      // here so executors can count PK-matched rows, stripped from the
+      // projection that reaches the writer.
       val preparedDF = joinedDF
-        .select((Seq("segment_id", "row_offset") ++ newFieldNames).map(col): _*)
+        .select(
+          (Seq("segment_id", "row_offset") ++ newFieldNames ++ Seq(
+            MatchFlagCol
+          )).map(col): _*
+        )
 
-      // Get the schema for new fields only (without segment_id and row_offset)
+      // Get the schema for new fields only (without segment_id, row_offset,
+      // or the match flag)
       val targetSchema = org.apache.spark.sql.types.StructType(
         newFieldNames.map(fieldName =>
           preparedDF.schema.fields.find(_.name == fieldName).get
@@ -911,12 +937,31 @@ object MilvusBackfill {
       val totalTime = results.map(_._1.executionTimeMs).sum
       val avgTime = if (results.nonEmpty) totalTime / results.length else 0
       val totalRows = results.map(_._1.rowCount).sum
+      val totalSource = results.map(_._1.sourceRowCount).sum
+      val totalMatched = results.map(_._1.matchedRowCount).sum
+      val matchRateStr =
+        if (totalSource > 0)
+          f"${totalMatched.toDouble / totalSource * 100}%.2f%%"
+        else "n/a"
 
       logger.info("=== Backfill Summary ===")
       logger.info(s"Total segments: ${results.length}")
-      logger.info(s"Total rows processed: $totalRows")
+      logger.info(s"Total source rows: $totalSource")
+      logger.info(
+        s"Total matched rows: $totalMatched (match rate: $matchRateStr)"
+      )
+      logger.info(s"Total rows written: $totalRows")
       logger.info(s"Total time for all segments: ${totalTime}ms")
       logger.info(s"Average time per segment: ${avgTime}ms")
+      results.sortBy(_._1.segmentId).foreach { case (r, _) =>
+        val segRate =
+          if (r.sourceRowCount > 0)
+            f"${r.matchedRowCount.toDouble / r.sourceRowCount * 100}%.2f%%"
+          else "n/a"
+        logger.info(
+          s"Segment ${r.segmentId}: source=${r.sourceRowCount}, matched=${r.matchedRowCount} ($segRate), written=${r.rowCount}"
+        )
+      }
 
       Right(successfulResults)
 
@@ -992,12 +1037,19 @@ object MilvusBackfill {
     try {
       var rowCount = 0L
       var nullRowCount = 0L
+      var matchedRowCount = 0L
 
       def writeRow(row: InternalRow): Unit = {
-        val targetFields = (2 until row.numFields)
+        // Row layout: [segment_id, row_offset, ...newFields, __bf_matched__]
+        // Strip the first two tracking cols and the trailing match flag before
+        // handing values to the writer.
+        val matchFlagIdx = row.numFields - 1
+        val dataEnd = matchFlagIdx
+        val targetFields = (2 until dataEnd)
           .map(i => row.get(i, targetSchema.fields(i - 2).dataType))
           .toArray
         if (targetFields.forall(_ == null)) nullRowCount += 1
+        if (!row.isNullAt(matchFlagIdx)) matchedRowCount += 1
         writer.write(
           new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(
             targetFields
@@ -1027,7 +1079,9 @@ object MilvusBackfill {
             manifestPaths = manifestPaths,
             outputPath = outputPath,
             executionTimeMs = System.currentTimeMillis() - startTime,
-            committedVersion = committedVersion
+            committedVersion = committedVersion,
+            sourceRowCount = rowCount,
+            matchedRowCount = matchedRowCount
           ),
           None
         )
@@ -1202,20 +1256,29 @@ object MilvusBackfill {
     )
 
     var rowCount = 0L
+    var matchedRowCount = 0L
     try {
-      // The first two columns of each row are (segment_id, row_offset); the
-      // V2 writer only wants the trailing data columns, so we build a
-      // projected row before calling write().
+      // Row layout: [segment_id, row_offset, ...newFields, __bf_matched__].
+      // The V2 writer only wants the newField columns; strip the tracking
+      // columns and the match flag (the flag is instead folded into
+      // matchedRowCount).
       def projected(row: InternalRow): InternalRow = {
-        val values = (2 until row.numFields)
+        val matchFlagIdx = row.numFields - 1
+        val dataEnd = matchFlagIdx
+        val values = (2 until dataEnd)
           .map(i => row.get(i, targetSchema.fields(i - 2).dataType))
           .toArray
         new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(values)
       }
+      def countMatch(row: InternalRow): Unit = {
+        if (!row.isNullAt(row.numFields - 1)) matchedRowCount += 1
+      }
 
+      countMatch(firstRow)
       writer.write(projected(firstRow))
       rowCount += 1
       iter.foreach { row =>
+        countMatch(row)
         writer.write(projected(row))
         rowCount += 1
       }
@@ -1246,7 +1309,9 @@ object MilvusBackfill {
                 storageVersion = 2L,
                 columnGroups = columnGroupArtifacts
               )
-            )
+            ),
+            sourceRowCount = rowCount,
+            matchedRowCount = matchedRowCount
           ),
           None
         )

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -73,6 +73,10 @@ object MilvusBackfill {
       case Right(_) => // Continue
     }
 
+    // Tracked so we can unpersist in the outer finally, even on mid-flight
+    // failure (the cache is taken right after column mapping, below).
+    var cachedBackfillDF: DataFrame = null
+
     logger.info(s"Backfill mode: ${config.mode}")
 
     // Step 1: Try to load snapshot metadata
@@ -163,18 +167,60 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
-      // One extra parquet scan so the result can report the raw input row
-      // count alongside snapshot / matched counts — useful when debugging
-      // low join-match rates (e.g. data file has keys that aren't in the
-      // collection).
-      val backfillRowCount = backfillDF.count()
-      logger.info(s"Backfill data file rows: $backfillRowCount")
+      // Cache so the upcoming count / distinct-PK aggregation doesn't force
+      // a second parquet scan when performJoin consumes the DF later. Held
+      // until after processSegments (see finally block for unpersist).
+      backfillDF.cache()
+      cachedBackfillDF = backfillDF
 
       // Extract new field names (all post-mapping columns except the PK).
       val newFieldNames = backfillDF.schema.fields
         .map(_.name)
         .filterNot(_ == pkName)
         .toSeq
+
+      // Reject a backfill column named MatchFlagCol: the join adds a
+      // lit(true) marker under that name, which would silently overwrite a
+      // user column (overwrite mode) or blow up with AnalysisException on
+      // the coalesce rename/self-reference (coalesce mode).
+      if (newFieldNames.contains(MatchFlagCol)) {
+        return Left(
+          SchemaValidationError(
+            s"Backfill parquet contains a column named '$MatchFlagCol', " +
+              "which is reserved for internal use by the backfill join. " +
+              "Rename the column (or use --column-mapping) and retry."
+          )
+        )
+      }
+
+      // One aggregation over the cached DF gives us both totals: the raw
+      // input row count (reported in the result / logs for debugging low
+      // match rates) and the distinct-PK count (used below to fail fast on
+      // duplicates — see rationale there).
+      val countsRow = backfillDF
+        .agg(count(lit(1)), countDistinct(col(pkName)))
+        .head()
+      val backfillRowCount = countsRow.getLong(0)
+      val distinctPkCount = countsRow.getLong(1)
+      logger.info(
+        s"Backfill data file rows: $backfillRowCount " +
+          s"(distinct ${pkName}: $distinctPkCount)"
+      )
+
+      // Duplicate PKs on the backfill side cause each source row with a
+      // matching PK to be emitted once per duplicate by the left join,
+      // inflating per-segment rowCount / sourceRowCount / matchedRowCount.
+      // Rather than silently report misleading metrics, fail fast so the
+      // user can dedupe upstream.
+      if (distinctPkCount != backfillRowCount) {
+        return Left(
+          SchemaValidationError(
+            s"Backfill parquet contains duplicate primary-key values " +
+              s"(rows=$backfillRowCount, distinct ${pkName}=$distinctPkCount). " +
+              "Deduplicate the input (e.g. dropDuplicates on the PK) and retry."
+          )
+        )
+      }
 
       // Build field name -> field ID mapping from collection schema. Resolved
       // early (was post-join) so coalesce mode can ask the reader to also
@@ -336,6 +382,14 @@ object MilvusBackfill {
         } catch {
           case e: Exception =>
             logger.warn("Failed to close Milvus client", e)
+        }
+      }
+      if (cachedBackfillDF != null) {
+        try {
+          cachedBackfillDF.unpersist()
+        } catch {
+          case e: Exception =>
+            logger.warn("Failed to unpersist backfill DataFrame", e)
         }
       }
     }

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -218,14 +218,16 @@ class BackfillModeTest
       MilvusOption.BackfillModeCoalesce
     )
 
-    // The join should have the same columns as the source side plus nothing
-    // else (the backfill-side target columns are dropped after coalesce).
+    // The join should have the same columns as the source side plus the
+    // backfill-match marker (the backfill-side target columns are dropped
+    // after coalesce). The marker is consumed by processSegments for stats.
     joined.columns.toSet shouldBe Set(
       "pk",
       "f1",
       "f2",
       "segment_id",
-      "row_offset"
+      "row_offset",
+      MilvusBackfill.MatchFlagCol
     )
 
     val byPk = joined


### PR DESCRIPTION
Adds three levels of observability to MilvusBackfill so users can verify join completeness and diagnose low match rates:

- per-segment `sourceRowCount` and `matchedRowCount` on `SegmentBackfillResult`
- top-level `totalSourceRows`, `totalBackfillDataRows`, `totalMatchedRows` on `BackfillResult` (all surfaced in `summary`, `segmentSummary`, and `toJson`)
- driver-side INFO logs for totals + per-segment source/matched/rate

Matched rows are counted via a `__bf_matched__ = lit(true)` marker injected on the backfill side before the left join (same semantics in overwrite and coalesce modes: "source row whose PK was present in the data file"). The marker column is stripped from the writer projection in both V3 and V2 paths. Backfill file total uses a single `backfillDF.count()` up front.