### PR TITLE
enhance: [backfill] report per-field source/data-file provenance counts in coalesce mode

### DIFF
--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -46,7 +46,17 @@ case class SegmentBackfillResult(
     /** Source rows whose PK was matched in the backfill parquet. Derived from a
       * `__bf_matched__` marker column injected before the left join.
       */
-    matchedRowCount: Long = 0L
+    matchedRowCount: Long = 0L,
+    /** Coalesce-mode only: per new-field count of rows whose written value came
+      * from the existing Milvus source (source value was non-null, so
+      * `coalesce(src, bf)` kept it). Empty in overwrite mode.
+      */
+    usedSourceByField: Map[String, Long] = Map.empty,
+    /** Coalesce-mode only: per new-field count of rows whose written value came
+      * from the backfill data file (source was null and the PK matched a
+      * non-null backfill value). Empty in overwrite mode.
+      */
+    usedDataFileByField: Map[String, Long] = Map.empty
 )
 
 /** Comprehensive result of backfill operation
@@ -63,7 +73,15 @@ case class BackfillResult(
     newFieldNames: Seq[String],
     totalSourceRows: Long = 0L,
     totalBackfillDataRows: Long = 0L,
-    totalMatchedRows: Long = 0L
+    totalMatchedRows: Long = 0L,
+    /** Coalesce-mode only: aggregated per new-field count of rows that kept the
+      * existing Milvus source value. Empty in overwrite mode.
+      */
+    totalUsedSourceByField: Map[String, Long] = Map.empty,
+    /** Coalesce-mode only: aggregated per new-field count of rows that took the
+      * backfill data file value. Empty in overwrite mode.
+      */
+    totalUsedDataFileByField: Map[String, Long] = Map.empty
 ) {
 
   private def matchRateStr(matched: Long, total: Long): String =
@@ -75,6 +93,18 @@ case class BackfillResult(
     val v2Count = segmentResults.count(_._2.v2Artifact.isDefined)
     val sourceRate = matchRateStr(totalMatchedRows, totalSourceRows)
     val dataFileRate = matchRateStr(totalMatchedRows, totalBackfillDataRows)
+    val coalesceBlock =
+      if (totalUsedSourceByField.isEmpty && totalUsedDataFileByField.isEmpty)
+        ""
+      else {
+        val fieldLines = newFieldNames.map { f =>
+          val src = totalUsedSourceByField.getOrElse(f, 0L)
+          val df = totalUsedDataFileByField.getOrElse(f, 0L)
+          val nullOut = totalSourceRows - src - df
+          s"    $f: source=$src, dataFile=$df, null=$nullOut"
+        }
+        s"  Coalesce Provenance (per field):\n${fieldLines.mkString("\n")}\n"
+      }
     s"""Backfill Summary:
        |  Status: ${if (success) "SUCCESS"
       else "FAILED"}
@@ -89,7 +119,7 @@ case class BackfillResult(
        |  New Fields: ${newFieldNames.mkString(", ")}
        |  Manifest Paths: ${manifestPaths.size} files
        |  StorageV2 Segments: $v2Count / ${segmentResults.size}
-       |""".stripMargin
+       |$coalesceBlock""".stripMargin
   }
 
   /** Get detailed per-segment results
@@ -127,6 +157,10 @@ case class BackfillResult(
           "outputPath" -> r.outputPath,
           "manifestPaths" -> r.manifestPaths
         )
+        if (r.usedSourceByField.nonEmpty)
+          base += "usedSourceByField" -> r.usedSourceByField
+        if (r.usedDataFileByField.nonEmpty)
+          base += "usedDataFileByField" -> r.usedDataFileByField
         r.v2Artifact.foreach { art =>
           base += "storage_version" -> art.storageVersion
           base += "column_groups" -> art.columnGroups.map { cg =>
@@ -154,6 +188,10 @@ case class BackfillResult(
       "newFieldNames" -> newFieldNames,
       "segments" -> segments
     )
+    if (totalUsedSourceByField.nonEmpty)
+      result += "totalUsedSourceByField" -> totalUsedSourceByField
+    if (totalUsedDataFileByField.nonEmpty)
+      result += "totalUsedDataFileByField" -> totalUsedDataFileByField
 
     mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result)
   }
@@ -185,6 +223,17 @@ object BackfillResult {
     val totalMatched = segmentResults.values.map(_.matchedRowCount).sum
     val allManifests = segmentResults.values.flatMap(_.manifestPaths).toSeq
 
+    def sumByField(
+        pick: SegmentBackfillResult => Map[String, Long]
+    ): Map[String, Long] =
+      segmentResults.values.foldLeft(Map.empty[String, Long]) { (acc, r) =>
+        pick(r).foldLeft(acc) { case (a, (k, v)) =>
+          a.updated(k, a.getOrElse(k, 0L) + v)
+        }
+      }
+    val totalUsedSrc = sumByField(_.usedSourceByField)
+    val totalUsedDf = sumByField(_.usedDataFileByField)
+
     BackfillResult(
       success = true,
       segmentsProcessed = segmentResults.size,
@@ -197,7 +246,9 @@ object BackfillResult {
       newFieldNames = newFieldNames,
       totalSourceRows = totalSource,
       totalBackfillDataRows = totalBackfillDataRows,
-      totalMatchedRows = totalMatched
+      totalMatchedRows = totalMatched,
+      totalUsedSourceByField = totalUsedSrc,
+      totalUsedDataFileByField = totalUsedDf
     )
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -43,6 +43,18 @@ object MilvusBackfill {
     */
   private[backfill] val MatchFlagCol = "__bf_matched__"
 
+  /** Per-field flag columns added only in coalesce mode: for each new field,
+    * one boolean marker recording whether the written value came from the
+    * source (src non-null) and another for whether it came from the backfill
+    * data file (src null AND bf non-null). Used by the writer to tally the
+    * per-field `usedSourceByField` / `usedDataFileByField` counts surfaced in
+    * `SegmentBackfillResult`.
+    */
+  private[backfill] def usedSrcCol(field: String): String =
+    s"__bf_used_src_${field}__"
+  private[backfill] def usedBfCol(field: String): String =
+    s"__bf_used_bf_${field}__"
+
   /** Backfill new fields into a Milvus collection
     *
     * @param spark
@@ -811,7 +823,18 @@ object MilvusBackfill {
             df.withColumnRenamed(n, n + suffix)
         }
         val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
-        newFieldNames.foldLeft(joined) { (df, n) =>
+        // Attach per-field provenance flags BEFORE the coalesce rewrites `n`,
+        // so the flags bind to the unresolved source-side `n` attribute. This
+        // keeps the flags accurate even though the later coalesce shadows the
+        // original `n` column in the output schema.
+        val withFlags = newFieldNames.foldLeft(joined) { (df, n) =>
+          df.withColumn(usedSrcCol(n), df.col(n).isNotNull)
+            .withColumn(
+              usedBfCol(n),
+              df.col(n).isNull && df.col(n + suffix).isNotNull
+            )
+        }
+        newFieldNames.foldLeft(withFlags) { (df, n) =>
           df.withColumn(n, coalesce(df.col(n), df.col(n + suffix)))
             .drop(n + suffix)
         }
@@ -896,12 +919,20 @@ object MilvusBackfill {
       // Prepare data: select only needed columns and add segment_id for
       // partitioning. Trailing column is the backfill match flag — retained
       // here so executors can count PK-matched rows, stripped from the
-      // projection that reaches the writer.
+      // projection that reaches the writer. In coalesce mode, two extra
+      // boolean flag columns per new field follow the match flag (usedSrc,
+      // usedBf interleaved, in `newFieldNames` order) so the writer can
+      // compute per-field usedSourceByField / usedDataFileByField counts.
+      val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+      val flagColNames: Seq[String] =
+        if (isCoalesceMode)
+          newFieldNames.flatMap(n => Seq(usedSrcCol(n), usedBfCol(n)))
+        else Seq.empty
       val preparedDF = joinedDF
         .select(
           (Seq("segment_id", "row_offset") ++ newFieldNames ++ Seq(
             MatchFlagCol
-          )).map(col): _*
+          ) ++ flagColNames).map(col): _*
         )
 
       // Get the schema for new fields only (without segment_id, row_offset,
@@ -1007,6 +1038,15 @@ object MilvusBackfill {
       logger.info(s"Total rows written: $totalRows")
       logger.info(s"Total time for all segments: ${totalTime}ms")
       logger.info(s"Average time per segment: ${avgTime}ms")
+      if (isCoalesceMode) {
+        logger.info("Coalesce provenance (per field, aggregated):")
+        newFieldNames.foreach { f =>
+          val src = results.map(_._1.usedSourceByField.getOrElse(f, 0L)).sum
+          val df = results.map(_._1.usedDataFileByField.getOrElse(f, 0L)).sum
+          val nullOut = totalSource - src - df
+          logger.info(s"  $f: source=$src, dataFile=$df, null=$nullOut")
+        }
+      }
       results.sortBy(_._1.segmentId).foreach { case (r, _) =>
         val segRate =
           if (r.sourceRowCount > 0)
@@ -1088,22 +1128,40 @@ object MilvusBackfill {
       .createBatchWriterFactory(null)
       .createWriter(0, System.currentTimeMillis())
 
+    val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+    val newFieldNames = targetSchema.fieldNames.toSeq
+    val numNewFields = newFieldNames.size
+    // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
+    // __bf_matched__, (usedSrc, usedBf)*numNewFields in coalesce mode only].
+    val matchFlagIdx = 2 + numNewFields
+    val firstFlagIdx = matchFlagIdx + 1
+
     try {
       var rowCount = 0L
       var nullRowCount = 0L
       var matchedRowCount = 0L
+      val usedSrcCounts = Array.fill(numNewFields)(0L)
+      val usedBfCounts = Array.fill(numNewFields)(0L)
 
       def writeRow(row: InternalRow): Unit = {
-        // Row layout: [segment_id, row_offset, ...newFields, __bf_matched__]
-        // Strip the first two tracking cols and the trailing match flag before
-        // handing values to the writer.
-        val matchFlagIdx = row.numFields - 1
         val dataEnd = matchFlagIdx
         val targetFields = (2 until dataEnd)
           .map(i => row.get(i, targetSchema.fields(i - 2).dataType))
           .toArray
         if (targetFields.forall(_ == null)) nullRowCount += 1
         if (!row.isNullAt(matchFlagIdx)) matchedRowCount += 1
+        if (isCoalesceMode) {
+          var i = 0
+          while (i < numNewFields) {
+            val srcIdx = firstFlagIdx + 2 * i
+            val bfIdx = srcIdx + 1
+            if (!row.isNullAt(srcIdx) && row.getBoolean(srcIdx))
+              usedSrcCounts(i) += 1
+            if (!row.isNullAt(bfIdx) && row.getBoolean(bfIdx))
+              usedBfCounts(i) += 1
+            i += 1
+          }
+        }
         writer.write(
           new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(
             targetFields
@@ -1125,6 +1183,14 @@ object MilvusBackfill {
       batchWrite.commit(Array(commitMessage))
       writer.close()
 
+      val (usedSrcByField, usedBfByField) =
+        if (isCoalesceMode)
+          (
+            newFieldNames.zip(usedSrcCounts).toMap,
+            newFieldNames.zip(usedBfCounts).toMap
+          )
+        else (Map.empty[String, Long], Map.empty[String, Long])
+
       Iterator.single(
         (
           SegmentBackfillResult(
@@ -1135,7 +1201,9 @@ object MilvusBackfill {
             executionTimeMs = System.currentTimeMillis() - startTime,
             committedVersion = committedVersion,
             sourceRowCount = rowCount,
-            matchedRowCount = matchedRowCount
+            matchedRowCount = matchedRowCount,
+            usedSourceByField = usedSrcByField,
+            usedDataFileByField = usedBfByField
           ),
           None
         )
@@ -1309,15 +1377,22 @@ object MilvusBackfill {
       allocateLogId = allocator
     )
 
+    val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+    val numNewFields = fieldNames.size
+    // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
+    // __bf_matched__, (usedSrc, usedBf)*numNewFields in coalesce mode only].
+    val matchFlagIdx = 2 + numNewFields
+    val firstFlagIdx = matchFlagIdx + 1
+
     var rowCount = 0L
     var matchedRowCount = 0L
+    val usedSrcCounts = Array.fill(numNewFields)(0L)
+    val usedBfCounts = Array.fill(numNewFields)(0L)
     try {
-      // Row layout: [segment_id, row_offset, ...newFields, __bf_matched__].
       // The V2 writer only wants the newField columns; strip the tracking
-      // columns and the match flag (the flag is instead folded into
-      // matchedRowCount).
+      // columns, the match flag, and any coalesce-mode provenance flags (the
+      // match flag + per-field flags are folded into the counters instead).
       def projected(row: InternalRow): InternalRow = {
-        val matchFlagIdx = row.numFields - 1
         val dataEnd = matchFlagIdx
         val values = (2 until dataEnd)
           .map(i => row.get(i, targetSchema.fields(i - 2).dataType))
@@ -1325,7 +1400,19 @@ object MilvusBackfill {
         new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(values)
       }
       def countMatch(row: InternalRow): Unit = {
-        if (!row.isNullAt(row.numFields - 1)) matchedRowCount += 1
+        if (!row.isNullAt(matchFlagIdx)) matchedRowCount += 1
+        if (isCoalesceMode) {
+          var i = 0
+          while (i < numNewFields) {
+            val srcIdx = firstFlagIdx + 2 * i
+            val bfIdx = srcIdx + 1
+            if (!row.isNullAt(srcIdx) && row.getBoolean(srcIdx))
+              usedSrcCounts(i) += 1
+            if (!row.isNullAt(bfIdx) && row.getBoolean(bfIdx))
+              usedBfCounts(i) += 1
+            i += 1
+          }
+        }
       }
 
       countMatch(firstRow)
@@ -1348,6 +1435,13 @@ object MilvusBackfill {
           rowCount = pf.rowsWritten
         )
       }
+      val (usedSrcByField, usedBfByField) =
+        if (isCoalesceMode)
+          (
+            fieldNames.zip(usedSrcCounts).toMap,
+            fieldNames.zip(usedBfCounts).toMap
+          )
+        else (Map.empty[String, Long], Map.empty[String, Long])
       Iterator.single(
         (
           SegmentBackfillResult(
@@ -1365,7 +1459,9 @@ object MilvusBackfill {
               )
             ),
             sourceRowCount = rowCount,
-            matchedRowCount = matchedRowCount
+            matchedRowCount = matchedRowCount,
+            usedSourceByField = usedSrcByField,
+            usedDataFileByField = usedBfByField
           ),
           None
         )

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -219,15 +219,19 @@ class BackfillModeTest
     )
 
     // The join should have the same columns as the source side plus the
-    // backfill-match marker (the backfill-side target columns are dropped
-    // after coalesce). The marker is consumed by processSegments for stats.
+    // backfill-match marker and, in coalesce mode, per-field provenance
+    // flags used downstream for the usedSource/usedDataFile counters.
     joined.columns.toSet shouldBe Set(
       "pk",
       "f1",
       "f2",
       "segment_id",
       "row_offset",
-      MilvusBackfill.MatchFlagCol
+      MilvusBackfill.MatchFlagCol,
+      MilvusBackfill.usedSrcCol("f1"),
+      MilvusBackfill.usedBfCol("f1"),
+      MilvusBackfill.usedSrcCol("f2"),
+      MilvusBackfill.usedBfCol("f2")
     )
 
     val byPk = joined
@@ -307,6 +311,54 @@ class BackfillModeTest
     )
     MilvusBackfill.validateCoalesceTypes(backfillSchema, extras) shouldBe Right(
       ()
+    )
+  }
+
+  test("coalesce mode: per-field provenance flags mark source vs datafile") {
+    // pk=1 — f1 non-null src → usedSrc(f1); f2 null src + bf non-null → usedBf(f2)
+    // pk=2 — f1 null src + bf non-null → usedBf(f1); f2 non-null src → usedSrc(f2)
+    // pk=3 — no backfill row; f1 non-null src → usedSrc(f1); f2 null src + no
+    //        bf row → neither flag (output is null).
+    val original = buildOriginal(
+      Seq(
+        (1, Int.box(1), null, 10L, 0L),
+        (2, null, "src2", 10L, 1L),
+        (3, Int.box(3), null, 10L, 2L)
+      )
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(100), "BF1"),
+        (2, Int.box(200), "BF2")
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeCoalesce
+    )
+
+    val flags = joined
+      .orderBy("pk")
+      .collect()
+      .map(r =>
+        (
+          r.getAs[Int]("pk"),
+          r.getAs[Boolean](MilvusBackfill.usedSrcCol("f1")),
+          r.getAs[Boolean](MilvusBackfill.usedBfCol("f1")),
+          r.getAs[Boolean](MilvusBackfill.usedSrcCol("f2")),
+          r.getAs[Boolean](MilvusBackfill.usedBfCol("f2"))
+        )
+      )
+      .toSeq
+
+    flags shouldBe Seq(
+      (1, true, false, false, true),
+      (2, false, true, true, false),
+      (3, true, false, false, false)
     )
   }
 


### PR DESCRIPTION
In coalesce mode, attach two boolean flag columns per new field before the coalesce rewrite to record whether each written value came from the existing Milvus source (src non-null) or from the backfill data file (src null and bf non-null). The writers (V1 and V2 paths) tally these flags per field and surface them as `usedSourceByField` / `usedDataFileByField` on `SegmentBackfillResult`, aggregated into `totalUsedSourceByField` / `totalUsedDataFileByField` on `BackfillResult`. Summary log and JSON output include a per-field `source / dataFile / null` breakdown; fields are empty in overwrite mode. Adds a test covering the new provenance flags and updates the existing coalesce-join schema assertion.