### PR TITLE
fix: [v2backfill] correct read/write for backfilled segments and V2 column naming

### DIFF
--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -6,6 +6,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.schema.Type
 import org.apache.spark.internal.Logging
 
 /** Parquet kv-metadata produced by the milvus-storage packed writer
@@ -82,6 +83,58 @@ object MilvusParquetFooterReader extends Logging {
               parseGroupFieldIdList(kv.get(GroupFieldIdListKey))
           )
         )
+      } finally {
+        parquet.close()
+      }
+    } catch {
+      case e: Throwable => Left(e)
+    }
+  }
+
+  /** Read the field IDs that this specific parquet file carries on its
+    * top-level columns.
+    *
+    * In StorageV2 each parquet file holds exactly one column group, so the
+    * file's own schema IS that group's field-id list. We prefer this over the
+    * footer's `group_field_id_list` kv-metadata because that kv is per
+    * write-session — after a backfill that appends new column groups to an
+    * existing segment, the original parquets still advertise only the original
+    * session's groups while the newly-written parquets advertise only the
+    * backfill session's groups. Reading each file's own schema avoids that trap
+    * entirely.
+    *
+    * milvus-storage writes the field id on each Arrow field as
+    * `PARQUET:field_id` metadata; arrow-cpp's parquet writer translates that
+    * into Parquet's native `SchemaElement.field_id`, which Parquet Java exposes
+    * via `Type.getId`.
+    *
+    * @return
+    *   `Right(fieldIds)` with one entry per top-level column, in schema order.
+    *   `Left(throwable)` on any I/O or parse failure, or if a column is missing
+    *   a field id (indicates a malformed parquet).
+    */
+  def readFieldIdsFromSchema(
+      path: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Seq[Long]] = {
+    try {
+      val inputFile =
+        HadoopInputFile.fromPath(new Path(path), hadoopConf)
+      val parquet = ParquetFileReader.open(inputFile)
+      try {
+        val schema = parquet.getFooter.getFileMetaData.getSchema
+        val fields = schema.getFields.asScala
+        val ids = fields.map { t: Type =>
+          val id = t.getId
+          if (id == null) {
+            throw new IllegalStateException(
+              s"parquet column '${t.getName}' in $path has no PARQUET:field_id " +
+                s"metadata; cannot recover StorageV2 column-group field ids"
+            )
+          }
+          id.intValue().toLong
+        }.toSeq
+        Right(ids)
       } finally {
         parquet.close()
       }

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -85,28 +85,34 @@ object V2SegmentLoader extends Logging {
             columnGroups = Seq.empty
           )
         } else {
-          // Any one of this segment's parquet files carries the full
-          // `group_field_id_list` in its kv-metadata. Skip any binlog_files
-          // entry that happens to be empty.
-          val sample = entry.binlogFiles
-            .find(_.binlogs.nonEmpty)
-            .get
-            .binlogs
-            .head
-            .logPath
-          val footerPath = resolvePath(sample, bucket)
-          val footer =
-            MilvusParquetFooterReader.read(footerPath, hadoopConf) match {
-              case Right(f) => f
-              case Left(err) =>
-                throw new RuntimeException(
-                  s"failed to read parquet footer $footerPath: ${err.getMessage}",
-                  err
-                )
+          // Per-entry field-id recovery: each V2 parquet file holds exactly
+          // one column group, and its schema's top-level columns ARE that
+          // group's field IDs. Reading per entry (rather than reusing a
+          // single footer's segment-level `group_field_id_list`) is required
+          // because a segment that has been backfilled contains parquets
+          // from multiple write sessions, each advertising only its own
+          // session's groups — see MilvusParquetFooterReader.readFieldIdsFromSchema.
+          val groupFieldIdListPerEntry: Seq[Seq[Long]] =
+            entry.binlogFiles.map { afb =>
+              if (afb.binlogs.isEmpty) Seq.empty
+              else {
+                val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
+                MilvusParquetFooterReader
+                  .readFieldIdsFromSchema(samplePath, hadoopConf) match {
+                  case Right(ids) => ids
+                  case Left(err) =>
+                    throw new RuntimeException(
+                      s"failed to read field ids from parquet $samplePath " +
+                        s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
+                        err.getMessage,
+                      err
+                    )
+                }
+              }
             }
           MilvusSegmentManifestReader.toV2SegmentInfo(
             entry,
-            footer.groupFieldIdList
+            groupFieldIdListPerEntry
           ) match {
             case Right(seg) => out += seg
             case Left(err) =>

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -64,79 +64,113 @@ object V2SegmentLoader extends Logging {
               err
             )
         }
-        if (entry.storageVersion != 2L) {
-          logInfo(
-            s"skipping segment ${entry.segmentId}: storage_version=${entry.storageVersion} " +
-              s"(!= 2); V2SegmentLoader only handles StorageV2"
-          )
-        } else if (
-          entry.binlogFiles.isEmpty ||
-          entry.binlogFiles.forall(_.binlogs.isEmpty)
-        ) {
-          logWarning(
-            s"segment ${entry.segmentId} has no binlog files with entries; " +
-              s"emitting as empty column-group list"
-          )
-          out += V2SegmentInfo(
+        buildV2SegmentInfoFromEntry(entry, bucket, hadoopConf) match {
+          case Right(Some(seg)) => out += seg
+          case Right(None)      => // skipped (storage version != 2)
+          case Left(err)        => throw err
+        }
+      }
+      Right(out.toSeq)
+    } catch {
+      case e: Throwable => Left(e)
+    }
+  }
+
+  /** Convert one parsed AVRO entry into a runtime `V2SegmentInfo`. Extracted
+    * for unit-testability — it needs only Hadoop FS, so local parquet files + a
+    * hand-built `AvroManifestEntry` cover the full behavior matrix without
+    * minio/S3.
+    *
+    * @return
+    *   `Right(Some(seg))` for a StorageV2 entry (including "all-empty" which
+    *   emits a segment with no column groups); `Right(None)` when the entry is
+    *   not StorageV2 and should be skipped; `Left(err)` with segment/slot
+    *   context on any unrecoverable failure.
+    */
+  private[read] def buildV2SegmentInfoFromEntry(
+      entry: AvroManifestEntry,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Option[V2SegmentInfo]] = {
+    if (entry.storageVersion != 2L) {
+      logInfo(
+        s"skipping segment ${entry.segmentId}: storage_version=${entry.storageVersion} " +
+          s"(!= 2); V2SegmentLoader only handles StorageV2"
+      )
+      Right(None)
+    } else if (
+      entry.binlogFiles.isEmpty ||
+      entry.binlogFiles.forall(_.binlogs.isEmpty)
+    ) {
+      logWarning(
+        s"segment ${entry.segmentId} has no binlog files with entries; " +
+          s"emitting as empty column-group list"
+      )
+      Right(
+        Some(
+          V2SegmentInfo(
             segmentId = entry.segmentId,
             partitionId = entry.partitionId,
             numOfRows = entry.numOfRows,
             storageVersion = entry.storageVersion,
             columnGroups = Seq.empty
           )
-        } else {
-          // Per-entry field-id recovery: each V2 parquet file holds exactly
-          // one column group, and its schema's top-level columns ARE that
-          // group's field IDs. Reading per entry (rather than reusing a
-          // single footer's segment-level `group_field_id_list`) is required
-          // because a segment that has been backfilled contains parquets
-          // from multiple write sessions, each advertising only its own
-          // session's groups — see MilvusParquetFooterReader.readFieldIdsFromSchema.
-          val groupFieldIdListPerEntry: Seq[Seq[Long]] =
-            entry.binlogFiles.map { afb =>
-              if (afb.binlogs.isEmpty) {
-                // The top-level guard above only rejects the all-empty case.
-                // A partial-empty entry alongside populated ones points at a
-                // corrupt manifest (we have no parquet to recover field ids
-                // from, and the downstream V2ColumnGroup would be a silent
-                // empty shell). Fail loudly with slot/segment context.
-                throw new IllegalStateException(
-                  s"segment ${entry.segmentId} has an empty binlog_files entry " +
-                    s"(slot ${afb.slotFieldId}) while other entries are populated; " +
-                    "cannot recover field ids for this column group — refusing to " +
-                    "emit an empty V2ColumnGroup from a partial manifest"
-                )
-              }
-              val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
-              MilvusParquetFooterReader
-                .readFieldIdsFromSchema(samplePath, hadoopConf) match {
-                case Right(ids) => ids
-                case Left(err) =>
-                  throw new RuntimeException(
-                    s"failed to read field ids from parquet $samplePath " +
-                      s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
-                      err.getMessage,
-                    err
-                  )
-              }
+        )
+      )
+    } else {
+      try {
+        // Per-entry field-id recovery: each V2 parquet file holds exactly
+        // one column group, and its schema's top-level columns ARE that
+        // group's field IDs. Reading per entry (rather than reusing a
+        // single footer's segment-level `group_field_id_list`) is required
+        // because a segment that has been backfilled contains parquets
+        // from multiple write sessions, each advertising only its own
+        // session's groups — see MilvusParquetFooterReader.readFieldIdsFromSchema.
+        val groupFieldIdListPerEntry: Seq[Seq[Long]] =
+          entry.binlogFiles.map { afb =>
+            if (afb.binlogs.isEmpty) {
+              // The top-level guard above only rejects the all-empty case.
+              // A partial-empty entry alongside populated ones points at a
+              // corrupt manifest (we have no parquet to recover field ids
+              // from, and the downstream V2ColumnGroup would be a silent
+              // empty shell). Fail loudly with slot/segment context.
+              throw new IllegalStateException(
+                s"segment ${entry.segmentId} has an empty binlog_files entry " +
+                  s"(slot ${afb.slotFieldId}) while other entries are populated; " +
+                  "cannot recover field ids for this column group — refusing to " +
+                  "emit an empty V2ColumnGroup from a partial manifest"
+              )
             }
-          MilvusSegmentManifestReader.toV2SegmentInfo(
-            entry,
-            groupFieldIdListPerEntry
-          ) match {
-            case Right(seg) => out += seg
-            case Left(err) =>
-              throw new RuntimeException(
+            val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
+            MilvusParquetFooterReader
+              .readFieldIdsFromSchema(samplePath, hadoopConf) match {
+              case Right(ids) => ids
+              case Left(err) =>
+                throw new RuntimeException(
+                  s"failed to read field ids from parquet $samplePath " +
+                    s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
+                    err.getMessage,
+                  err
+                )
+            }
+          }
+        MilvusSegmentManifestReader.toV2SegmentInfo(
+          entry,
+          groupFieldIdListPerEntry
+        ) match {
+          case Right(seg) => Right(Some(seg))
+          case Left(err) =>
+            Left(
+              new RuntimeException(
                 s"failed to build V2SegmentInfo for segment ${entry.segmentId}: " +
                   err.getMessage,
                 err
               )
-          }
+            )
         }
+      } catch {
+        case e: Throwable => Left(e)
       }
-      Right(out.toSeq)
-    } catch {
-      case e: Throwable => Left(e)
     }
   }
 

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -94,20 +94,30 @@ object V2SegmentLoader extends Logging {
           // session's groups — see MilvusParquetFooterReader.readFieldIdsFromSchema.
           val groupFieldIdListPerEntry: Seq[Seq[Long]] =
             entry.binlogFiles.map { afb =>
-              if (afb.binlogs.isEmpty) Seq.empty
-              else {
-                val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
-                MilvusParquetFooterReader
-                  .readFieldIdsFromSchema(samplePath, hadoopConf) match {
-                  case Right(ids) => ids
-                  case Left(err) =>
-                    throw new RuntimeException(
-                      s"failed to read field ids from parquet $samplePath " +
-                        s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
-                        err.getMessage,
-                      err
-                    )
-                }
+              if (afb.binlogs.isEmpty) {
+                // The top-level guard above only rejects the all-empty case.
+                // A partial-empty entry alongside populated ones points at a
+                // corrupt manifest (we have no parquet to recover field ids
+                // from, and the downstream V2ColumnGroup would be a silent
+                // empty shell). Fail loudly with slot/segment context.
+                throw new IllegalStateException(
+                  s"segment ${entry.segmentId} has an empty binlog_files entry " +
+                    s"(slot ${afb.slotFieldId}) while other entries are populated; " +
+                    "cannot recover field ids for this column group — refusing to " +
+                    "emit an empty V2ColumnGroup from a partial manifest"
+                )
+              }
+              val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
+              MilvusParquetFooterReader
+                .readFieldIdsFromSchema(samplePath, hadoopConf) match {
+                case Right(ids) => ids
+                case Left(err) =>
+                  throw new RuntimeException(
+                    s"failed to read field ids from parquet $samplePath " +
+                      s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
+                      err.getMessage,
+                    err
+                  )
               }
             }
           MilvusSegmentManifestReader.toV2SegmentInfo(

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -215,7 +215,11 @@ object ArrowConverter extends Logging {
         if (str == null) {
           vector.setNull(rowIndex)
         } else {
-          vector.asInstanceOf[VarCharVector].set(rowIndex, str.getBytes)
+          // setSafe grows the data buffer when actual bytes exceed the
+          // density-based initial capacity. `set` throws IndexOutOfBounds
+          // instead of reallocating, which blows up whenever strings average
+          // more than the configured density (32 bytes).
+          vector.asInstanceOf[VarCharVector].setSafe(rowIndex, str.getBytes)
         }
 
       case ArrayType(FloatType, _) =>
@@ -262,7 +266,8 @@ object ArrowConverter extends Logging {
         if (bytes == null) {
           vector.setNull(rowIndex)
         } else {
-          vector.asInstanceOf[VarBinaryVector].set(rowIndex, bytes)
+          // See StringType above — setSafe grows the data buffer; set does not.
+          vector.asInstanceOf[VarBinaryVector].setSafe(rowIndex, bytes)
         }
 
       case MapType(keyType, valueType, _) =>

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -228,13 +228,23 @@ object MilvusSchemaUtil {
     * @param vectorDimensions
     *   Optional map of field name to vector dimension (for float arrays as
     *   vectors)
+    * @param fieldIds
+    *   Optional map of field name -> Milvus fieldID. When non-empty, each
+    *   matched field carries a `PARQUET:field_id` metadata entry.
+    * @param useFieldIdAsName
+    *   When true (default, V3 writer semantics), fields with an explicit
+    *   fieldID entry get their Arrow column name rewritten to the fieldID
+    *   string. When false (V2 packed-parquet semantics — what milvus segcore
+    *   produces), the Arrow column name stays as the Spark field's logical name
+    *   while `PARQUET:field_id` metadata still carries the fieldID.
     * @return
     *   Arrow Schema
     */
   def convertSparkSchemaToArrow(
       sparkSchema: org.apache.spark.sql.types.StructType,
       vectorDimensions: Map[String, Int] = Map.empty,
-      fieldIds: Map[String, Long] = Map.empty
+      fieldIds: Map[String, Long] = Map.empty,
+      useFieldIdAsName: Boolean = true
   ): org.apache.arrow.vector.types.pojo.Schema = {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.types._
@@ -282,9 +292,10 @@ object MilvusSchemaUtil {
       val metadata = Map("PARQUET:field_id" -> fieldId.toString).asJava
 
       val fieldType = new FieldType(true, arrowType, null, metadata)
-      // Use field ID as column name when explicit field IDs are provided
       val fieldName =
-        if (fieldIds.contains(field.name)) fieldId.toString else field.name
+        if (useFieldIdAsName && fieldIds.contains(field.name))
+          fieldId.toString
+        else field.name
       new Field(fieldName, fieldType, null)
     }
 

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -108,11 +108,17 @@ class MilvusV2BinlogWriter(
   private val allocator = new RootAllocator(Long.MaxValue)
   private val fieldNameToId: Map[String, Long] =
     newFieldNames.zip(newFieldIds).toMap
+  // V2 packed-parquet written by milvus segcore uses LOGICAL field names as
+  // parquet column names (with `PARQUET:field_id` metadata for cross-reference).
+  // The V2 reader matches columns by logical name, so we must emit the same
+  // shape — NOT the V3 fieldID-as-string convention. `useFieldIdAsName = false`
+  // keeps the logical name while still stamping `PARQUET:field_id` metadata.
   private val arrowSchema =
     MilvusSchemaUtil.convertSparkSchemaToArrow(
       targetSchema,
       vectorDimensions = Map.empty,
-      fieldIds = fieldNameToId
+      fieldIds = fieldNameToId,
+      useFieldIdAsName = false
     )
 
   // Single-field column groups: one parquet output per field, paths in the

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -1,11 +1,26 @@
 package com.zilliz.spark.connector.read
 
+import java.nio.file.Files
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path => HPath}
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.example.{
+  ExampleParquetWriter,
+  GroupWriteSupport
+}
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.schema.{MessageType, Types}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-/** Tests for [[MilvusParquetFooterReader]]. The actual footer read against S3
-  * needs minio + hadoop-aws at runtime, so here we only cover the pure parser
-  * logic. End-to-end footer reads are covered by the backfill integration test.
+/** Tests for [[MilvusParquetFooterReader]]. S3-backed reads need minio +
+  * hadoop-aws at runtime, but the field-id recovery path can be exercised
+  * against a local parquet written by parquet-mr's example writer — that writer
+  * honours per-column `id(...)` settings and writes them into Parquet's native
+  * `SchemaElement.field_id`, the same place milvus-storage writes them (via
+  * arrow-cpp).
   */
 class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
 
@@ -41,5 +56,131 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
       Seq(100L, 0L, 1L),
       Seq(102L)
     )
+  }
+
+  test("readFieldIdsFromSchema returns per-column field ids in schema order") {
+    val tmp = Files.createTempFile("milvus-fid-test-", ".parquet")
+    Files.delete(tmp)
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .id(100)
+      .named("pk")
+      .required(PrimitiveTypeName.INT64)
+      .id(0)
+      .named("row_id")
+      .required(PrimitiveTypeName.INT64)
+      .id(1)
+      .named("ts")
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(tmp.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(
+        factory
+          .newGroup()
+          .append("pk", 1L)
+          .append("row_id", 10L)
+          .append("ts", 100L)
+      )
+    } finally {
+      writer.close()
+    }
+
+    try {
+      val result = MilvusParquetFooterReader.readFieldIdsFromSchema(
+        tmp.toUri.toString,
+        new Configuration()
+      )
+      result shouldBe Right(Seq(100L, 0L, 1L))
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
+  }
+
+  test("readFieldIdsFromSchema on single-field (backfill-style) parquet") {
+    val tmp = Files.createTempFile("milvus-fid-test-bf-", ".parquet")
+    Files.delete(tmp)
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .id(105)
+      .named("new_field")
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(tmp.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(factory.newGroup().append("new_field", 42L))
+    } finally {
+      writer.close()
+    }
+
+    try {
+      val result = MilvusParquetFooterReader.readFieldIdsFromSchema(
+        tmp.toUri.toString,
+        new Configuration()
+      )
+      result shouldBe Right(Seq(105L))
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
+  }
+
+  test("readFieldIdsFromSchema returns Left when a column has no field id") {
+    val tmp = Files.createTempFile("milvus-fid-test-bad-", ".parquet")
+    Files.delete(tmp)
+    // No `.id(...)` on the second column — mimics a malformed parquet where
+    // PARQUET:field_id never made it into the SchemaElement.
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .id(200)
+      .named("good")
+      .required(PrimitiveTypeName.INT64)
+      .named("no_id")
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(tmp.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(factory.newGroup().append("good", 1L).append("no_id", 2L))
+    } finally {
+      writer.close()
+    }
+
+    try {
+      val result = MilvusParquetFooterReader.readFieldIdsFromSchema(
+        tmp.toUri.toString,
+        new Configuration()
+      )
+      result shouldBe a[Left[_, _]]
+      result.left.toOption.get.getMessage should include("no_id")
+      result.left.toOption.get.getMessage should include("PARQUET:field_id")
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
   }
 }

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -1,0 +1,262 @@
+package com.zilliz.spark.connector.read
+
+import java.nio.file.{Files, Path => NPath}
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path => HPath}
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.hadoop.example.{
+  ExampleParquetWriter,
+  GroupWriteSupport
+}
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.schema.{MessageType, Types}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Unit tests for [[V2SegmentLoader.buildV2SegmentInfoFromEntry]].
+  *
+  * Integration with S3/minio is covered by the backfill E2E test; here we
+  * exercise the per-entry schema recovery, partial-empty fail-fast, and
+  * enriched error-context branches against local parquet files written by
+  * parquet-mr's example writer. That writer honours per-column `id(...)`
+  * settings and stamps them into Parquet's native `SchemaElement.field_id` —
+  * the same place milvus-storage's arrow-cpp writer puts them.
+  */
+class V2SegmentLoaderTest extends AnyFunSuite with Matchers {
+
+  /** Write a single-column parquet at `path` carrying the given field id, so
+    * `readFieldIdsFromSchema` will return `Seq(fieldId)`.
+    */
+  private def writeSingleFieldParquet(
+      path: NPath,
+      columnName: String,
+      fieldId: Int
+  ): Unit = {
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .id(fieldId)
+      .named(columnName)
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(path.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(factory.newGroup().append(columnName, 1L))
+    } finally {
+      writer.close()
+    }
+  }
+
+  /** Write a parquet whose only column has NO `PARQUET:field_id` — simulates a
+    * malformed / non-milvus parquet.
+    */
+  private def writeFieldIdLessParquet(path: NPath): Unit = {
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .named("no_id")
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(path.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(factory.newGroup().append("no_id", 1L))
+    } finally {
+      writer.close()
+    }
+  }
+
+  private def mkTempParquet(prefix: String): NPath = {
+    val p = Files.createTempFile(prefix, ".parquet")
+    Files.delete(p) // ExampleParquetWriter refuses to overwrite existing files
+    p
+  }
+
+  private def entry(
+      segmentId: Long,
+      binlogs: Seq[AvroFieldBinlogEntry],
+      storageVersion: Long = 2L
+  ): AvroManifestEntry =
+    AvroManifestEntry(
+      segmentId = segmentId,
+      partitionId = 10L,
+      numOfRows = 100L,
+      storageVersion = storageVersion,
+      binlogFiles = binlogs
+    )
+
+  test(
+    "per-entry recovery returns each parquet's OWN field ids (backfill-safe)"
+  ) {
+    // Simulates a backfilled segment: two column groups, each written in a
+    // different session. Previously the loader sampled ONE footer and reused
+    // its `group_field_id_list` for all groups, which mis-attributed the
+    // second group's field ids. With per-entry recovery each group now gets
+    // its own parquet's field ids.
+    val pq0 = mkTempParquet("v2loader-g0-")
+    val pq1 = mkTempParquet("v2loader-g1-")
+    try {
+      writeSingleFieldParquet(pq0, "pk", fieldId = 100)
+      writeSingleFieldParquet(pq1, "new_col", fieldId = 105)
+
+      val manifest = entry(
+        segmentId = 1001L,
+        binlogs = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq0.toUri.toString, 10L))
+          ),
+          AvroFieldBinlogEntry(
+            slotFieldId = 105L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq1.toUri.toString, 10L))
+          )
+        )
+      )
+
+      val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+        manifest,
+        bucket = "",
+        new Configuration()
+      )
+
+      result shouldBe a[Right[_, _]]
+      val Some(seg) = result.toOption.get
+      seg.segmentId shouldBe 1001L
+      seg.columnGroups.map(_.fieldIds) shouldBe Seq(Seq(100L), Seq(105L))
+      seg.columnGroups.map(_.filePaths) shouldBe Seq(
+        Seq(pq0.toUri.toString),
+        Seq(pq1.toUri.toString)
+      )
+      seg.columnGroups.map(_.fileRowCounts) shouldBe Seq(Seq(10L), Seq(10L))
+    } finally {
+      Files.deleteIfExists(pq0)
+      Files.deleteIfExists(pq1)
+    }
+  }
+
+  test(
+    "partial-empty binlog entry fails loudly with segmentId + slotFieldId context"
+  ) {
+    val pq0 = mkTempParquet("v2loader-partial-")
+    try {
+      writeSingleFieldParquet(pq0, "pk", fieldId = 100)
+
+      val manifest = entry(
+        segmentId = 2002L,
+        binlogs = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq0.toUri.toString, 10L))
+          ),
+          // One entry populated, one empty — the corrupt-manifest case the
+          // top-level all-empty guard does NOT cover.
+          AvroFieldBinlogEntry(slotFieldId = 77L, binlogs = Seq.empty)
+        )
+      )
+
+      val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+        manifest,
+        bucket = "",
+        new Configuration()
+      )
+
+      result shouldBe a[Left[_, _]]
+      val err = result.swap.toOption.get
+      err shouldBe an[IllegalStateException]
+      err.getMessage should include("2002") // segmentId
+      err.getMessage should include("77") // slotFieldId of the empty entry
+      err.getMessage should include("empty")
+    } finally {
+      Files.deleteIfExists(pq0)
+    }
+  }
+
+  test(
+    "malformed parquet (no PARQUET:field_id) surfaces as Left with enriched context"
+  ) {
+    val pq0 = mkTempParquet("v2loader-malformed-")
+    try {
+      writeFieldIdLessParquet(pq0)
+
+      val manifest = entry(
+        segmentId = 3003L,
+        binlogs = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 42L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq0.toUri.toString, 10L))
+          )
+        )
+      )
+
+      val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+        manifest,
+        bucket = "",
+        new Configuration()
+      )
+
+      result shouldBe a[Left[_, _]]
+      val msg = result.swap.toOption.get.getMessage
+      msg should include("3003") // segmentId
+      msg should include("42") // slotFieldId
+      msg should include(pq0.toUri.toString) // path
+      msg should include("PARQUET:field_id")
+    } finally {
+      Files.deleteIfExists(pq0)
+    }
+  }
+
+  test(
+    "all-empty binlog_files emits a segment with no column groups (not an error)"
+  ) {
+    val manifest = entry(
+      segmentId = 4004L,
+      binlogs = Seq(
+        AvroFieldBinlogEntry(slotFieldId = 100L, binlogs = Seq.empty),
+        AvroFieldBinlogEntry(slotFieldId = 101L, binlogs = Seq.empty)
+      )
+    )
+
+    val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+      manifest,
+      bucket = "",
+      new Configuration()
+    )
+
+    val Some(seg) = result.toOption.get
+    seg.segmentId shouldBe 4004L
+    seg.columnGroups shouldBe empty
+  }
+
+  test("non-StorageV2 entry is skipped (returns Right(None))") {
+    val manifest = entry(
+      segmentId = 5005L,
+      binlogs = Seq.empty,
+      storageVersion = 3L // V3
+    )
+
+    val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+      manifest,
+      bucket = "",
+      new Configuration()
+    )
+
+    result shouldBe Right(None)
+  }
+}

