### PR TITLE
fix: [reader] switch partition readers to per-batch RecordBatchReader to avoid Arrow Java offset bug

### DIFF
--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -32,6 +32,7 @@ import io.milvus.storage.{
   ArrowUtils,
   LatestColumnGroupsResult,
   MilvusStorageManifest,
+  MilvusStorageProperties,
   MilvusStorageReader,
   NativeLibraryLoader
 }
@@ -60,9 +61,6 @@ class MilvusLoonPartitionReader(
 
   private val sourceSchema = schema
 
-  // Create Arrow schema from Milvus schema
-  private val (arrowSchemaObj, arrowSchemaPtr) = createArrowSchema()
-
   private val fieldNameToId: Map[String, Long] = {
     val systemFields = Map("row_id" -> 0L, "timestamp" -> 1L)
     val userFields = milvusSchema.fields.map { field =>
@@ -74,55 +72,92 @@ class MilvusLoonPartitionReader(
   private val fieldNameToIdString: Map[String, String] =
     fieldNameToId.map { case (name, id) => name -> id.toString }
 
-  // Create reader properties from MilvusOption
-  private val readerProperties = Properties.fromMilvusOption(milvusOption)
-
   private val columnNames = getColumnNames()
 
-  // Get column groups from manifest (use specific version if provided, otherwise latest)
-  private val manifestResult: LatestColumnGroupsResult = if (readVersion > 0) {
-    logInfo(s"Reading manifest at version $readVersion for path: $manifestPath")
-    MilvusStorageManifest.getColumnGroupsScala(
-      manifestPath,
-      readerProperties,
-      readVersion
-    )
-  } else {
-    MilvusStorageManifest.getLatestColumnGroupsScala(
-      manifestPath,
+  // Native resource handles. Initialized to safe defaults so a partial-init
+  // failure can roll back whatever was allocated so far via releaseAll().
+  // Spark only calls close() on a fully-constructed reader, so any throw
+  // from the init block below has to release its own resources before
+  // bubbling out.
+  private var arrowSchemaObj: ArrowSchema = null
+  private var arrowSchemaPtr: Long = 0L
+  private var readerProperties: MilvusStorageProperties = null
+  private var columnGroupsPtr: Long = 0L
+  private var reader: MilvusStorageReader = null
+  // Per-batch record batch reader handle (see milvus-storage
+  // loon_record_batch_reader_*). We deliberately avoid the ArrowArrayStream
+  // path because Arrow Java's `ArrowReader.loadNextBatch` shares one
+  // VectorSchemaRoot across batches and ignores the ArrowArray `offset`
+  // field — when the underlying C++ reader emits `RecordBatch::Slice`
+  // results, every batch after the first would show the same data.
+  //
+  // `var` + sentinel 0L so close() can null it out and stay idempotent
+  // (Spark may call close() more than once on error paths).
+  private var rbrHandle: Long = 0L
+
+  private var _currentBatch: VectorSchemaRoot = null
+  private var _currentRowIndex: Int = 0
+
+  try {
+    // Create Arrow schema from Milvus schema.
+    val (schemaObj, schemaPtr) = createArrowSchema()
+    arrowSchemaObj = schemaObj
+    arrowSchemaPtr = schemaPtr
+
+    // Reader properties from MilvusOption.
+    readerProperties = Properties.fromMilvusOption(milvusOption)
+
+    // Column groups from manifest (specific version if provided, latest otherwise).
+    val manifestResult: LatestColumnGroupsResult = if (readVersion > 0) {
+      logInfo(
+        s"Reading manifest at version $readVersion for path: $manifestPath"
+      )
+      MilvusStorageManifest.getColumnGroupsScala(
+        manifestPath,
+        readerProperties,
+        readVersion
+      )
+    } else {
+      MilvusStorageManifest.getLatestColumnGroupsScala(
+        manifestPath,
+        readerProperties
+      )
+    }
+    if (manifestResult.readVersion == 0) {
+      throw new IllegalStateException(
+        s"No manifest file found at path: $manifestPath. " +
+          "The milvus-storage format manifest files do not exist. " +
+          "Please turn on useLoonFFI and compact the data before reading through Spark connector."
+      )
+    }
+    columnGroupsPtr = manifestResult.columnGroupsPtr
+
+    reader = new MilvusStorageReader()
+    reader.create(
+      columnGroupsPtr,
+      arrowSchemaPtr,
+      columnNames,
       readerProperties
     )
+    if (!reader.isValid) {
+      throw new IllegalStateException(
+        s"Failed to create MilvusStorageReader for path: $manifestPath."
+      )
+    }
+
+    // Open the per-batch RecordBatchReader and eagerly load the first
+    // batch so empty segments short-circuit upfront.
+    rbrHandle = reader.openRecordBatchReaderScala(null)
+    _currentBatch = pullNextBatch()
+  } catch {
+    case e: Throwable =>
+      releaseAll()
+      throw e
   }
-
-  if (manifestResult.readVersion == 0) {
-    throw new IllegalStateException(
-      s"No manifest file found at path: $manifestPath. " +
-        "The milvus-storage format manifest files do not exist. " +
-        "Please turn on useLoonFFI and compact the data before reading through Spark connector."
-    )
-  }
-
-  private val columnGroupsPtr = manifestResult.columnGroupsPtr
-
-  // Create Storage V2 reader
-  private val reader = new MilvusStorageReader()
-  reader.create(columnGroupsPtr, arrowSchemaPtr, columnNames, readerProperties)
-
-  if (!reader.isValid) {
-    throw new IllegalStateException(
-      s"Failed to create MilvusStorageReader for path: $manifestPath."
-    )
-  }
-
-  // Open the per-batch RecordBatchReader. Arrow Java's ArrowArrayStream path
-  // cannot be used here: its C Data importer ignores `ArrowArray.offset`, so
-  // sliced batches (the common case once a row group exceeds the reader's
-  // min_rows) would duplicate data. The per-batch API exports each batch as a
-  // fresh offset=0 ArrowArray+ArrowSchema pair.
-  private val rbrHandle: Long = reader.openRecordBatchReaderScala(null)
 
   // Pull the next batch as a freshly-owned VectorSchemaRoot, or null on EOF.
   private def pullNextBatch(): VectorSchemaRoot = {
+    if (rbrHandle == 0L) return null
     val arr = ArrowArray.allocateNew(allocator)
     val sch = ArrowSchema.allocateNew(allocator)
     try {
@@ -138,10 +173,6 @@ class MilvusLoonPartitionReader(
       sch.close()
     }
   }
-
-  // Eagerly load the first batch so empty segments short-circuit upfront.
-  private var _currentBatch: VectorSchemaRoot = pullNextBatch()
-  private var _currentRowIndex: Int = 0
 
   // Vector search state
   private val vectorSearchEnabled = topK.isDefined && queryVector.isDefined
@@ -226,19 +257,42 @@ class MilvusLoonPartitionReader(
     }
   }
 
-  override def close(): Unit = {
-    try {
-      if (_currentBatch != null) {
-        _currentBatch.close()
-        _currentBatch = null
+  override def close(): Unit = releaseAll()
+
+  // Each native resource is released in its own try-catch so one failing
+  // release doesn't strand the rest. Null/zero sentinels make this
+  // idempotent — safe to call from both close() and the ctor rollback
+  // path even if Spark calls close() more than once.
+  private def releaseAll(): Unit = {
+    if (_currentBatch != null) {
+      try _currentBatch.close()
+      catch { case e: Throwable => logWarning("close currentBatch failed", e) }
+      _currentBatch = null
+    }
+    if (rbrHandle != 0L && reader != null) {
+      try reader.destroyRecordBatchReaderScala(rbrHandle)
+      catch { case e: Throwable => logWarning("destroy rbrHandle failed", e) }
+      rbrHandle = 0L
+    }
+    if (reader != null) {
+      try reader.destroy()
+      catch { case e: Throwable => logWarning("destroy reader failed", e) }
+      reader = null
+    }
+    if (arrowSchemaObj != null) {
+      try arrowSchemaObj.close()
+      catch {
+        case e: Throwable => logWarning("close arrowSchemaObj failed", e)
       }
-      if (rbrHandle != 0L) reader.destroyRecordBatchReaderScala(rbrHandle)
-      if (reader != null) reader.destroy()
-      if (arrowSchemaObj != null) arrowSchemaObj.close()
-      readerProperties.free()
-    } catch {
-      case e: Exception =>
-        logWarning("Error closing Storage V2 reader", e)
+      arrowSchemaObj = null
+      arrowSchemaPtr = 0L
+    }
+    if (readerProperties != null) {
+      try readerProperties.free()
+      catch {
+        case e: Throwable => logWarning("free readerProperties failed", e)
+      }
+      readerProperties = null
     }
   }
 

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -221,12 +221,13 @@ class MilvusLoonPartitionReader(
           _currentBatch = pullNextBatch()
           _currentRowIndex = 0
           if (_currentBatch == null) {
-            // No more batches
-            return false
-          } else if (_currentBatch.getRowCount == 0) {
+            // EOF — no more batches.
             return false
           }
-          // else: continue loop to check first row of new batch
+          // A 0-row batch isn't EOF: fall through, the outer-loop
+          // guard (_currentRowIndex < _currentBatch.getRowCount) is
+          // false for rowCount=0, so the next iteration re-enters
+          // this branch and pulls the following batch.
         }
       }
       false // Unreachable but needed for compilation

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -3,7 +3,7 @@ package com.zilliz.spark.connector.read
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-import org.apache.arrow.c.{ArrowArrayStream, ArrowSchema, Data}
+import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.Vectors
@@ -114,26 +114,34 @@ class MilvusLoonPartitionReader(
     )
   }
 
-  // Get Arrow stream
-  private val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
-  private val arrowArrayStream = ArrowArrayStream.wrap(recordBatchReaderPtr)
-  private val arrowReader = Data.importArrayStream(allocator, arrowArrayStream)
+  // Open the per-batch RecordBatchReader. Arrow Java's ArrowArrayStream path
+  // cannot be used here: its C Data importer ignores `ArrowArray.offset`, so
+  // sliced batches (the common case once a row group exceeds the reader's
+  // min_rows) would duplicate data. The per-batch API exports each batch as a
+  // fresh offset=0 ArrowArray+ArrowSchema pair.
+  private val rbrHandle: Long = reader.openRecordBatchReaderScala(null)
 
-  // Eagerly try to load first batch to check if data exists
-  private val (currentBatch, currentRowIndex): (VectorSchemaRoot, Int) = {
-    val hasFirstBatch = arrowReader.loadNextBatch()
-    if (!hasFirstBatch) {
-      // Manifest exists but has no data - this is valid for empty segments
-      (null, 0)
-    } else {
-      val batch = arrowReader.getVectorSchemaRoot
-      (batch, 0)
+  // Pull the next batch as a freshly-owned VectorSchemaRoot, or null on EOF.
+  private def pullNextBatch(): VectorSchemaRoot = {
+    val arr = ArrowArray.allocateNew(allocator)
+    val sch = ArrowSchema.allocateNew(allocator)
+    try {
+      val hasBatch = reader.readNextBatchScala(
+        rbrHandle,
+        arr.memoryAddress(),
+        sch.memoryAddress()
+      )
+      if (!hasBatch) null
+      else Data.importVectorSchemaRoot(allocator, arr, sch, null)
+    } finally {
+      arr.close()
+      sch.close()
     }
   }
 
-  // Need mutable versions for iteration
-  private var _currentBatch: VectorSchemaRoot = currentBatch
-  private var _currentRowIndex: Int = currentRowIndex
+  // Eagerly load the first batch so empty segments short-circuit upfront.
+  private var _currentBatch: VectorSchemaRoot = pullNextBatch()
+  private var _currentRowIndex: Int = 0
 
   // Vector search state
   private val vectorSearchEnabled = topK.isDefined && queryVector.isDefined
@@ -175,18 +183,19 @@ class MilvusLoonPartitionReader(
           }
         } else {
           // Try to load next batch
-          if (arrowReader.loadNextBatch()) {
-            _currentBatch = arrowReader.getVectorSchemaRoot
-            _currentRowIndex = 0
-            if (_currentBatch.getRowCount > 0) {
-              // Continue loop to check first row of new batch
-            } else {
-              return false
-            }
-          } else {
+          if (_currentBatch != null) {
+            _currentBatch.close()
+            _currentBatch = null
+          }
+          _currentBatch = pullNextBatch()
+          _currentRowIndex = 0
+          if (_currentBatch == null) {
             // No more batches
             return false
+          } else if (_currentBatch.getRowCount == 0) {
+            return false
           }
+          // else: continue loop to check first row of new batch
         }
       }
       false // Unreachable but needed for compilation
@@ -219,8 +228,11 @@ class MilvusLoonPartitionReader(
 
   override def close(): Unit = {
     try {
-      if (arrowReader != null) arrowReader.close()
-      if (arrowArrayStream != null) arrowArrayStream.close()
+      if (_currentBatch != null) {
+        _currentBatch.close()
+        _currentBatch = null
+      }
+      if (rbrHandle != 0L) reader.destroyRecordBatchReaderScala(rbrHandle)
       if (reader != null) reader.destroy()
       if (arrowSchemaObj != null) arrowSchemaObj.close()
       readerProperties.free()
@@ -348,13 +360,24 @@ class MilvusLoonPartitionReader(
       }
     }
 
-    // Process the first batch that was already loaded in constructor
+    // Process the first batch that was already loaded in constructor, then
+    // drop it — each per-batch root is independently owned, so we must close
+    // it before pulling the next.
     processBatch(_currentBatch)
+    if (_currentBatch != null) {
+      _currentBatch.close()
+      _currentBatch = null
+    }
 
     // Iterate through remaining batches
-    while (arrowReader.loadNextBatch()) {
-      val batch = arrowReader.getVectorSchemaRoot
-      processBatch(batch)
+    var nextBatch = pullNextBatch()
+    while (nextBatch != null) {
+      try {
+        processBatch(nextBatch)
+      } finally {
+        nextBatch.close()
+      }
+      nextBatch = pullNextBatch()
     }
 
     logInfo(

--- a/src/main/scala/read/MilvusLoonV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonV2PartitionReader.scala
@@ -166,8 +166,20 @@ class MilvusLoonV2PartitionReader(
   // before the next import so buffers are correctly reclaimed. This
   // intentionally does not reuse a single root across batches — Arrow
   // Java's shared-root import drops the per-batch `offset`.
-  private var _currentBatch: VectorSchemaRoot = loadNextBatch()
+  //
+  // Initialized inside its own try/catch: Spark only calls close() on
+  // a fully-constructed reader, so a throw from the first loadNextBatch
+  // (e.g. a malformed parquet chunk) would otherwise leak every native
+  // handle allocated in the main init block above.
+  private var _currentBatch: VectorSchemaRoot = null
   private var _currentRowIndex: Int = 0
+  try {
+    _currentBatch = loadNextBatch()
+  } catch {
+    case e: Throwable =>
+      releaseAll()
+      throw e
+  }
 
   private def loadNextBatch(): VectorSchemaRoot = {
     if (rbrHandle == 0L) return null

--- a/src/main/scala/read/MilvusLoonV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonV2PartitionReader.scala
@@ -1,6 +1,11 @@
 package com.zilliz.spark.connector.read
 
-import org.apache.arrow.c.{ArrowArrayStream, ArrowSchema, Data}
+import org.apache.arrow.c.{
+  ArrowArray,
+  ArrowSchema,
+  CDataDictionaryProvider,
+  Data
+}
 import org.apache.arrow.vector.VectorSchemaRoot
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
@@ -94,8 +99,14 @@ class MilvusLoonV2PartitionReader(
   private var readerProperties: MilvusStorageProperties = null
   private var columnGroupsPtr: Long = 0L
   private var reader: MilvusStorageReader = null
-  private var arrowArrayStream: ArrowArrayStream = null
-  private var arrowReader: org.apache.arrow.vector.ipc.ArrowReader = null
+  // Per-batch record batch reader handle (see milvus-storage
+  // loon_record_batch_reader_*). We deliberately avoid the ArrowArrayStream
+  // path because Arrow Java's `ArrowReader.loadNextBatch` shares one
+  // VectorSchemaRoot across batches and ignores the ArrowArray `offset`
+  // field — when the underlying C++ reader emits `RecordBatch::Slice`
+  // results, every batch after the first would show the same data.
+  private var rbrHandle: Long = 0L
+  private var dictProvider: CDataDictionaryProvider = null
 
   try {
     // Arrow schema for the read: columns named by their logical names so the
@@ -142,31 +153,70 @@ class MilvusLoonV2PartitionReader(
       )
     }
 
-    val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
-    arrowArrayStream = ArrowArrayStream.wrap(recordBatchReaderPtr)
-    arrowReader = Data.importArrayStream(allocator, arrowArrayStream)
+    rbrHandle = reader.openRecordBatchReaderScala()
+    dictProvider = new CDataDictionaryProvider()
   } catch {
     case e: Throwable =>
       releaseAll()
       throw e
   }
 
-  private var _currentBatch: VectorSchemaRoot = {
-    if (arrowReader.loadNextBatch()) arrowReader.getVectorSchemaRoot else null
-  }
+  // Per-batch state: each loadNextBatch() imports a FRESH RecordBatch
+  // into a NEW VectorSchemaRoot. The previous root (if any) is closed
+  // before the next import so buffers are correctly reclaimed. This
+  // intentionally does not reuse a single root across batches — Arrow
+  // Java's shared-root import drops the per-batch `offset`.
+  private var _currentBatch: VectorSchemaRoot = loadNextBatch()
   private var _currentRowIndex: Int = 0
 
+  private def loadNextBatch(): VectorSchemaRoot = {
+    if (rbrHandle == 0L) return null
+
+    val cArr = ArrowArray.allocateNew(allocator)
+    val cSchema = ArrowSchema.allocateNew(allocator)
+    var gotBatch = false
+    try {
+      gotBatch = reader.readNextBatchScala(
+        rbrHandle,
+        cArr.memoryAddress(),
+        cSchema.memoryAddress()
+      )
+      if (!gotBatch) {
+        null
+      } else {
+        // Import the ArrowArray+ArrowSchema as a RecordBatch-backed
+        // VectorSchemaRoot. Import takes ownership of the release
+        // callbacks (moves them out), so the subsequent `.close()` on
+        // cArr / cSchema is a no-op w.r.t. the live buffers; closing
+        // the returned root (in close()/loadNextBatch) is what releases
+        // them.
+        Data.importVectorSchemaRoot(allocator, cArr, cSchema, dictProvider)
+      }
+    } finally {
+      // Always close the C-struct wrappers: after a successful import
+      // their release callback has been moved into the root and this is
+      // a no-op; on failure we need to release them to avoid leaks.
+      try cArr.close()
+      catch { case e: Throwable => logWarning("close cArr failed", e) }
+      try cSchema.close()
+      catch { case e: Throwable => logWarning("close cSchema failed", e) }
+    }
+  }
+
   override def next(): Boolean = {
-    // Advance past exhausted batches.
+    // Advance past exhausted batches; close the previous root before
+    // loading the next so we bound JVM direct memory to one live batch.
     while (
       _currentBatch != null && _currentRowIndex >= _currentBatch.getRowCount
     ) {
-      if (arrowReader.loadNextBatch()) {
-        _currentBatch = arrowReader.getVectorSchemaRoot
-        _currentRowIndex = 0
-      } else {
-        _currentBatch = null
+      val exhausted = _currentBatch
+      _currentBatch = null
+      try exhausted.close()
+      catch {
+        case e: Throwable => logWarning("close exhausted batch failed", e)
       }
+      _currentBatch = loadNextBatch()
+      _currentRowIndex = 0
     }
     _currentBatch != null && _currentRowIndex < _currentBatch.getRowCount
   }
@@ -191,17 +241,20 @@ class MilvusLoonV2PartitionReader(
   // release doesn't strand the rest. Also reused by the constructor's
   // failure path to roll back a partial init.
   private def releaseAll(): Unit = {
-    if (arrowReader != null) {
-      try arrowReader.close()
-      catch { case e: Throwable => logWarning("close arrowReader failed", e) }
-      arrowReader = null
+    if (_currentBatch != null) {
+      try _currentBatch.close()
+      catch { case e: Throwable => logWarning("close currentBatch failed", e) }
+      _currentBatch = null
     }
-    if (arrowArrayStream != null) {
-      try arrowArrayStream.close()
-      catch {
-        case e: Throwable => logWarning("close arrowArrayStream failed", e)
-      }
-      arrowArrayStream = null
+    if (rbrHandle != 0L) {
+      try reader.destroyRecordBatchReaderScala(rbrHandle)
+      catch { case e: Throwable => logWarning("destroy rbrHandle failed", e) }
+      rbrHandle = 0L
+    }
+    if (dictProvider != null) {
+      try dictProvider.close()
+      catch { case e: Throwable => logWarning("close dictProvider failed", e) }
+      dictProvider = null
     }
     if (reader != null) {
       try reader.destroy()

--- a/src/test/scala/loon/MilvusStorageFFITest.scala
+++ b/src/test/scala/loon/MilvusStorageFFITest.scala
@@ -5,15 +5,9 @@ import java.nio.file.{Files, Path}
 import java.util.{HashMap => JHashMap}
 import scala.collection.JavaConverters._
 
-import org.apache.arrow.c.{
-  ArrowArray,
-  ArrowArrayStream,
-  ArrowSchema => CArrowSchema,
-  Data
-}
+import org.apache.arrow.c.{ArrowArray, ArrowSchema => CArrowSchema, Data}
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex.ListVector
-import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.arrow.vector.types.pojo.{
   ArrowType,
   Field => ArrowField,
@@ -73,8 +67,14 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
       )
       info("✓ Writer created\n")
 
-      // Create and write test data
-      val numRows = 100
+      // Create and write test data. numRows is deliberately chosen to span
+      // multiple record batches: `reader.record_batch_max_rows` defaults to
+      // 8192, so writing >16384 rows forces the packed reader's ReadNext to
+      // emit sliced batches (rb->Slice(min_rows)) starting from batch 2. Any
+      // test with numRows <= 8192 would pass against the buggy
+      // ArrowArrayStream path too and therefore can't serve as a regression
+      // test for the Arrow Java offset bug fixed in milvus-storage#493.
+      val numRows = 20480
       val vectorDim = 4
       val (root, arrowArray, arrowArrayPtr) =
         createTestData(allocator, numRows, vectorDim)
@@ -117,6 +117,15 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
         try {
           var batchCount = 0
           var totalRows = 0
+          // Regression check for milvus-storage#493 / Arrow Java offset bug.
+          // Writer produced id[i] = i for i in [0, numRows). If the reader
+          // incorrectly imported sliced batches via ArrowArrayStream (which
+          // ignores `ArrowArray.offset`), every batch past the first would
+          // restart from id=0 and we'd observe id = rowOffset mod 8192. The
+          // per-batch API exports each batch at offset 0 so ids must remain
+          // strictly `id == rowOffset` across the 8192 boundary.
+          var firstMismatch: Option[(Long, Long, Int)] =
+            None // (expected, got, batchIdx)
 
           var done = false
           while (!done) {
@@ -140,6 +149,17 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
                 )
                 try {
                   val rows = displayBatchData(readRoot, batchCount)
+                  val idVec =
+                    readRoot.getVector("id").asInstanceOf[BigIntVector]
+                  var i = 0
+                  while (i < rows && firstMismatch.isEmpty) {
+                    val rowOffset = (totalRows + i).toLong
+                    val got = idVec.get(i)
+                    if (got != rowOffset) {
+                      firstMismatch = Some((rowOffset, got, batchCount))
+                    }
+                    i += 1
+                  }
                   totalRows += rows
                 } finally {
                   readRoot.close()
@@ -157,6 +177,19 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
 
           totalRows should be(numRows)
           batchCount should be > 0
+          // numRows is chosen to force >=2 sliced batches from the packed
+          // reader (default record_batch_max_rows=8192), so anything less
+          // than 3 means the fix isn't actually being exercised.
+          batchCount should be >= 3
+          withClue(
+            s"Arrow offset regression: at row ${firstMismatch.map(_._1).getOrElse(-1L)} " +
+              s"(batch ${firstMismatch.map(_._3).getOrElse(-1)}) " +
+              s"expected id=${firstMismatch.map(_._1).getOrElse(-1L)} " +
+              s"but got id=${firstMismatch.map(_._2).getOrElse(-1L)} — " +
+              "this is the milvus-storage#493 / ArrowArrayStream slice bug. "
+          ) {
+            firstMismatch shouldBe None
+          }
         } finally {
           reader.destroyRecordBatchReaderScala(rbrHandle)
         }

--- a/src/test/scala/loon/MilvusStorageFFITest.scala
+++ b/src/test/scala/loon/MilvusStorageFFITest.scala
@@ -110,35 +110,55 @@ class MilvusStorageFFITest extends AnyFunSuite with Matchers {
         )
         info("✓ Reader created\n")
 
-        // Read data using Arrow C Data Interface
-        val recordBatchReaderPtr = reader.getRecordBatchReaderScala()
-        val arrowArrayStream = ArrowArrayStream.wrap(recordBatchReaderPtr)
-
+        // Read data via the per-batch RecordBatchReader (the only Java-safe
+        // path — the ArrowArrayStream API duplicates data when Arrow Java
+        // imports a batch whose ArrowArray carries a non-zero offset).
+        val rbrHandle = reader.openRecordBatchReaderScala()
         try {
-          val arrowReader = Data.importArrayStream(allocator, arrowArrayStream)
+          var batchCount = 0
+          var totalRows = 0
 
-          try {
-            var batchCount = 0
-            var totalRows = 0
-
-            while (arrowReader.loadNextBatch()) {
-              batchCount += 1
-              val readRoot = arrowReader.getVectorSchemaRoot
-              val rows = displayBatchData(readRoot, batchCount)
-              totalRows += rows
+          var done = false
+          while (!done) {
+            val batchArray = ArrowArray.allocateNew(allocator)
+            val batchSchema = CArrowSchema.allocateNew(allocator)
+            try {
+              val hasBatch = reader.readNextBatchScala(
+                rbrHandle,
+                batchArray.memoryAddress(),
+                batchSchema.memoryAddress()
+              )
+              if (!hasBatch) {
+                done = true
+              } else {
+                batchCount += 1
+                val readRoot = Data.importVectorSchemaRoot(
+                  allocator,
+                  batchArray,
+                  batchSchema,
+                  null
+                )
+                try {
+                  val rows = displayBatchData(readRoot, batchCount)
+                  totalRows += rows
+                } finally {
+                  readRoot.close()
+                }
+              }
+            } finally {
+              batchArray.close()
+              batchSchema.close()
             }
-
-            info(
-              s"\nSuccessfully read $totalRows rows in $batchCount batch(es)\n"
-            )
-
-            totalRows should be(numRows)
-            batchCount should be > 0
-          } finally {
-            arrowReader.close()
           }
+
+          info(
+            s"\nSuccessfully read $totalRows rows in $batchCount batch(es)\n"
+          )
+
+          totalRows should be(numRows)
+          batchCount should be > 0
         } finally {
-          arrowArrayStream.close()
+          reader.destroyRecordBatchReaderScala(rbrHandle)
         }
 
         // Clean up reader - use close() on Java objects, not native free()


### PR DESCRIPTION
Arrow Java's `ArrowReader.loadNextBatch` (the C Data ArrowArrayStream path) imports every batch into the same VectorSchemaRoot and ignores `ArrowArray.offset`. When the underlying C++ `PackedRecordBatchReader` emits a sliced batch (the common case once a row group exceeds `min_rows` — the remainder is kept as `rb->Slice(min_rows)` in its per-chunk queue), every post-slice batch re-reads from buffer position 0. The observable symptom in the Spark connector was a row-cycle of period `min_rows`: e.g. primary keys repeated as `ID = row_offset mod 8192` while `row_offset` itself kept advancing, so a 20480-row segment surfaced only 8192 distinct IDs.

Pick up milvus-io/milvus-storage#493, which adds a per-batch FFI (`loon_record_batch_reader_new / read_next / destroy`) that exports each batch as a fresh offset-0 `ArrowArray`+`ArrowSchema` pair (columns with non-zero offsets are materialised via `arrow::Concatenate` on the C++ side), and rewire both partition readers onto it:

* Bump `milvus-storage` submodule 216e7ff → 84b433d.
* `MilvusLoonPartitionReader`: drop `ArrowArrayStream` / `arrowReader`; open an `rbrHandle` via `openRecordBatchReaderScala`, pull each batch with `readNextBatchScala` into a freshly-imported `VectorSchemaRoot`, close the previous root before importing the next. Same shape for the batch-mode scan path in `readAllRowsIntoInternalRows`.
* `MilvusLoonV2PartitionReader`: same migration; track a single live batch at a time to bound JVM direct memory, and release the `CDataDictionaryProvider` / handle in `releaseAll`.
* `MilvusStorageFFITest`: update the end-to-end test to drive the per-batch API.

Verified end-to-end against a V2 snapshot: a 5-group / 20480-row segment now reads monotonically-correct primary keys (`row_offset=8192 → ID=8192`, `row_offset=10000 → ID=10000`).