### PR TITLE
enhance!: [backfill] default --mode to coalesce for safer fill-if-null semantics

### DIFF
--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -72,8 +72,20 @@ object BackfillApp {
       sourceS3Region = parsed.get("source-s3-region"),
       batchSize = parsed.getOrElse("batch-size", "1024").toInt,
       columnMapping = parsed.get("column-mapping").map(parseColumnMapping),
-      mode = parsed.getOrElse("mode", MilvusOption.BackfillModeOverwrite)
+      mode = parsed.getOrElse("mode", MilvusOption.BackfillModeCoalesce)
     )
+
+    // Surface the default flip (#91) loudly: downstream jobs that omit
+    // --mode silently switched from full-overwrite to fill-if-null, and
+    // client-mode callers now fail validation. Printing to stderr so it
+    // reaches the driver log even when the user's log config hides INFO.
+    if (!parsed.contains("mode")) {
+      System.err.println(
+        s"[BackfillApp] --mode not set; defaulting to '${config.mode}' " +
+          s"(fill-if-null). Pass '--mode ${MilvusOption.BackfillModeOverwrite}' " +
+          "to restore the pre-#91 full-overwrite behavior."
+      )
+    }
 
     val spark = SparkSession.builder
       .appName("MilvusBackfill")

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -79,12 +79,12 @@ case class BackfillConfig(
     columnMapping: Option[Map[String, String]] = None,
 
     // Merge mode for backfill values:
-    //   "overwrite" (default) — parquet is the source of truth; for every row
-    //     in the collection, write the parquet value (null included).
-    //   "coalesce" — read the target field's current value from source and
-    //     only write the parquet value where the source value is null.
-    //     Per-field: each target field is decided independently.
-    mode: String = MilvusOption.BackfillModeOverwrite
+    //   "coalesce" (default) — read the target field's current value from
+    //     source and only write the parquet value where the source value is
+    //     null. Per-field: each target field is decided independently.
+    //   "overwrite" — parquet is the source of truth; for every row in the
+    //     collection, write the parquet value (null included).
+    mode: String = MilvusOption.BackfillModeCoalesce
 ) {
 
   /** Validate S3 and writer configuration (always required)

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -44,7 +44,8 @@ spark-submit \
   [--source-use-iam] \
   [--source-s3-region us-east-1] \
   [--batch-size 1024] \
-  [--output-result s3a://milvus-bucket/backfill/result.json]
+  [--output-result s3a://milvus-bucket/backfill/result.json] \
+  [--mode coalesce|overwrite]
 ```
 
 ### Authentication and dual-bucket credentials
@@ -73,10 +74,44 @@ spark-submit \
 | `--s3-endpoint`| S3 endpoint for the Milvus storage bucket          |
 | `--s3-bucket`  | Milvus storage bucket name                         |
 
+### Optional flags
+
+| Flag              | Default     | Description                                                                  |
+|-------------------|-------------|------------------------------------------------------------------------------|
+| `--mode`          | `coalesce`  | Merge semantics: `coalesce` (fill-if-null) or `overwrite`. See "Merge modes" below. |
+| `--batch-size`    | `1024`      | Rows per Arrow batch flushed to the writer.                                  |
+| `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |
+| `--output-result` | *(none)*    | Path to write the result JSON.                                               |
+
+## Merge modes (`--mode`)
+
+Distinct from the read-mode choice above (snapshot vs client), `--mode`
+controls how per-row values are merged into each target field:
+
+| Mode        | Default | Semantics                                                                                                        |
+|-------------|---------|------------------------------------------------------------------------------------------------------------------|
+| `coalesce`  | ✅      | Per field, keep the existing source value when non-null; only write the parquet value where the source is null. |
+| `overwrite` |         | Parquet is the source of truth: for every row in the collection, write the parquet value (including `null`).    |
+
+**`coalesce` caveats** (enforced at validation):
+
+- Requires `--snapshot` — each target field is read from the snapshot so
+  the merge can coalesce against the existing value. Client mode (no
+  `--snapshot`) therefore cannot use the default and must pass
+  `--mode overwrite` explicitly.
+- Parquet column types must match the snapshot field types **exactly**
+  — no Spark widening (Int32 → Int64 is rejected).
+- Slightly heavier I/O than `overwrite` because the existing field is
+  read per segment.
+
+See `docs/user-guide-snapshot-backfill.md` §6 for deeper discussion and
+worked examples.
+
 ## Programmatic API
 
 ```scala
 import org.apache.spark.sql.SparkSession
+import com.zilliz.spark.connector.MilvusOption
 import com.zilliz.spark.connector.operations.backfill._
 
 val spark = SparkSession.builder().appName("Backfill").getOrCreate()
@@ -103,7 +138,12 @@ val config = BackfillConfig(
   sourceS3UseIam    = Some(true),
   sourceS3Region    = Some("us-east-1"),
 
-  batchSize = 1024
+  batchSize = 1024,
+
+  // Merge mode. Defaults to "coalesce" (fill-if-null). Use
+  // MilvusOption.BackfillModeOverwrite for the legacy "parquet wins"
+  // semantics. See "Merge modes" above.
+  mode = MilvusOption.BackfillModeCoalesce
 )
 
 val result = MilvusBackfill.run(
@@ -143,6 +183,9 @@ result match {
   corresponding main `s3*` value.
 - `batchSize` — writer batch size (default 1024).
 - `customOutputPath` — override the per-segment output path.
+- `mode` — merge semantics (default `MilvusOption.BackfillModeCoalesce`).
+  Set to `MilvusOption.BackfillModeOverwrite` to restore the previous
+  "parquet wins" default. See "Merge modes" above for caveats.
 
 ## Error handling
 

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -41,14 +41,14 @@ class BackfillModeTest
 
   // ============ Config / CLI parsing ============
 
-  test("BackfillConfig defaults to overwrite mode") {
+  test("BackfillConfig defaults to coalesce mode") {
     val config = BackfillConfig(
       s3Endpoint = "localhost:9000",
       s3BucketName = "a-bucket",
       s3AccessKey = "ak",
       s3SecretKey = "sk"
     )
-    config.mode shouldBe MilvusOption.BackfillModeOverwrite
+    config.mode shouldBe MilvusOption.BackfillModeCoalesce
     config.validate() shouldBe Right(())
   }
 


### PR DESCRIPTION
Flip BackfillConfig.mode and BackfillApp's --mode fallback from
"overwrite" to "coalesce". Coalesce only writes the parquet value when
the existing source field is null, so a re-run or repair job no longer
silently overwrites rows that already have data — the previous default
made accidental wipes too easy.

When --mode is omitted, BackfillApp now emits a startup notice on
stderr pointing at the change and the legacy opt-out, so operators spot the default flip in driver logs even if they don't read the release notes.

BREAKING CHANGE: the default value of --mode / BackfillConfig.mode has changed from "overwrite" to "coalesce".

Migration guidance for downstream callers that relied on the old default:

- Add --mode overwrite (CLI) or mode = MilvusOption.BackfillModeOverwrite (programmatic API) to restore the pre-https://github.com/zilliztech/spark-milvus/pull/91 "parquet wins" semantics.
- Client-mode callers (no --snapshot) MUST opt in to overwrite: coalesce needs the snapshot to read each target field and will otherwise fail validation with "--mode=coalesce requires a  snapshot path".
- Coalesce also enforces exact parquet ↔ collection field type match  (no Spark widening such as Int32 → Int64). Fix the parquet schema or switch back to overwrite.

Docs and the backfill README are updated with a Merge modes section, an Optional flags table that names --mode, and an updated programmatic-API example. The existing "BackfillConfig defaults to overwrite mode" unit test is renamed and now asserts the coalesce default; all other mode tests already set mode explicitly and remain
unchanged.