### PR TITLE
enhance!: [backfill] rename --mode overwrite → replace; add new overwrite mode for matched-only overrides

### DIFF
--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -119,10 +119,19 @@ object MilvusOption {
   val WriterFieldIds =
     "milvus.writer.fieldIds" // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
 
-  // Backfill merge mode
+  // Backfill merge mode.
+  //   replace   — file is source of truth for target columns: matched rows
+  //               take file values (null included); unmatched source rows get
+  //               null target columns.
+  //   coalesce  — fill-if-null: matched rows pick coalesce(src, file) per
+  //               field (source wins when non-null); unmatched source rows
+  //               keep their original values.
+  //   overwrite — file overrides matched rows only (null included); unmatched
+  //               source rows keep their original values.
   val BackfillMode = "milvus.backfill.mode"
-  val BackfillModeOverwrite = "overwrite"
+  val BackfillModeReplace = "replace"
   val BackfillModeCoalesce = "coalesce"
+  val BackfillModeOverwrite = "overwrite"
 
   // Snapshot-based reading options (for offline/client-free mode)
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -12,7 +12,15 @@ import com.zilliz.spark.connector.MilvusOption
   * --s3-endpoint <endpoint> --s3-bucket <bucket> \ --s3-access-key <key>
   * --s3-secret-key <secret> \ [--s3-root-path <path>] [--s3-region <region>]
   * [--s3-use-ssl] \ [--batch-size <n>] [--output-result <path>] \ [--mode
-  * overwrite|coalesce]
+  * replace|coalesce|overwrite]
+  *
+  * --mode:
+  *   - replace: parquet is absolute source of truth; unmatched source rows get
+  *     null target columns (destructive)
+  *   - coalesce: fill-if-null — source wins when non-null, parquet fills nulls;
+  *     unmatched source rows keep original values (default)
+  *   - overwrite: file overrides matched rows (null included); unmatched source
+  *     rows keep original values
   */
 object BackfillApp {
 
@@ -75,15 +83,17 @@ object BackfillApp {
       mode = parsed.getOrElse("mode", MilvusOption.BackfillModeCoalesce)
     )
 
-    // Surface the default flip (#91) loudly: downstream jobs that omit
-    // --mode silently switched from full-overwrite to fill-if-null, and
-    // client-mode callers now fail validation. Printing to stderr so it
-    // reaches the driver log even when the user's log config hides INFO.
+    // Surface the default (#91) loudly: downstream jobs that omit --mode get
+    // fill-if-null, and client-mode callers fail validation without a
+    // snapshot. Printing to stderr so it reaches the driver log even when the
+    // user's log config hides INFO.
     if (!parsed.contains("mode")) {
       System.err.println(
         s"[BackfillApp] --mode not set; defaulting to '${config.mode}' " +
-          s"(fill-if-null). Pass '--mode ${MilvusOption.BackfillModeOverwrite}' " +
-          "to restore the pre-#91 full-overwrite behavior."
+          s"(fill-if-null). Pass '--mode ${MilvusOption.BackfillModeReplace}' " +
+          "for the pre-#91 full-overwrite behavior, or " +
+          s"'--mode ${MilvusOption.BackfillModeOverwrite}' to overwrite only " +
+          "matched rows."
       )
     }
 

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -80,12 +80,25 @@ case class BackfillConfig(
 
     // Merge mode for backfill values:
     //   "coalesce" (default) — read the target field's current value from
-    //     source and only write the parquet value where the source value is
-    //     null. Per-field: each target field is decided independently.
-    //   "overwrite" — parquet is the source of truth; for every row in the
-    //     collection, write the parquet value (null included).
+    //     source and pick coalesce(src, parquet) per row per field (source
+    //     wins when non-null; parquet fills nulls). Unmatched source rows
+    //     keep their original target values.
+    //   "overwrite" — parquet overrides the target field for rows whose pk
+    //     matches (null included). Unmatched source rows keep their original
+    //     target values.
+    //   "replace" — parquet is the absolute source of truth: every source
+    //     row's target field becomes the parquet value (null if the pk has
+    //     no parquet match). Destructive on unmatched rows.
     mode: String = MilvusOption.BackfillModeCoalesce
 ) {
+
+  /** Whether the merge path needs to read each target field from the source
+    * side too. Coalesce and overwrite both compare source and parquet values
+    * per row at join time; replace takes parquet verbatim and therefore only
+    * needs the pk + segment tracking columns from source.
+    */
+  def readsSourceFields: Boolean =
+    mode != MilvusOption.BackfillModeReplace
 
   /** Validate S3 and writer configuration (always required)
     */
@@ -97,12 +110,14 @@ case class BackfillConfig(
     } else if (batchSize <= 0) {
       Left("batchSize must be positive")
     } else if (
-      mode != MilvusOption.BackfillModeOverwrite &&
-      mode != MilvusOption.BackfillModeCoalesce
+      mode != MilvusOption.BackfillModeReplace &&
+      mode != MilvusOption.BackfillModeCoalesce &&
+      mode != MilvusOption.BackfillModeOverwrite
     ) {
       Left(
-        s"mode must be '${MilvusOption.BackfillModeOverwrite}' or " +
-          s"'${MilvusOption.BackfillModeCoalesce}' (got '$mode')"
+        s"mode must be one of '${MilvusOption.BackfillModeReplace}', " +
+          s"'${MilvusOption.BackfillModeCoalesce}', " +
+          s"'${MilvusOption.BackfillModeOverwrite}' (got '$mode')"
       )
     } else if (!s3UseIam && (s3AccessKey.isEmpty || s3SecretKey.isEmpty)) {
       // Hard invariant: must use IAM or supply both AK and SK. Half-set

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -43,12 +43,14 @@ object MilvusBackfill {
     */
   private[backfill] val MatchFlagCol = "__bf_matched__"
 
-  /** Per-field flag columns added only in coalesce mode: for each new field,
-    * one boolean marker recording whether the written value came from the
-    * source (src non-null) and another for whether it came from the backfill
-    * data file (src null AND bf non-null). Used by the writer to tally the
-    * per-field `usedSourceByField` / `usedDataFileByField` counts surfaced in
-    * `SegmentBackfillResult`.
+  /** Per-field flag columns added in any mode that reads source-side target
+    * values (coalesce + overwrite). For each new field, one boolean marker
+    * records whether the written value came from the source side and another
+    * whether it came from the backfill data file. Semantics differ per mode:
+    *   - coalesce: usedSrc = src non-null; usedBf = src null AND bf non-null
+    *   - overwrite: usedSrc = pk unmatched; usedBf = pk matched
+    * Used by the writer to tally the per-field `usedSourceByField` /
+    * `usedDataFileByField` counts surfaced in `SegmentBackfillResult`.
     */
   private[backfill] def usedSrcCol(field: String): String =
     s"__bf_used_src_${field}__"
@@ -260,18 +262,19 @@ object MilvusBackfill {
       }
       val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
 
-      // In coalesce mode, also read each target field from source so
-      // `coalesce(src, backfill)` can keep the existing value when non-null.
-      // Requires a snapshot — we need the field's Spark type.
-      val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+      // In coalesce / overwrite modes, also read each target field from source
+      // so the merge step (coalesce(src,bf) or when(matched, bf).otherwise(src))
+      // can compare source and parquet values per row. Requires a snapshot —
+      // we need the field's Spark type.
+      val readsSourceFields = config.readsSourceFields
       val extraReadFields
           : Seq[(String, Long, org.apache.spark.sql.types.StructField)] =
-        if (isCoalesceMode) {
+        if (readsSourceFields) {
           val metadata = snapshotMetadataOpt.getOrElse {
             return Left(
               SchemaValidationError(
-                s"--mode=${MilvusOption.BackfillModeCoalesce} requires a " +
-                  "snapshot path so source field values can be read"
+                s"--mode=${config.mode} requires a snapshot path so source " +
+                  "field values can be read"
               )
             )
           }
@@ -296,10 +299,14 @@ object MilvusBackfill {
           }
         } else Seq.empty
 
-      // In coalesce mode, parquet column types must match snapshot field
-      // types exactly (see validateCoalesceTypes for rationale).
-      if (isCoalesceMode) {
-        validateCoalesceTypes(backfillDF.schema, extraReadFields) match {
+      // In any source-reading mode, parquet column types must match snapshot
+      // field types exactly (see validateMergeableFieldTypes for rationale).
+      if (readsSourceFields) {
+        validateMergeableFieldTypes(
+          backfillDF.schema,
+          extraReadFields,
+          config.mode
+        ) match {
           case Left(error) => return Left(error)
           case Right(_)    => // Continue
         }
@@ -650,8 +657,9 @@ object MilvusBackfill {
               )
           }
 
-          // Extend with any extra fields requested (coalesce mode). Field
-          // order in the schema must match the ReaderFieldIDs order.
+          // Extend with any extra fields requested (coalesce / overwrite
+          // modes). Field order in the schema must match the ReaderFieldIDs
+          // order.
           val withExtras = extraReadFields.foldLeft(pkSchema) {
             case (acc, (_, _, field)) => acc.add(field)
           }
@@ -709,17 +717,20 @@ object MilvusBackfill {
     }
   }
 
-  /** Coalesce mode requires parquet column types to match snapshot field types
-    * exactly. Spark's `coalesce(src, bf)` would otherwise widen to a common
-    * supertype (e.g. Int + Long → Long) and the writer would emit binlogs whose
-    * Arrow type no longer matches the Milvus field — Milvus would later misread
-    * them.
+  /** Coalesce and overwrite modes require parquet column types to match
+    * snapshot field types exactly. Both modes synthesize a per-row choice
+    * between the source-side and parquet-side values (`coalesce(src, bf)` in
+    * coalesce, `when(matched, bf).otherwise(src)` in overwrite) — Spark would
+    * otherwise widen to a common supertype (e.g. Int + Long → Long) and the
+    * writer would emit binlogs whose Arrow type no longer matches the Milvus
+    * field, which Milvus would later misread.
     */
-  private[backfill] def validateCoalesceTypes(
+  private[backfill] def validateMergeableFieldTypes(
       backfillSchema: org.apache.spark.sql.types.StructType,
       extraReadFields: Seq[
         (String, Long, org.apache.spark.sql.types.StructField)
-      ]
+      ],
+      mode: String
   ): Either[BackfillError, Unit] = {
     val backfillTypes =
       backfillSchema.fields.map(f => f.name -> f.dataType).toMap
@@ -734,8 +745,8 @@ object MilvusBackfill {
     if (mismatches.nonEmpty) {
       Left(
         SchemaValidationError(
-          s"--mode=${MilvusOption.BackfillModeCoalesce} requires backfill " +
-            s"parquet column types to match snapshot field types exactly. " +
+          s"--mode=$mode requires backfill parquet column types to match " +
+            s"snapshot field types exactly. " +
             s"Mismatched: ${mismatches.mkString(", ")}"
         )
       )
@@ -798,11 +809,17 @@ object MilvusBackfill {
 
   /** Merge original (source) rows with backfill rows per `mode`.
     *
-    *   - overwrite: left join on PK; backfill value replaces source (source
-    *     only contributes PK + segment tracking columns).
-    *   - coalesce: original side carries source values for each target field;
-    *     after the left join, compute `coalesce(src, backfill)` per field (keep
-    *     source when non-null, otherwise use backfill).
+    *   - replace: left join on PK; backfill value replaces source (source only
+    *     contributes PK + segment tracking columns). Unmatched source rows end
+    *     up with null target columns.
+    *   - coalesce: source side carries the target fields; after the left join,
+    *     compute `coalesce(src, backfill)` per field (source wins when
+    *     non-null, otherwise use backfill). Unmatched source rows keep their
+    *     original target values.
+    *   - overwrite: source side carries the target fields; after the left join,
+    *     compute `when(matched, backfill).otherwise(src)` per field (file wins
+    *     when the pk matched, even if the file value is null). Unmatched source
+    *     rows keep their original target values.
     */
   private[backfill] def performJoin(
       originalDF: DataFrame,
@@ -839,11 +856,42 @@ object MilvusBackfill {
             .drop(n + suffix)
         }
 
-      case _ =>
+      case MilvusOption.BackfillModeOverwrite =>
+        // Same suffix-rename scaffolding as coalesce — both modes need both
+        // sides' target columns live on the joined frame.
+        val suffix = "__bf__"
+        val renamedBackfill = newFieldNames.foldLeft(backfillWithFlag) {
+          (df, n) =>
+            df.withColumnRenamed(n, n + suffix)
+        }
+        val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
+        // Match flag is null for unmatched left rows, non-null for matched.
+        // Using it (rather than `bf.isNotNull`) preserves overwrite's "file
+        // wins, null included" semantics when the file explicitly stores null.
+        val matched = col(MatchFlagCol).isNotNull
+        val withFlags = newFieldNames.foldLeft(joined) { (df, n) =>
+          df.withColumn(usedSrcCol(n), !matched)
+            .withColumn(usedBfCol(n), matched)
+        }
+        newFieldNames.foldLeft(withFlags) { (df, n) =>
+          df.withColumn(
+            n,
+            when(matched, df.col(n + suffix)).otherwise(df.col(n))
+          ).drop(n + suffix)
+        }
+
+      case MilvusOption.BackfillModeReplace =>
         // Use the using-column join form: both sides share the pkName column
         // (guaranteed by applyColumnMapping), so Spark collapses it into one,
         // avoiding ambiguous-reference errors downstream.
         originalDF.join(backfillWithFlag, Seq(pkName), "left")
+
+      case other =>
+        // Defensive: validate() rejects anything else, but keep a clear error
+        // in case a new mode constant is added without extending this match.
+        throw new IllegalArgumentException(
+          s"Unknown backfill mode '$other'"
+        )
     }
   }
 
@@ -919,13 +967,14 @@ object MilvusBackfill {
       // Prepare data: select only needed columns and add segment_id for
       // partitioning. Trailing column is the backfill match flag — retained
       // here so executors can count PK-matched rows, stripped from the
-      // projection that reaches the writer. In coalesce mode, two extra
-      // boolean flag columns per new field follow the match flag (usedSrc,
-      // usedBf interleaved, in `newFieldNames` order) so the writer can
-      // compute per-field usedSourceByField / usedDataFileByField counts.
-      val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+      // projection that reaches the writer. In any source-reading mode
+      // (coalesce / overwrite), two extra boolean flag columns per new field
+      // follow the match flag (usedSrc, usedBf interleaved, in
+      // `newFieldNames` order) so the writer can compute per-field
+      // usedSourceByField / usedDataFileByField counts.
+      val readsSourceFields = config.readsSourceFields
       val flagColNames: Seq[String] =
-        if (isCoalesceMode)
+        if (readsSourceFields)
           newFieldNames.flatMap(n => Seq(usedSrcCol(n), usedBfCol(n)))
         else Seq.empty
       val preparedDF = joinedDF
@@ -1038,8 +1087,10 @@ object MilvusBackfill {
       logger.info(s"Total rows written: $totalRows")
       logger.info(s"Total time for all segments: ${totalTime}ms")
       logger.info(s"Average time per segment: ${avgTime}ms")
-      if (isCoalesceMode) {
-        logger.info("Coalesce provenance (per field, aggregated):")
+      if (readsSourceFields) {
+        logger.info(
+          s"Per-field provenance (mode=${config.mode}, aggregated):"
+        )
         newFieldNames.foreach { f =>
           val src = results.map(_._1.usedSourceByField.getOrElse(f, 0L)).sum
           val df = results.map(_._1.usedDataFileByField.getOrElse(f, 0L)).sum
@@ -1128,11 +1179,12 @@ object MilvusBackfill {
       .createBatchWriterFactory(null)
       .createWriter(0, System.currentTimeMillis())
 
-    val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+    val readsSourceFields = config.readsSourceFields
     val newFieldNames = targetSchema.fieldNames.toSeq
     val numNewFields = newFieldNames.size
     // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
-    // __bf_matched__, (usedSrc, usedBf)*numNewFields in coalesce mode only].
+    // __bf_matched__, (usedSrc, usedBf)*numNewFields in source-reading modes
+    // (coalesce / overwrite) only].
     val matchFlagIdx = 2 + numNewFields
     val firstFlagIdx = matchFlagIdx + 1
 
@@ -1150,7 +1202,7 @@ object MilvusBackfill {
           .toArray
         if (targetFields.forall(_ == null)) nullRowCount += 1
         if (!row.isNullAt(matchFlagIdx)) matchedRowCount += 1
-        if (isCoalesceMode) {
+        if (readsSourceFields) {
           var i = 0
           while (i < numNewFields) {
             val srcIdx = firstFlagIdx + 2 * i
@@ -1184,7 +1236,7 @@ object MilvusBackfill {
       writer.close()
 
       val (usedSrcByField, usedBfByField) =
-        if (isCoalesceMode)
+        if (readsSourceFields)
           (
             newFieldNames.zip(usedSrcCounts).toMap,
             newFieldNames.zip(usedBfCounts).toMap
@@ -1438,10 +1490,11 @@ object MilvusBackfill {
       allocateLogId = allocator
     )
 
-    val isCoalesceMode = config.mode == MilvusOption.BackfillModeCoalesce
+    val readsSourceFields = config.readsSourceFields
     val numNewFields = fieldNames.size
     // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
-    // __bf_matched__, (usedSrc, usedBf)*numNewFields in coalesce mode only].
+    // __bf_matched__, (usedSrc, usedBf)*numNewFields in source-reading modes
+    // (coalesce / overwrite) only].
     val matchFlagIdx = 2 + numNewFields
     val firstFlagIdx = matchFlagIdx + 1
 
@@ -1451,8 +1504,9 @@ object MilvusBackfill {
     val usedBfCounts = Array.fill(numNewFields)(0L)
     try {
       // The V2 writer only wants the newField columns; strip the tracking
-      // columns, the match flag, and any coalesce-mode provenance flags (the
-      // match flag + per-field flags are folded into the counters instead).
+      // columns, the match flag, and any source-reading-mode provenance flags
+      // (the match flag + per-field flags are folded into the counters
+      // instead).
       def projected(row: InternalRow): InternalRow = {
         val dataEnd = matchFlagIdx
         val values = (2 until dataEnd)
@@ -1462,7 +1516,7 @@ object MilvusBackfill {
       }
       def countMatch(row: InternalRow): Unit = {
         if (!row.isNullAt(matchFlagIdx)) matchedRowCount += 1
-        if (isCoalesceMode) {
+        if (readsSourceFields) {
           var i = 0
           while (i < numNewFields) {
             val srcIdx = firstFlagIdx + 2 * i
@@ -1497,7 +1551,7 @@ object MilvusBackfill {
         )
       }
       val (usedSrcByField, usedBfByField) =
-        if (isCoalesceMode)
+        if (readsSourceFields)
           (
             fieldNames.zip(usedSrcCounts).toMap,
             fieldNames.zip(usedBfCounts).toMap

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -45,7 +45,7 @@ spark-submit \
   [--source-s3-region us-east-1] \
   [--batch-size 1024] \
   [--output-result s3a://milvus-bucket/backfill/result.json] \
-  [--mode coalesce|overwrite]
+  [--mode replace|coalesce|overwrite]
 ```
 
 ### Authentication and dual-bucket credentials
@@ -78,7 +78,7 @@ spark-submit \
 
 | Flag              | Default     | Description                                                                  |
 |-------------------|-------------|------------------------------------------------------------------------------|
-| `--mode`          | `coalesce`  | Merge semantics: `coalesce` (fill-if-null) or `overwrite`. See "Merge modes" below. |
+| `--mode`          | `coalesce`  | Merge semantics: `replace`, `coalesce` (fill-if-null), or `overwrite`. See "Merge modes" below. |
 | `--batch-size`    | `1024`      | Rows per Arrow batch flushed to the writer.                                  |
 | `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |
 | `--output-result` | *(none)*    | Path to write the result JSON.                                               |
@@ -86,23 +86,40 @@ spark-submit \
 ## Merge modes (`--mode`)
 
 Distinct from the read-mode choice above (snapshot vs client), `--mode`
-controls how per-row values are merged into each target field:
+controls how per-row values are merged into each target field. All three
+modes use a LEFT JOIN from source (Milvus) to parquet on the PK; parquet
+rows whose PK is not in the collection are always dropped. They differ on
+what happens for matched rows and for source rows with no parquet match:
 
-| Mode        | Default | Semantics                                                                                                        |
-|-------------|---------|------------------------------------------------------------------------------------------------------------------|
-| `coalesce`  | ✅      | Per field, keep the existing source value when non-null; only write the parquet value where the source is null. |
-| `overwrite` |         | Parquet is the source of truth: for every row in the collection, write the parquet value (including `null`).    |
+| Mode        | Default | Matched row (PK in both)         | Source row unmatched by parquet |
+|-------------|---------|----------------------------------|---------------------------------|
+| `replace`   |         | Parquet wins (null included)     | Target columns set to NULL      |
+| `coalesce`  | ✅      | `coalesce(src, parquet)` per field — source wins when non-null | Source preserved |
+| `overwrite` |         | Parquet wins (null included)     | Source preserved                |
 
-**`coalesce` caveats** (enforced at validation):
+Typical fits:
 
-- Requires `--snapshot` — each target field is read from the snapshot so
-  the merge can coalesce against the existing value. Client mode (no
-  `--snapshot`) therefore cannot use the default and must pass
-  `--mode overwrite` explicitly.
+- `replace` — fresh backfill of a brand-new field where parquet is the
+  full authoritative source.
+- `coalesce` — incremental / repair runs that only want to fill gaps.
+- `overwrite` — corrective update for a subset of rows; parquet is
+  authoritative only for the PKs it covers and untouched rows must be
+  preserved.
+
+**`coalesce` / `overwrite` caveats** (enforced at validation — both read
+source-side target values):
+
+- Require `--snapshot` — each target field is read from the snapshot so
+  the merge can compare against the existing value. Client mode (no
+  `--snapshot`) cannot use these and must pass `--mode replace` explicitly.
 - Parquet column types must match the snapshot field types **exactly**
-  — no Spark widening (Int32 → Int64 is rejected).
-- Slightly heavier I/O than `overwrite` because the existing field is
-  read per segment.
+  — no Spark widening (Int32 → Int64 is rejected). Only `replace` lets
+  Spark cast between compatible numeric widths.
+- Slightly heavier I/O than `replace` because the existing field is read
+  per segment.
+- For `overwrite`: an explicitly null value in the parquet **will** clobber
+  the existing source value on matched rows — the match flag drives the
+  projection, not the file column's null-ness.
 
 See `docs/user-guide-snapshot-backfill.md` §6 for deeper discussion and
 worked examples.
@@ -140,9 +157,11 @@ val config = BackfillConfig(
 
   batchSize = 1024,
 
-  // Merge mode. Defaults to "coalesce" (fill-if-null). Use
-  // MilvusOption.BackfillModeOverwrite for the legacy "parquet wins"
-  // semantics. See "Merge modes" above.
+  // Merge mode. Defaults to "coalesce" (fill-if-null). Set to
+  // MilvusOption.BackfillModeOverwrite for matched-rows-only overwrite
+  // (parquet wins on matched PKs, unmatched source rows preserved), or
+  // MilvusOption.BackfillModeReplace for full overwrite (unmatched source
+  // rows get null target columns). See "Merge modes" above.
   mode = MilvusOption.BackfillModeCoalesce
 )
 
@@ -184,8 +203,10 @@ result match {
 - `batchSize` — writer batch size (default 1024).
 - `customOutputPath` — override the per-segment output path.
 - `mode` — merge semantics (default `MilvusOption.BackfillModeCoalesce`).
-  Set to `MilvusOption.BackfillModeOverwrite` to restore the previous
-  "parquet wins" default. See "Merge modes" above for caveats.
+  Set to `MilvusOption.BackfillModeOverwrite` for matched-rows-only
+  overwrite, or `MilvusOption.BackfillModeReplace` for full overwrite
+  (unmatched source rows get null target columns). See "Merge modes"
+  above for caveats.
 
 ## Error handling
 

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -15,8 +15,8 @@ import org.scalatest.BeforeAndAfterAll
 import com.zilliz.spark.connector.read.{V2ColumnGroup, V2SegmentInfo}
 import com.zilliz.spark.connector.MilvusOption
 
-/** Tests for the new `--mode` backfill parameter: CLI/config validation and the
-  * `performJoin` merge semantics (overwrite vs coalesce).
+/** Tests for the `--mode` backfill parameter: CLI/config validation and the
+  * `performJoin` merge semantics (replace vs coalesce vs overwrite).
   */
 class BackfillModeTest
     extends AnyFunSuite
@@ -140,7 +140,7 @@ class BackfillModeTest
     spark.createDataFrame(spark.sparkContext.parallelize(javaRows), schema)
   }
 
-  test("overwrite mode: source has only PK, backfill values win") {
+  test("replace mode: source has only PK, backfill values win") {
     val originalSchema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
@@ -166,7 +166,7 @@ class BackfillModeTest
       backfill,
       "pk",
       Seq("f1", "f2"),
-      MilvusOption.BackfillModeOverwrite
+      MilvusOption.BackfillModeReplace
     )
 
     val byPk = joined
@@ -184,7 +184,7 @@ class BackfillModeTest
     byPk shouldBe Seq(
       (1, Some(100), Some("A")),
       (2, None, Some("B")),
-      (3, None, None)
+      (3, None, None) // unmatched source row: target columns become null
     )
   }
 
@@ -255,9 +255,9 @@ class BackfillModeTest
     )
   }
 
-  // ============ validateCoalesceTypes ============
+  // ============ validateMergeableFieldTypes ============
 
-  test("validateCoalesceTypes: matching types pass") {
+  test("validateMergeableFieldTypes: matching types pass") {
     val backfillSchema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
@@ -269,14 +269,19 @@ class BackfillModeTest
       ("f1", 101L, StructField("f1", IntegerType, nullable = true)),
       ("f2", 102L, StructField("f2", StringType, nullable = true))
     )
-    MilvusBackfill.validateCoalesceTypes(backfillSchema, extras) shouldBe Right(
-      ()
-    )
+    MilvusBackfill.validateMergeableFieldTypes(
+      backfillSchema,
+      extras,
+      MilvusOption.BackfillModeCoalesce
+    ) shouldBe Right(())
   }
 
-  test("validateCoalesceTypes: mismatched type rejected with clear message") {
+  test(
+    "validateMergeableFieldTypes: mismatched type rejected with clear message"
+  ) {
     // parquet sees IntegerType but snapshot says LongType — Spark's coalesce
-    // would silently widen and produce a Long binlog, breaking Milvus reads.
+    // / when-otherwise would silently widen and produce a Long binlog,
+    // breaking Milvus reads.
     val backfillSchema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
@@ -287,7 +292,11 @@ class BackfillModeTest
       ("f1", 101L, StructField("f1", LongType, nullable = true))
     )
     val err = MilvusBackfill
-      .validateCoalesceTypes(backfillSchema, extras)
+      .validateMergeableFieldTypes(
+        backfillSchema,
+        extras,
+        MilvusOption.BackfillModeOverwrite
+      )
       .left
       .toOption
       .get
@@ -296,10 +305,12 @@ class BackfillModeTest
     err.message should include("f1")
     err.message should include("snapshot=bigint")
     err.message should include("parquet=int")
+    // Error surfaces the active mode so users know which flag to fix.
+    err.message should include(MilvusOption.BackfillModeOverwrite)
   }
 
   test(
-    "validateCoalesceTypes: backfill missing the field is not flagged here"
+    "validateMergeableFieldTypes: backfill missing the field is not flagged here"
   ) {
     // performJoin/processSegments handles missing columns via the left join.
     // The type validator only complains when both sides have the column AND
@@ -310,9 +321,11 @@ class BackfillModeTest
     val extras = Seq(
       ("f1", 101L, StructField("f1", LongType, nullable = true))
     )
-    MilvusBackfill.validateCoalesceTypes(backfillSchema, extras) shouldBe Right(
-      ()
-    )
+    MilvusBackfill.validateMergeableFieldTypes(
+      backfillSchema,
+      extras,
+      MilvusOption.BackfillModeCoalesce
+    ) shouldBe Right(())
   }
 
   test("coalesce mode: per-field provenance flags mark source vs datafile") {
@@ -394,6 +407,122 @@ class BackfillModeTest
       .toSeq
 
     byPk shouldBe Seq((1, 10, "A"), (2, 20, "B"))
+  }
+
+  // ============ overwrite mode (matched rows take file, unmatched keep src) ============
+
+  test(
+    "overwrite mode: matched rows take backfill, unmatched rows keep source"
+  ) {
+    // pk=1 — matched, backfill has non-null values → take backfill for both
+    //        fields (differs from coalesce: even where src is non-null, file
+    //        wins when matched).
+    // pk=2 — matched, backfill has null f1 → write null (differs from
+    //        coalesce: coalesce would keep src; overwrite overrides).
+    // pk=3 — no backfill row → keep source values (differs from replace,
+    //        which would null them out).
+    val original = buildOriginal(
+      Seq(
+        (1, Int.box(1), "src1", 10L, 0L),
+        (2, Int.box(2), "src2", 10L, 1L),
+        (3, Int.box(3), "src3", 10L, 2L)
+      )
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(100), "BF1"),
+        (2, null, "BF2")
+        // pk=3 missing
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeOverwrite
+    )
+
+    // Output layout mirrors coalesce: source-side columns + match flag +
+    // per-field provenance flags.
+    joined.columns.toSet shouldBe Set(
+      "pk",
+      "f1",
+      "f2",
+      "segment_id",
+      "row_offset",
+      MilvusBackfill.MatchFlagCol,
+      MilvusBackfill.usedSrcCol("f1"),
+      MilvusBackfill.usedBfCol("f1"),
+      MilvusBackfill.usedSrcCol("f2"),
+      MilvusBackfill.usedBfCol("f2")
+    )
+
+    val byPk = joined
+      .orderBy("pk")
+      .collect()
+      .map(r =>
+        (
+          r.getAs[Int]("pk"),
+          Option(r.get(r.fieldIndex("f1"))).map(_.asInstanceOf[Int]),
+          Option(r.getAs[String]("f2"))
+        )
+      )
+      .toSeq
+
+    byPk shouldBe Seq(
+      (1, Some(100), Some("BF1")), // matched: backfill wins on both
+      (2, None, Some("BF2")), // matched: backfill's null clobbers src
+      (3, Some(3), Some("src3")) // unmatched: source preserved
+    )
+  }
+
+  test(
+    "overwrite mode: per-field provenance — matched → usedBf, unmatched → usedSrc"
+  ) {
+    val original = buildOriginal(
+      Seq(
+        (1, Int.box(1), "src1", 10L, 0L),
+        (2, Int.box(2), "src2", 10L, 1L)
+      )
+    )
+    val backfill = buildBackfill(
+      Seq(
+        (1, Int.box(100), "BF1")
+        // pk=2 missing — unmatched
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      "pk",
+      Seq("f1", "f2"),
+      MilvusOption.BackfillModeOverwrite
+    )
+
+    val flags = joined
+      .orderBy("pk")
+      .collect()
+      .map(r =>
+        (
+          r.getAs[Int]("pk"),
+          r.getAs[Boolean](MilvusBackfill.usedSrcCol("f1")),
+          r.getAs[Boolean](MilvusBackfill.usedBfCol("f1")),
+          r.getAs[Boolean](MilvusBackfill.usedSrcCol("f2")),
+          r.getAs[Boolean](MilvusBackfill.usedBfCol("f2"))
+        )
+      )
+      .toSeq
+
+    // Overwrite's per-field flags track the row-level match — same value
+    // across every field for a given row (unlike coalesce, where each field
+    // decides independently).
+    flags shouldBe Seq(
+      (1, false, true, false, true), // matched: backfill wins for both fields
+      (2, true, false, true, false) // unmatched: source kept for both fields
+    )
   }
 
   // ============ dedupColumnGroupsBySlot ============


### PR DESCRIPTION
The old --mode overwrite nulled out unmatched source rows, conflicting with the intuitive reading of "overwrite" (parquet should override what it covers, not what it doesn't). Since that mode was never released on a tagged build (PR #91 is still in main), the namespace is reshuffled:

replace   (was overwrite) — parquet is absolute source of truth;
                            unmatched source rows get null target cols
coalesce  (unchanged)     — fill-if-null; source wins when non-null;
                            unmatched rows preserved
overwrite (new)           — parquet wins on matched rows (null
                            included); unmatched source rows preserved

The new overwrite mode fills the common "corrective update" shape where parquet is authoritative only for the PKs it covers and untouched rows must not be clobbered.

Changes
-------
- MilvusOption: split BackfillModeOverwrite into BackfillModeReplace ("replace") + BackfillModeOverwrite ("overwrite", new semantics).
- BackfillConfig: three-way validator; new `readsSourceFields` derived helper (= mode != replace) gating reader extension, type validation, provenance flag projection, and per-field summary logs.
- MilvusBackfill.performJoin: explicit three-way match (no catch-all); new overwrite branch mirrors coalesce's suffix-rename scaffold and uses MatchFlagCol.isNotNull to drive when(matched, bf).otherwise(src) per field, so explicit parquet nulls still clobber src on matched rows.
- validateCoalesceTypes → validateMergeableFieldTypes; now called for any source-reading mode, error message carries the active mode.
- All isCoalesceMode locals replaced by readsSourceFields.
- BackfillApp: usage + default-mode warning updated; warning points at --mode replace for pre-#91 behaviour and --mode overwrite for partial corrections.
- BackfillModeTest: existing "overwrite" tests renamed to "replace"; two new overwrite-mode tests (matched file-wins incl null / unmatched src preserved; per-field provenance flags collapse to row-level match); validateMergeableFieldTypes tests adapted to new signature.
- docs/user-guide-snapshot-backfill.md, docs/design-snapshot-backfill.md, src/main/scala/operations/backfill/README.md rewritten with the three-mode comparison table and shared caveats.
- docs/backfill-mode-plan.md, docs/backfill-mode-commit-message.md (both untracked) rewritten as the authoritative three-mode plan.

Compatibility
-------------
No backwards-compat shim. `--mode overwrite` now denotes the new matched-only overwrite semantics; callers that still want the pre-#91 destructive variant must pass `--mode replace`. Since the coalesce default (PR #91) already covers the path where the flag is omitted, no silent behaviour change occurs for existing default-without-flag jobs.

Tests
-----
BackfillModeTest (14 tests), BackfillConfigTest, ColumnMappingTest, BackfillAppTest — 78 tests green. MilvusBackfillTest failure is the pre-existing localhost:19530 dependency and unrelated.