### PR TITLE
enhance: [naming] align storage-version names with segment-info enum

### DIFF
--- a/docs/milvus-storage-versions.md
+++ b/docs/milvus-storage-versions.md
@@ -1,0 +1,143 @@
+# Milvus Storage Versions — Reference
+
+Authoritative definitions of `storage_version` as used by Milvus
+segment-info, plus the naming conventions used in this connector. If anything
+below disagrees with `milvus/internal/storage/rw.go`, `rw.go` wins.
+
+> **TL;DR:** there are three on-disk formats — V1 (binlog), V2 (packed
+> parquet, no manifest), V3 (packed parquet with AVRO manifest). The name
+> "V2" is overloaded: the milvus-storage C++ library calls its own
+> manifest-based format "format v2", which **is the server's V3**. Always
+> clarify which "V2" you mean.
+
+---
+
+## The segment-info enum (source of truth)
+
+From `milvus/internal/storage/rw.go`:
+
+| Value | Name       | On-disk layout |
+|-------|------------|----------------|
+| **0** | StorageV1  | Row-oriented binlog. One binlog file per field per segment under `insert_log/{coll}/{part}/{seg}/{fieldID}/{logID}`. Each field has its own schema; no column grouping. |
+| **1** | *(unused)* | No segment has this value. |
+| **2** | StorageV2  | Packed parquet, **no external manifest**. Column groups live at `insert_log/{coll}/{part}/{seg}/{slot}/{logID}` where `slot` is the column-group slot (a single-field group's slot is the field ID; a multi-field group's slot is the smallest unused int `< 100`). Layout is recovered at read time by combining (a) the per-segment AVRO from the snapshot's `manifest_list`, which gives `slot → file paths`, with (b) any one parquet file's footer KV-metadata `group_field_id_list`, which gives `slot → real field IDs`. |
+| **3** | StorageV3  | Packed parquet **with** external loon manifest at `{basePath}/_metadata/manifest-<ver>.avro`. The manifest alone describes column groups, file paths, and row counts — no snapshot-side AVRO decode needed. Written and read via milvus-storage's `loon_reader_new` / loon transaction FFI. Listed separately in the snapshot JSON under `storagev2_manifest_list`. |
+
+Parquet files in V2 and V3 share the same footer schema and KV trio
+(`row_group_metadata`, `storage_version = "1.0.0"`, `group_field_id_list`).
+Only the **manifest layer** differs — V2 has none, V3 has an AVRO file.
+
+---
+
+## Two "V2"s (naming trap)
+
+| Context | "V2" means |
+|---------|-----------|
+| Milvus segment-info enum | `storage_version = 2` — non-manifest packed parquet |
+| `milvus-storage` C++ library internals | Its own on-disk format "version 2" — which actually corresponds to the server's **V3** (manifest-based) |
+| Parquet footer KV `storage_version = "1.0.0"` | Yet another versioning namespace (milvus-storage's parquet-level format string) |
+
+Consequences:
+
+- A class called `MilvusLoonXxxV2` may handle V3 (library sense) — **check
+  the class comment for which "V2" it uses**.
+- The snapshot JSON wire key `storagev2_manifest_list` carries V3 manifests.
+  This is a historical mis-name baked into the datacoord snapshot writer;
+  cannot be renamed from the connector alone.
+
+---
+
+## How segments are surfaced in the connector
+
+### Snapshot mode (offline, no Milvus client)
+
+A snapshot JSON produced by milvus-datacoord has two separate arrays:
+
+- `manifest_list` — per-segment AVRO paths. These can contain **V1 or V2**
+  segments; `MilvusSegmentManifestReader` decodes each AVRO and branches on
+  the inner `storage_version` field.
+- `storagev2_manifest_list` — array of `StorageV2ManifestItem`. These are
+  **V3** (despite the key name). Each carries a `basePath` and a `ver` that
+  locates the loon manifest.
+
+`MilvusDataSource.planInputPartitionsFromSnapshot` dispatches:
+
+| Source                          | InputPartition                      | Reader                            |
+|---------------------------------|-------------------------------------|-----------------------------------|
+| `storagev2_manifest_list` items | `MilvusStorageV3InputPartition`     | `MilvusLoonPartitionReader`       |
+| `SnapshotV2Segments` option     | `MilvusPackedV2InputPartition`      | `MilvusPackedV2PartitionReader`   |
+
+Both sources can coexist (mixed-version snapshot).
+
+### Client mode (online, via gRPC `getPersistentSegmentInfo`)
+
+`MilvusClient.getSegments` returns `MilvusSegmentInfo` with a
+`storageVersion: Long` field reflecting the segment-info enum.
+
+**As of 2026-04-24 the client-mode planner does NOT distinguish V2 from V3.**
+It filters `storageVersion >= 2` and routes every match to the V3 reader. A
+collection containing real V2 segments will therefore fail to read in client
+mode. See the "Client-mode V2 dispatch" task tracked separately.
+
+---
+
+## Connector class / option map (post-rename, 2026-04-24)
+
+| Symbol                                 | Handles            |
+|----------------------------------------|--------------------|
+| `read/MilvusStorageV3InputPartition`   | V3 (loon manifest) |
+| `read/MilvusPackedV2InputPartition`    | V2 (non-manifest)  |
+| `read/MilvusLoonPartitionReader`       | V3                 |
+| `read/MilvusPackedV2PartitionReader`   | V2                 |
+| `read/MilvusSegmentManifestReader`     | Decodes per-segment AVROs; produces `AvroManifestEntry` with inner `storageVersion` field (can be 0/2/3 — 2 is then fed into `V2SegmentLoader`; 3 is exposed via `storagev2_manifest_list`; 0 is V1 and not supported for backfill) |
+| `read/MilvusParquetFooterReader`       | Reads `storage_version`/`group_field_id_list`/`row_group_metadata` from parquet footer KV (used only for V2 — V3 learns the same info from the loon manifest) |
+| `read/V2SegmentLoader`                 | Turns `AvroManifestEntry` + parquet footer into a `V2SegmentInfo` |
+| `read/V2SegmentInfo` / `V2ColumnGroup` | V2 runtime view    |
+| `write/MilvusLoonWriter`               | V3 writer (FFI transaction) |
+| `write/MilvusV2BinlogWriter`           | V2 writer (direct `AvroParquetWriter` per field) |
+| `operations/backfill/V2SegmentArtifact` | V2 backfill output, consumed to patch snapshot AVRO |
+| `operations/backfill/SegmentBackfillResult.committedVersion` / `.manifestPaths` | V3 backfill output (new manifest version) |
+| JSON wire key `storagev2_manifest_list` | V3 manifest list — wire name is historical, frozen |
+| JSON wire key `manifest_list`            | Per-segment AVRO paths (V1 or V2) |
+| Spark option `milvus.snapshot.manifests` | Serialized `Seq[StorageV2ManifestItem]` — i.e. V3 |
+| Spark option `milvus.snapshot.v2.segments` | Serialized `Seq[V2SegmentInfo]` — i.e. V2 |
+
+---
+
+## Decision flow for new code
+
+When you need to reason about storage versions, answer these in order:
+
+1. **Which layer am I at?**
+   - Server segment-info enum (`storageVersion` on `MilvusSegmentInfo`,
+     `AvroManifestEntry.storageVersion`) → use the **V1/V2/V3** mapping above.
+   - milvus-storage C++ format name → use "library format v2" = server V3.
+     Don't mix the two.
+2. **Do I have a manifest file?**
+   - Yes, at `_metadata/manifest-*.avro` → V3. Use `MilvusLoonPartitionReader`
+     / `MilvusLoonWriter`.
+   - No → V2. Use `MilvusPackedV2PartitionReader` /
+     `MilvusV2BinlogWriter`.
+3. **Am I planning from a snapshot or a live Milvus client?**
+   - Snapshot: look at both `manifest_list` (V1/V2) and
+     `storagev2_manifest_list` (V3).
+   - Client: beware — planner does not currently dispatch V2 vs V3
+     (see separate task).
+
+## Pitfalls
+
+- **Don't trust a class name ending in `V2`** — read the class comment.
+  Several "V2" names still refer to V3 for historical reasons.
+- **Don't derive the column-group slot from the field IDs inside the file.**
+  For multi-field groups the slot is a small int allocator's output, not a
+  field ID. For single-field groups it happens to equal the field ID —
+  backfill exploits this invariant but general code shouldn't.
+- **Don't rename `@JsonProperty("storagev2_manifest_list")`** on the
+  deserialize-only `SnapshotMetadata` case class — the wire key is produced
+  by milvus-datacoord and renaming it here silently drops V3 parsing.
+- **V1 segments are read-only to this connector.** Backfill does not write
+  binlog format; a collection that still has V1 segments must be flushed to
+  V2/V3 before backfill runs.
+- **Parquet footer `storage_version = "1.0.0"`** is milvus-storage's
+  parquet-level format version, *not* the segment-info enum. Both V2 and V3
+  parquet files carry the same footer value; it is not a discriminator.

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -135,12 +135,17 @@ object MilvusOption {
 
   // Snapshot-based reading options (for offline/client-free mode)
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
-  val SnapshotManifests =
-    "milvus.snapshot.manifests" // JSON array of StorageV2ManifestItem
-  // JSON array of com.zilliz.spark.connector.read.V2SegmentInfo (StorageV2,
-  // non-manifest packed parquet). Populated by backfill after decoding the
-  // per-segment AVROs + parquet footers; consumed by MilvusDataSource's
-  // snapshot planner to create MilvusPackedV2InputPartition instances.
+  // JSON array of StorageV2ManifestItem. Despite the "V2" in the class name,
+  // these are StorageV3 loon manifests (segment-info storage_version = 3).
+  // The class name + JSON wire key are historical: milvus-storage's library
+  // calls its own manifest format "format v2", which collides with the
+  // server's segment-info enum where V2 means non-manifest packed parquet.
+  val SnapshotManifests = "milvus.snapshot.manifests"
+  // JSON array of com.zilliz.spark.connector.read.V2SegmentInfo — true
+  // StorageV2 (segment-info storage_version = 2, non-manifest packed parquet).
+  // Populated by backfill after decoding the per-segment AVROs + parquet
+  // footers; consumed by MilvusDataSource's snapshot planner to create
+  // MilvusPackedV2InputPartition instances.
   val SnapshotV2Segments = "milvus.snapshot.v2.segments"
   val SnapshotCollectionId = "milvus.snapshot.collection.id"
   val SnapshotPartitionIds = "milvus.snapshot.partition.ids"

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -4,16 +4,19 @@ import org.apache.spark.sql.connector.read.InputPartition
 
 import com.zilliz.spark.connector.MilvusOption
 
-// Storage V2 InputPartition - requires Milvus 2.6+
+// InputPartition for milvus-segment-info `storage_version = 3` (StorageV3) —
+// the manifest-based packed parquet format consumed by milvus-storage's
+// `loon_reader_new` via `LoonManifest`. See `milvus/internal/storage/rw.go`
+// for the authoritative segment-info enum (V1=0, V2=2, V3=3).
 //
-// Naming note: "V2" here refers to the **milvus-storage format version 2**
-// (manifest-based, consumed by `loon_reader_new` via `LoonManifest`). In
-// milvus's segment-info convention this is `storage_version = 3`
-// (StorageV3). See `milvus/internal/storage/rw.go` for the authoritative
-// segment-info enum. For the **non-manifest packed parquet** segments
-// (segment-info `storage_version = 2`, StorageV2) use
-// [[MilvusPackedV2InputPartition]].
-case class MilvusStorageV2InputPartition(
+// For the non-manifest packed-parquet format (segment-info
+// `storage_version = 2`, StorageV2) use [[MilvusPackedV2InputPartition]].
+//
+// Historical note: this class used to be called `MilvusStorageV2InputPartition`
+// because the underlying milvus-storage library calls its own manifest format
+// "format v2". That collided with the segment-info enum where V2 means
+// something different; the class was renamed to match the enum.
+case class MilvusStorageV3InputPartition(
     manifestPath: String, // Path to manifest in S3/MinIO
     milvusSchemaBytes: Array[Byte], // Serialized protobuf
     partitionName: String,

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -25,21 +25,22 @@ import io.milvus.storage.{
 }
 
 /** Spark partition reader for milvus-segment-info `storage_version = 2`
-  * (non-manifest packed parquet) segments.
+  * (StorageV2, non-manifest packed parquet) segments.
   *
-  * Unlike [[MilvusLoonPartitionReader]], which resolves a milvus-storage
-  * `.milvus_manifest` file via `MilvusStorageManifest.getColumnGroupsScala`,
-  * this reader is handed a pre-materialized set of [[V2ColumnGroup]]s recovered
-  * from the snapshot AVRO (slot -> file paths) + one parquet footer's
-  * `group_field_id_list` kv-metadata (slot -> real field IDs). The packed
-  * reader then opens only the files for the requested columns.
+  * Unlike [[MilvusLoonPartitionReader]] (which handles StorageV3: manifest
+  * based, resolves a milvus-storage `.milvus_manifest` file via
+  * `MilvusStorageManifest.getColumnGroupsScala`), this reader is handed a
+  * pre-materialized set of [[V2ColumnGroup]]s recovered from the snapshot AVRO
+  * (slot -> file paths) + one parquet footer's `group_field_id_list`
+  * kv-metadata (slot -> real field IDs). The packed reader then opens only the
+  * files for the requested columns.
   *
   * The reader iterates the Arrow stream sequentially (no vector search, no
   * filter pushdown). Backfill only needs the PK column plus positional row
   * metadata added by [[MilvusPartitionReaderFactory]], so the minimal shape
   * fits well.
   */
-class MilvusLoonV2PartitionReader(
+class MilvusPackedV2PartitionReader(
     schema: StructType,
     columnGroups: Seq[V2ColumnGroup],
     milvusSchema: CollectionSchema,

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -24,12 +24,12 @@ class MilvusPartitionReaderFactory(
       partition: InputPartition
   ): PartitionReader[InternalRow] = {
     partition match {
-      case p: MilvusStorageV2InputPartition =>
+      case p: MilvusStorageV3InputPartition =>
         logInfo(
-          s"Creating V2 reader for partition with segmentID=${p.segmentID}"
+          s"Creating V3 reader for partition with segmentID=${p.segmentID}"
         )
 
-        // Storage V2 doesn't support system fields (row_id, timestamp) and extra metadata columns (segment_id, row_offset)
+        // Storage V3 doesn't support system fields (row_id, timestamp) and extra metadata columns (segment_id, row_offset)
         // Filter them out from the schema for the underlying reader
         val v2Schema = StructType(schema.fields.filter { field =>
           field.name != "row_id" &&
@@ -131,7 +131,7 @@ class MilvusPartitionReaderFactory(
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
 
-        val underlying = new MilvusLoonV2PartitionReader(
+        val underlying = new MilvusPackedV2PartitionReader(
           innerSchema,
           p.columnGroups,
           milvusSchema,

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -235,7 +235,14 @@ case class ManifestContent(
     @JsonProperty("base_path") basePath: String
 )
 
-/** Storage V2 manifest item
+/** One loon manifest entry from the snapshot JSON's `storagev2_manifest_list`.
+  *
+  * NAMING NOTE: despite the "V2" in class name + JSON key, these entries are
+  * StorageV3 (segment-info `storage_version = 3`, manifest-based packed
+  * parquet). The "V2" comes from milvus-storage's library-internal version, not
+  * from the server's segment-info enum. The wire key is emitted by
+  * milvus-datacoord (Go side) and can't be renamed from the connector alone.
+  * See `read/MilvusInputPartition.scala` for the authoritative enum.
   */
 case class StorageV2ManifestItem(
     @JsonProperty("segmentID") @JsonAlias(

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -22,7 +22,7 @@ import org.apache.spark.internal.Logging
   *      `MilvusSegmentManifestReader.toV2SegmentInfo` to join the two.
   *
   * The resulting `Seq[V2SegmentInfo]` is the runtime view consumed by
-  * `MilvusPackedV2InputPartition` / `MilvusLoonV2PartitionReader`.
+  * `MilvusPackedV2InputPartition` / `MilvusPackedV2PartitionReader`.
   *
   * Path resolution: AVRO and parquet paths that milvus writes are
   * bucket-relative (`files/snapshots/...`). When `bucket` is non-empty we

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -45,7 +45,7 @@ import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusPackedV2InputPartition,
   MilvusPartitionReaderFactory,
-  MilvusStorageV2InputPartition
+  MilvusStorageV3InputPartition
 }
 import com.zilliz.spark.connector.write.{MilvusWrite, MilvusWriteBuilder}
 import io.milvus.grpc.schema.CollectionSchema
@@ -691,17 +691,18 @@ class MilvusScan(
         partitionID: String
     ): InputPartition = {
       // Build segment path where manifest files exist
-      // V2 segments have manifest files at: rootPath/insert_log/collectionID/partitionID/segmentID/_metadata/
+      // StorageV3 segments have manifest files at:
+      //   rootPath/insert_log/collectionID/partitionID/segmentID/_metadata/
       val segmentPath =
         s"$s3RootPath/insert_log/$collection/$partitionID/$segmentID"
       logInfo(
-        s"Creating V2 partition: segmentID=$segmentID, segmentPath=$segmentPath"
+        s"Creating V3 partition: segmentID=$segmentID, segmentPath=$segmentPath"
       )
 
       val segmentIDLong =
         try { segmentID.toLong }
         catch { case _: NumberFormatException => -1L }
-      MilvusStorageV2InputPartition(
+      MilvusStorageV3InputPartition(
         segmentPath,
         collectionInfo.schema.toByteArray,
         partitionID,
@@ -714,8 +715,11 @@ class MilvusScan(
       )
     }
 
-    // Get all V2 segments with partition info
-    val allV2Segments = client
+    // Get all segments with storage_version >= 2 (StorageV2 packed parquet
+    // without manifest, or StorageV3 packed parquet with loon manifest).
+    // NOTE: current planner treats every >= 2 segment as StorageV3; a separate
+    // task is tracking client-mode StorageV2 (non-manifest) dispatch.
+    val allPackedSegments = client
       .getSegments(
         milvusOption.databaseName,
         milvusOption.collectionName
@@ -725,18 +729,20 @@ class MilvusScan(
       )
       .filter(_.storageVersion >= 2)
 
-    if (allV2Segments.isEmpty) {
+    if (allPackedSegments.isEmpty) {
       throw new IllegalArgumentException(
-        s"No Storage V2 segments found in collection ${milvusOption.collectionName}. " +
-          "This connector requires Milvus 2.6+ with Storage V2. " +
-          "Please ensure the collection has been flushed and contains data."
+        s"No packed-parquet segments (StorageV2/V3) found in collection " +
+          s"${milvusOption.collectionName}. This connector requires Milvus " +
+          "2.6+ with Storage V2 or V3. Please ensure the collection has " +
+          "been flushed and contains data."
       )
     }
 
     val partitions: Array[InputPartition] =
       if (!partition.isEmpty() && !segment.isEmpty()) {
         // Case 1: Specific segment specified - validate segment belongs to partition
-        val segmentInfo = allV2Segments.find(_.segmentID.toString == segment)
+        val segmentInfo =
+          allPackedSegments.find(_.segmentID.toString == segment)
         segmentInfo match {
           case Some(seg) =>
             if (seg.partitionID.toString != partition) {
@@ -747,26 +753,28 @@ class MilvusScan(
             Array(createPartition(segment, partition))
           case None =>
             throw new IllegalArgumentException(
-              s"Segment $segment not found or not a V2 segment (Storage V2 required)"
+              s"Segment $segment not found or has storage_version < 2 " +
+                "(StorageV2/V3 packed parquet required)"
             )
         }
 
       } else if (!partition.isEmpty()) {
-        // Case 2: Partition specified - only process V2 segments in this partition
-        allV2Segments
+        // Case 2: Partition specified - only process packed segments in this partition
+        allPackedSegments
           .filter(_.partitionID.toString == partition)
           .map(seg => createPartition(seg.segmentID.toString, partition))
           .toArray
 
       } else {
-        // Case 3: No partition specified - process all V2 segments
-        allV2Segments.map { seg =>
+        // Case 3: No partition specified - process all packed segments
+        allPackedSegments.map { seg =>
           createPartition(seg.segmentID.toString, seg.partitionID.toString)
         }.toArray
       }
 
     logInfo(
-      s"Created ${partitions.length} partitions for Storage V2 (Milvus 2.6+)"
+      s"Created ${partitions.length} partitions (treating all StorageV2/V3 " +
+        "segments as V3; see V2 dispatch TODO)"
     )
     client.close()
     partitions
@@ -867,7 +875,7 @@ class MilvusScan(
       logInfo(
         s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"
       )
-      MilvusStorageV2InputPartition(
+      MilvusStorageV3InputPartition(
         basePath, // The basePath extracted from manifest JSON
         schemaBytes, // Protobuf CollectionSchema bytes from snapshot
         defaultPartitionId, // Partition name/ID

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -45,8 +45,13 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
-/** MilvusLoonWriteTable provides write support using Storage V2 FFI This table
-  * is used by MilvusLoonDataSource for write operations
+/** MilvusLoonWriteTable provides write support for StorageV3 (segment-info
+  * `storage_version = 3`, the manifest-based packed parquet format consumed by
+  * milvus-storage's loon reader/writer FFI). Used by MilvusLoonDataSource.
+  *
+  * Naming note: milvus-storage's own library calls this format its "format v2",
+  * hence the "Loon" (= loon manifest) prefix, but in segment-info parlance this
+  * is V3. See `read/MilvusInputPartition.scala` for the full enum.
   */
 case class MilvusLoonWriteTable(
     milvusOption: MilvusOption,


### PR DESCRIPTION
The milvus-storage C++ library calls its own manifest-based on-disk format "version 2", which collides with Milvus server's segment-info enum where `storage_version = 2` is the *non-manifest* packed parquet format and `storage_version = 3` is the manifest-based one. Several internal symbols said "V2" but actually handled V3 — a naming trap that made planner code misleading to read.

Internal renames (no user-facing API touched):
- MilvusStorageV2InputPartition → MilvusStorageV3InputPartition (handles storage_version=3, loon manifest path)
- MilvusLoonV2PartitionReader   → MilvusPackedV2PartitionReader
(handles storage_version=2, non-manifest packed parquet; file renamed)

Docstring / comment / log clarifications:
- MilvusLoonWriter: class docstring now says "StorageV3 (loon manifest) FFI".
- StorageV2ManifestItem: docstring warns class + wire key are historical — entries actually carry V3 manifests. The JSON key
`storagev2_manifest_list` is emitted by milvus-datacoord and cannot be renamed from the connector alone.
- MilvusOption.SnapshotManifests: clarifies it carries V3-despite-name.
- MilvusDataSource client-mode planner: local `allV2Segments` → `allPackedSegments`; error text now says "StorageV2/V3 packed parquet"; final log explicitly notes the planner still routes every `storage_version >= 2` segment to the V3 reader — real V2 segments would fail here. Tracked as a follow-up task (V2 dispatch in client mode).
- V2SegmentLoader / MilvusPartitionReaderFactory: update cross-references.

Docs:
- Add docs/milvus-storage-versions.md — authoritative reference for the V1/V2/V3 enum (sourced from milvus/internal/storage/rw.go), the two overloaded meanings of "V2", the full post-rename symbol map, and a decision flow + pitfalls list. Intended as the first read for anyone touching storage-version-sensitive code.

No on-disk, wire, or behavior changes. Pure rename + documentation.