--- a/src/test/scala/serde/SchemaUtilTest.scala
+++ b/src/test/scala/serde/SchemaUtilTest.scala
@@ -297,6 +297,75 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test(
+    "useFieldIdAsName = true (V3 default) rewrites column names to fieldID"
+  ) {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import org.apache.spark.sql.types._
+
+    val schema = StructType(
+      Seq(
+        StructField("pk", LongType),
+        StructField("vec", ArrayType(FloatType)),
+        StructField("unmapped", StringType)
+      )
+    )
+
+    val fieldIds = Map("pk" -> 100L, "vec" -> 101L)
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(
+      schema,
+      vectorDimensions = Map("vec" -> 4),
+      fieldIds = fieldIds
+      // useFieldIdAsName defaults to true
+    )
+
+    val byIdx = arrowSchema.getFields.asScala
+    byIdx.size shouldBe 3
+
+    // Mapped fields take their fieldID as the column name.
+    byIdx(0).getName shouldBe "100"
+    byIdx(1).getName shouldBe "101"
+    // Unmapped fields fall back to (idx+1); name stays logical.
+    byIdx(2).getName shouldBe "unmapped"
+
+    // PARQUET:field_id metadata is always stamped, regardless of rename.
+    byIdx(0).getMetadata.get("PARQUET:field_id") shouldBe "100"
+    byIdx(1).getMetadata.get("PARQUET:field_id") shouldBe "101"
+    byIdx(2).getMetadata.get("PARQUET:field_id") shouldBe "3" // idx+1 fallback
+  }
+
+  test(
+    "useFieldIdAsName = false (V2 packed-parquet) preserves logical column names"
+  ) {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import org.apache.spark.sql.types._
+
+    val schema = StructType(
+      Seq(
+        StructField("pk", LongType),
+        StructField("vec", ArrayType(FloatType)),
+        StructField("ts", LongType)
+      )
+    )
+
+    val fieldIds = Map("pk" -> 100L, "vec" -> 101L, "ts" -> 1L)
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(
+      schema,
+      vectorDimensions = Map("vec" -> 4),
+      fieldIds = fieldIds,
+      useFieldIdAsName = false
+    )
+
+    val byName = arrowSchema.getFields.asScala.map(f => f.getName -> f).toMap
+    byName.keySet shouldBe Set("pk", "vec", "ts")
+
+    // Arrow column names stay logical — this is the shape milvus segcore
+    // emits, and the V2 reader matches by name.
+    byName("pk").getMetadata.get("PARQUET:field_id") shouldBe "100"
+    byName("vec").getMetadata.get("PARQUET:field_id") shouldBe "101"
+    byName("ts").getMetadata.get("PARQUET:field_id") shouldBe "1"
+  }
+
   test("Handle nullable fields correctly") {
     val spark = SparkSession
       .builder()


### PR DESCRIPTION
Three independent correctness fixes along the V2 read/write path, all surfaced by backfill + reader integration:

1. V2SegmentLoader: per-entry field-id recovery. A segment that has been backfilled contains parquets from multiple write sessions; each parquet's footer-level `group_field_id_list` kv-metadata only advertises that session's groups. Reading one arbitrary footer and reusing its list for every AddField entry mis-attributes newly appended column groups. Recover field ids per entry from each parquet's own top-level schema instead — in StorageV2 one parquet == one column group, so the schema's columns ARE that group's field ids. Added `MilvusParquetFooterReader.readFieldIdsFromSchema` plus unit tests (normal multi-column, backfill-style single-column, and malformed no-field-id parquet).

2. MilvusV2BinlogWriter: keep logical column names in packed parquet. Milvus segcore's V2 packed parquet uses logical field names as parquet column names and carries the numeric fieldID only in `PARQUET:field_id` metadata. The V2 reader matches columns by logical name, so writing fieldID-as-string (V3 writer convention) produces files the reader cannot join. `SchemaUtil` gains a `useFieldIdAsName` flag (default true to preserve V3 behavior); the V2 writer sets it to false.

3. ArrowConverter: use `setSafe` for VarChar/VarBinary. `VarCharVector.set` / `VarBinaryVector.set` throw IndexOutOfBoundsException when the actual bytes exceed the density-based initial capacity (32 bytes per row). `setSafe` reallocates the data buffer instead — matches how the rest of the writer already behaves and removes a latent crash on longer strings/blobs.