### PR TITLE
fix: [v2backfill] dedup V2 column groups by slot when snapshot lacks child_fields

### DIFF
--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1228,6 +1228,57 @@ object MilvusBackfill {
     }
   }
 
+  /** Workaround until Milvus snapshot exposes `FieldBinlog.child_fields`: when
+    * the same Milvus fieldID is claimed by multiple V2 column groups (e.g. an
+    * original multi-field group at slot < 100 PLUS a single-field group at slot
+    * \== fieldID written by a prior addfield+backfill), keep the field only in
+    * the group with the largest `slotFieldId`.
+    *
+    * Backfill writes single-field groups with `slot == fieldID` (>= 100), and
+    * Milvus segcore allocates multi-field group slots from the smallest unused
+    * int < 100, so "max slot wins" is equivalent to "newer single-field group
+    * wins" under the current column-group naming convention. When Milvus's
+    * snapshot starts emitting `FieldBinlog.child_fields`, this should be
+    * replaced by the authoritative mapping (see `V2SegmentLoader` line 88-94
+    * for the parquet-footer-based reconciliation that this defends against).
+    *
+    * Skips dedup entirely when any contributing group has `slotFieldId < 0L`
+    * (the sentinel for "unknown slot", e.g. the snapshot-JSON DTO path that
+    * doesn't carry the AVRO slot id) so we don't accidentally drop fields when
+    * the slot signal is missing. We must NOT use `0L` as the sentinel because
+    * RowID's column group is legitimately at slot 0 — using 0L would
+    * short-circuit dedup on every AVRO-loaded segment.
+    */
+  private[backfill] def dedupColumnGroupsBySlot(
+      seg: com.zilliz.spark.connector.read.V2SegmentInfo
+  ): com.zilliz.spark.connector.read.V2SegmentInfo = {
+    val groups = seg.columnGroups
+    if (groups.isEmpty || groups.exists(_.slotFieldId < 0L)) return seg
+
+    val maxSlotPerField: Map[Long, Long] =
+      groups
+        .flatMap(g => g.fieldIds.map(fid => fid -> g.slotFieldId))
+        .groupBy(_._1)
+        .map { case (fid, pairs) => fid -> pairs.map(_._2).max }
+
+    val rebuilt = groups.flatMap { g =>
+      val keptFids =
+        g.fieldIds.filter(fid => maxSlotPerField(fid) == g.slotFieldId)
+      val stripped = g.fieldIds.diff(keptFids)
+      if (stripped.nonEmpty) {
+        logger.info(
+          s"V2 dedup segment=${seg.segmentId} slot=${g.slotFieldId}: " +
+            s"stripped fieldIds=${stripped.mkString(",")} " +
+            s"(owned by larger slots ${stripped.map(maxSlotPerField).mkString(",")})"
+        )
+      }
+      if (keptFids.isEmpty) None
+      else Some(g.copy(fieldIds = keptFids))
+    }
+
+    seg.copy(columnGroups = rebuilt)
+  }
+
   /** Decode the StorageV2 segments referenced by the snapshot's
     * `manifest_list`. Each AVRO gives us slot→paths; the matching parquet
     * footer's `group_field_id_list` recovers the real field IDs per column
@@ -1260,10 +1311,20 @@ object MilvusBackfill {
           hadoopConf
         ) match {
         case Right(segs) =>
+          // Workaround for Milvus snapshot not yet exposing FieldBinlog.child_fields:
+          // some segments carry both an old multi-field column group (slot < 100,
+          // declaring fields like 102..114) AND newer single-field groups (slot ==
+          // fieldID, written by a prior addfield+backfill). The C++ packed reader
+          // picks an undefined source when the same fieldID appears in multiple
+          // groups, often returning the older slot's stale (mostly-null) data —
+          // which silently breaks coalesce-mode merges. dedupColumnGroupsBySlot
+          // strips overlapping fieldIDs from the older (smaller-slot) groups so
+          // each fieldID resolves to exactly one column group.
+          val deduped = segs.map(dedupColumnGroupsBySlot)
           logger.info(
-            s"Loaded ${segs.size} StorageV2 segment(s) from snapshot AVRO manifest_list"
+            s"Loaded ${deduped.size} StorageV2 segment(s) from snapshot AVRO manifest_list (post-dedup)"
           )
-          Right(segs)
+          Right(deduped)
         case Left(err) =>
           Left(
             SchemaValidationError(

--- a/src/main/scala/read/MilvusSegmentManifestReader.scala
+++ b/src/main/scala/read/MilvusSegmentManifestReader.scala
@@ -192,7 +192,12 @@ object MilvusSegmentManifestReader extends Logging {
           V2ColumnGroup(
             fieldIds = realFieldIds,
             filePaths = sorted.map(_.logPath),
-            fileRowCounts = sorted.map(_.entriesNum)
+            fileRowCounts = sorted.map(_.entriesNum),
+            // Surface the AVRO slot id so downstream can dedup when the same
+            // fieldID is claimed by multiple groups (e.g. an old multi-field
+            // group at slot < 100 plus a backfill-written single-field group
+            // at slot == fieldID). See MilvusBackfill.dedupColumnGroupsBySlot.
+            slotFieldId = afb.slotFieldId
           )
         }
       Right(

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -331,11 +331,19 @@ case class V2SegmentInfoDTO(
   *   end_index)` ranges per file. Comes from the AVRO's
   *   `AvroBinlog.entries_num`. Default empty for legacy callers — the packed-V2
   *   reader will reject empty.
+  * @param slotFieldId
+  *   The AVRO `AvroFieldBinlog.field_id` — the column-group slot id (also the
+  *   directory name in S3). For single-field groups this equals the actual
+  *   fieldID (>= 100); for multi-field groups it's the smallest unused int <
+  *   100. `-1L` is the sentinel for "unknown slot" (e.g. snapshot-JSON DTO path
+  *   that doesn't carry the AVRO slot id) and disables slot-based dedup. We
+  *   intentionally do NOT use `0L` because RowID's column group is at slot 0.
   */
 case class V2ColumnGroup(
     fieldIds: Seq[Long],
     filePaths: Seq[String],
-    fileRowCounts: Seq[Long] = Seq.empty
+    fileRowCounts: Seq[Long] = Seq.empty,
+    slotFieldId: Long = -1L
 )
 
 /** One StorageV2 segment's manifest information needed by backfill. */

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -12,6 +12,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
+import com.zilliz.spark.connector.read.{V2ColumnGroup, V2SegmentInfo}
 import com.zilliz.spark.connector.MilvusOption
 
 /** Tests for the new `--mode` backfill parameter: CLI/config validation and the
@@ -393,5 +394,156 @@ class BackfillModeTest
       .toSeq
 
     byPk shouldBe Seq((1, 10, "A"), (2, 20, "B"))
+  }
+
+  // ============ dedupColumnGroupsBySlot ============
+
+  private def seg(groups: V2ColumnGroup*): V2SegmentInfo =
+    V2SegmentInfo(
+      segmentId = 1L,
+      partitionId = 2L,
+      numOfRows = 0L,
+      storageVersion = 2L,
+      columnGroups = groups.toSeq
+    )
+
+  test(
+    "dedupColumnGroupsBySlot: single-field group at slot=fieldID strips that " +
+      "fieldID from older multi-field group at slot < 100"
+  ) {
+    // Mirrors the production scenario: an original multi-field packed parquet
+    // (slot 1) declares fields 102..114, but a prior addfield+backfill wrote
+    // single-field groups at slot 113 / 114. Without dedup the reader sees
+    // 113/114 in BOTH groups and the C++ packed reader picks an undefined source,
+    // typically the older slot-1 file (mostly null). After dedup, slot 1's
+    // fieldIds drops 113/114 so each fieldID resolves to one group.
+    val input = seg(
+      V2ColumnGroup(
+        fieldIds = Seq(102L, 103L, 113L, 114L),
+        filePaths = Seq("seg/1/old"),
+        fileRowCounts = Seq(100L),
+        slotFieldId = 1L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(113L),
+        filePaths = Seq("seg/113/new"),
+        fileRowCounts = Seq(100L),
+        slotFieldId = 113L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(114L),
+        filePaths = Seq("seg/114/new"),
+        fileRowCounts = Seq(100L),
+        slotFieldId = 114L
+      )
+    )
+
+    val out = MilvusBackfill.dedupColumnGroupsBySlot(input)
+    out.columnGroups.map(g => (g.slotFieldId, g.fieldIds)) shouldBe Seq(
+      (1L, Seq(102L, 103L)),
+      (113L, Seq(113L)),
+      (114L, Seq(114L))
+    )
+  }
+
+  test(
+    "dedupColumnGroupsBySlot: drops a group entirely if every fieldID it carries " +
+      "is owned by a larger slot"
+  ) {
+    val input = seg(
+      V2ColumnGroup(
+        fieldIds = Seq(113L),
+        filePaths = Seq("p/old"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 1L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(113L),
+        filePaths = Seq("p/new"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 113L
+      )
+    )
+    val out = MilvusBackfill.dedupColumnGroupsBySlot(input)
+    out.columnGroups should have size 1
+    out.columnGroups.head.slotFieldId shouldBe 113L
+    out.columnGroups.head.fieldIds shouldBe Seq(113L)
+  }
+
+  test(
+    "dedupColumnGroupsBySlot: leaves single-group / no-conflict layouts untouched"
+  ) {
+    val input = seg(
+      V2ColumnGroup(
+        fieldIds = Seq(100L, 0L, 1L),
+        filePaths = Seq("p/0"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 0L // Real slot 0 = RowID; legal AVRO value.
+      )
+    )
+    val out = MilvusBackfill.dedupColumnGroupsBySlot(input)
+    out shouldBe input
+  }
+
+  test(
+    "dedupColumnGroupsBySlot: slot 0 (RowID) is a real slot id, not the unknown " +
+      "sentinel — must NOT short-circuit dedup when other groups conflict"
+  ) {
+    // Regression: an earlier version used 0L as the unknown-slot sentinel,
+    // but RowID's AVRO entry legitimately has field_id=0. That made dedup
+    // skip every AVRO-loaded segment, defeating the fix entirely. The
+    // sentinel is now -1L; slot 0L participates in dedup like any other slot.
+    val input = seg(
+      V2ColumnGroup(
+        fieldIds = Seq(0L), // RowID
+        filePaths = Seq("p/rowid"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 0L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(102L, 113L),
+        filePaths = Seq("p/multi"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 1L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(113L),
+        filePaths = Seq("p/single"),
+        fileRowCounts = Seq(1L),
+        slotFieldId = 113L
+      )
+    )
+    val out = MilvusBackfill.dedupColumnGroupsBySlot(input)
+    out.columnGroups.map(g => (g.slotFieldId, g.fieldIds)) shouldBe Seq(
+      (0L, Seq(0L)),
+      (1L, Seq(102L)),
+      (113L, Seq(113L))
+    )
+  }
+
+  test(
+    "dedupColumnGroupsBySlot: skips dedup when ANY group's slotFieldId is the " +
+      "-1L sentinel (snapshot-JSON DTO path) — never silently drops a fieldID"
+  ) {
+    // Snapshot JSON deserialization currently doesn't surface AVRO slot ids,
+    // so V2ColumnGroup.slotFieldId stays at its default -1L. In that mode we
+    // must NOT dedup, otherwise we'd treat all groups as if they shared the
+    // same unknown slot and arbitrarily strip fields.
+    val input = seg(
+      V2ColumnGroup(
+        fieldIds = Seq(102L, 113L),
+        filePaths = Seq("p/multi"),
+        fileRowCounts = Seq(1L)
+        // slotFieldId defaults to -1L
+      ),
+      V2ColumnGroup(
+        fieldIds = Seq(113L),
+        filePaths = Seq("p/single"),
+        fileRowCounts = Seq(1L)
+        // slotFieldId defaults to -1L
+      )
+    )
+    val out = MilvusBackfill.dedupColumnGroupsBySlot(input)
+    out shouldBe input
   }
 }

--- a/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
@@ -95,6 +95,12 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
     seg.columnGroups(2).filePaths shouldBe Seq(
       "files/insert_log/465602255560377587/465602255560377588/465602255560578628/102/465602255560688631"
     )
+
+    // The AVRO slot id (AvroFieldBinlog.field_id) must be propagated onto
+    // V2ColumnGroup so MilvusBackfill.dedupColumnGroupsBySlot can resolve
+    // multi-group fieldID conflicts. Slots match the per-group directory
+    // names {0, 1, 102} for this fixture.
+    seg.columnGroups.map(_.slotFieldId) shouldBe Seq(0L, 1L, 102L)
   }
 
   test("toV2SegmentInfo rejects non-StorageV2 entries") {


### PR DESCRIPTION
Workaround for Milvus snapshots that predate FieldBinlog.child_fields: when the same fieldID is claimed by both an old multi-field column group (slot < 100) and a newer single-field group written by a prior addfield+backfill (slot == fieldID), the C++ packed reader picks an undefined source and often returns the older slot's stale mostly-null data, silently corrupting coalesce-mode merges.

dedupColumnGroupsBySlot resolves each fieldID to the group with the largest slotFieldId (equivalent to "newer single-field group wins" under the current naming convention). The AVRO slotFieldId is now surfaced on V2ColumnGroup; -1L is the "unknown slot" sentinel that disables dedup for the snapshot-JSON DTO path. 0L is intentionally NOT used as the sentinel because RowID's column group legitimately sits at slot 0.