### PR TITLE
enhance: [reader] add snapshot-backed read entrypoint

### DIFF
--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -139,6 +139,7 @@ val s3Options = Map(
 | 参数名 | 类型 | 必需 | 默认值 | 描述 |
 |--------|------|------|--------|------|
 | `MilvusOption.MilvusInsertMaxBatchSize` | Int | 否 | 5000 | 单次插入的最大批次大小 |
+| `MilvusOption.WriterVariableWidthBytesPerValue` | Double | 否 | 32.0 | VARCHAR/JSON/binary 写入列的 Arrow 初始 buffer 密度；宽变长字段可调大。必须是有限正数。 |
 | `MilvusOption.MilvusRetryCount` | Int | 否 | 3 | 操作失败时的重试次数 |
 | `MilvusOption.MilvusRetryInterval` | Int | 否 | 1000 | 重试间隔时间（毫秒） |
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -139,6 +139,7 @@ val s3Options = Map(
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.MilvusInsertMaxBatchSize` | Int | No | 5000 | Maximum batch size for single insert operation |
+| `MilvusOption.WriterVariableWidthBytesPerValue` | Double | No | 32.0 | Initial Arrow buffer density for VARCHAR/JSON/binary writer columns; increase for wide variable-width values. Must be finite and positive. |
 | `MilvusOption.MilvusRetryCount` | Int | No | 3 | Number of retries on operation failure |
 | `MilvusOption.MilvusRetryInterval` | Int | No | 1000 | Retry interval in milliseconds |
 

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -59,21 +59,20 @@ import io.milvus.grpc.schema.{
   ValueField
 }
 
-import io.grpc._
-import io.grpc.{ClientInterceptor, Metadata, Status => GrpcStatus}
+import io.grpc.{
+  ClientInterceptor,
+  ManagedChannel,
+  Metadata,
+  Status => GrpcStatus,
+  StatusException,
+  StatusRuntimeException
+}
 import io.grpc.netty.shaded.io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 import io.grpc.stub.MetadataUtils
-import io.grpc.Status.Code
 
 /** A simplified client for interacting with Milvus
   */
 class MilvusClient(params: MilvusConnectionParams) extends Logging {
-  private val retryInterceptor = new GrpcRetryInterceptor(
-    maxRetries = 5,
-    initialDelayMillis = 500,
-    delayMultiplier = 2.0,
-    maxDelayMillis = 5000
-  )
   private lazy val channel: ManagedChannel = {
     val uri = new URI(params.uri)
     val scheme = uri.getScheme
@@ -88,10 +87,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       }
     }
 
-    val interceptors = Seq(
-      getConnectionMetadataInterceptor(),
-      retryInterceptor
-    )
+    val interceptors = Seq(getConnectionMetadataInterceptor())
     var channelBuilder = if (params.serverPemPath.nonEmpty) {
       val sslContext = GrpcSslContexts
         .forClient()
@@ -940,31 +936,42 @@ object MilvusClient {
   val RateLimitReasonMarker: String = "rate limit exceeded"
   val ServiceNotImplementedMarker: String = "service not implemented"
 
+  private val SnapshotRpcNames: Set[String] = Set(
+    "createsnapshot",
+    "describesnapshot",
+    "dropsnapshot"
+  )
+
+  private val ServiceUnavailableMarkers: Set[String] = Set(
+    ServiceNotImplementedMarker,
+    "unknown method",
+    "method not registered"
+  )
+
+  private def grpcStatus(t: Throwable): Option[GrpcStatus] = t match {
+    case e: StatusRuntimeException => Some(e.getStatus)
+    case e: StatusException        => Some(e.getStatus)
+    case _                         => None
+  }
+
+  private def isSnapshotRpcUnavailable(description: String): Boolean = {
+    val normalized = description.toLowerCase
+    SnapshotRpcNames.exists(normalized.contains) &&
+    ServiceUnavailableMarkers.exists(normalized.contains)
+  }
+
   def isServiceNotImplemented(t: Throwable): Boolean = {
     val visited = java.util.Collections.newSetFromMap(
       new java.util.IdentityHashMap[Throwable, java.lang.Boolean]()
     )
     var current = t
     while (current != null && visited.add(current)) {
-      current match {
-        case e: StatusRuntimeException
-            if e.getStatus.getCode == GrpcStatus.Code.UNIMPLEMENTED =>
-          return true
-        case e: StatusException
-            if e.getStatus.getCode == GrpcStatus.Code.UNIMPLEMENTED =>
-          return true
-        case _ =>
-      }
-
-      val message = Option(current.getMessage).getOrElse("").toLowerCase
-      val isGrpcException = current.isInstanceOf[StatusRuntimeException] ||
-        current.isInstanceOf[StatusException]
-      if (
-        isGrpcException &&
-        (message.contains(ServiceNotImplementedMarker) ||
-          message.contains("unknown method"))
-      ) {
-        return true
+      grpcStatus(current).foreach { status =>
+        if (status.getCode == GrpcStatus.Code.UNIMPLEMENTED) return true
+        if (status.getCode == GrpcStatus.Code.UNKNOWN) {
+          val description = Option(status.getDescription).getOrElse("")
+          if (isSnapshotRpcUnavailable(description)) return true
+        }
       }
       current = current.getCause
     }
@@ -1076,89 +1083,5 @@ object PKProcessor {
 
   implicit object StringProcessor extends PKProcessor[String] {
     def process(seq: Seq[String]): String = seq.map(s => s"'$s'").mkString(", ")
-  }
-}
-
-class GrpcRetryInterceptor(
-    maxRetries: Int = 5,
-    initialDelayMillis: Long = 500,
-    delayMultiplier: Double = 2.0,
-    maxDelayMillis: Long = 5000
-) extends ClientInterceptor {
-
-  private val nonRetryableCodes: Set[Code] = Set(
-    Code.DEADLINE_EXCEEDED,
-    Code.PERMISSION_DENIED,
-    Code.UNAUTHENTICATED,
-    Code.INVALID_ARGUMENT,
-    Code.ALREADY_EXISTS,
-    Code.RESOURCE_EXHAUSTED,
-    Code.UNIMPLEMENTED
-  )
-
-  override def interceptCall[ReqT, RespT](
-      method: MethodDescriptor[ReqT, RespT],
-      callOptions: CallOptions,
-      next: Channel
-  ): ClientCall[ReqT, RespT] = {
-    new ForwardingClientCall.SimpleForwardingClientCall[ReqT, RespT](
-      next.newCall(method, callOptions)
-    ) {
-      override def start(
-          responseListener: ClientCall.Listener[RespT],
-          headers: Metadata
-      ): Unit = {
-        var currentAttempt = 0
-        var currentDelay = initialDelayMillis
-
-        def executeCall(): Unit = {
-          currentAttempt += 1
-          println(
-            s"Attempting gRPC call for method ${method.getFullMethodName()}, attempt $currentAttempt"
-          )
-
-          val originalListener =
-            new ForwardingClientCallListener.SimpleForwardingClientCallListener[
-              RespT
-            ](responseListener) {
-              override def onClose(
-                  status: GrpcStatus,
-                  trailers: Metadata
-              ): Unit = {
-                if (status.isOk) {
-                  // Call succeeded
-                  super.onClose(status, trailers)
-                } else {
-                  val statusCode = status.getCode
-                  if (nonRetryableCodes.contains(statusCode)) {
-                    println(
-                      s"gRPC call failed with non-retryable status: $statusCode. Not retrying."
-                    )
-                    super.onClose(status, trailers)
-                  } else if (currentAttempt < maxRetries) {
-                    println(
-                      s"gRPC call failed with retryable status: $statusCode. Retrying in $currentDelay ms."
-                    )
-                    Thread.sleep(currentDelay)
-                    currentDelay = Math.min(
-                      (currentDelay * delayMultiplier).toLong,
-                      maxDelayMillis
-                    )
-                    executeCall()
-                  } else {
-                    println(
-                      s"gRPC call failed after $maxRetries attempts with status: $statusCode. No more retries."
-                    )
-                    super.onClose(status, trailers)
-                  }
-                }
-              }
-            }
-          super.start(originalListener, headers)
-        }
-
-        executeCall() // Start the first attempt
-      }
-    }
   }
 }

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -920,8 +920,9 @@ object MilvusClient {
       val isGrpcException = current.isInstanceOf[StatusRuntimeException] ||
         current.isInstanceOf[StatusException]
       if (
-        message.contains(ServiceNotImplementedMarker) ||
-        (isGrpcException && message.contains("unknown method"))
+        isGrpcException &&
+        (message.contains(ServiceNotImplementedMarker) ||
+          message.contains("unknown method"))
       ) {
         return true
       }

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -139,22 +139,26 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
     val server = MilvusServiceGrpc
       .blockingStub(channel)
       .withWaitForReady()
+    server
       .withDeadlineAfter(10, TimeUnit.SECONDS)
-    server.connect(
-      ConnectRequest(
-        clientInfo = Some(
-          ClientInfo(
-            sdkType = "spark-connector",
-            sdkVersion = "0.1.0",
-            localTime = java.time.LocalDateTime.now().toString,
-            host = java.net.InetAddress.getLocalHost.getHostName,
-            user = "scala-sdk-user"
+      .connect(
+        ConnectRequest(
+          clientInfo = Some(
+            ClientInfo(
+              sdkType = "spark-connector",
+              sdkVersion = "0.1.0",
+              localTime = java.time.LocalDateTime.now().toString,
+              host = java.net.InetAddress.getLocalHost.getHostName,
+              user = "scala-sdk-user"
+            )
           )
         )
       )
-    )
     server
   }
+
+  private def rpcStub: MilvusServiceGrpc.MilvusServiceBlockingStub =
+    stub.withDeadlineAfter(10, TimeUnit.SECONDS)
 
   private lazy val httpClient: HttpClient = {
     HttpClient
@@ -202,7 +206,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       properties: Map[String, String] = Map.empty
   ): Try[Status] = {
     try {
-      val status = stub.createDatabase(
+      val status = rpcStub.createDatabase(
         CreateDatabaseRequest(
           dbName = dbName,
           properties = properties
@@ -287,7 +291,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       properties: Map[String, String] = Map.empty
   ): Try[Status] = {
     try {
-      val status = stub.createCollection(
+      val status = rpcStub.createCollection(
         CreateCollectionRequest(
           dbName = dbName,
           collectionName = collectionName,
@@ -314,7 +318,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       collectionName: String
   ): Try[Status] = {
     try {
-      val status = stub.dropCollection(
+      val status = rpcStub.dropCollection(
         DropCollectionRequest(
           dbName = dbName,
           collectionName = collectionName
@@ -334,7 +338,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       collectionNames: Seq[String] = Seq.empty
   ): Try[Status] = {
     try {
-      val flushResponse = stub.flush(
+      val flushResponse = rpcStub.flush(
         FlushRequest(
           dbName = dbName,
           collectionNames = collectionNames
@@ -375,7 +379,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       schemaTimestamp: Long = 0L
   ): Try[Status] = {
     try {
-      val insertResult = stub.insert(
+      val insertResult = rpcStub.insert(
         InsertRequest(
           dbName = dbName,
           collectionName = collectionName,
@@ -411,7 +415,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       rowBased: Boolean = false
   ): Try[Seq[Long]] = {
     try {
-      val importResult = stub.`import`(
+      val importResult = rpcStub.`import`(
         ImportRequest(
           dbName = dbName,
           collectionName = collectionName,
@@ -448,7 +452,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
 
   def getImportState(taskId: Long): Try[GetImportStateResponse] = {
     try {
-      val importStateResult = stub.getImportState(
+      val importStateResult = rpcStub.getImportState(
         GetImportStateRequest(task = taskId)
       )
       val status = importStateResult.status.getOrElse(
@@ -497,7 +501,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
           s"$name in [${processor.process(pks)}]"
         }
       }
-      val deleteResult = stub.delete(
+      val deleteResult = rpcStub.delete(
         DeleteRequest(
           dbName = dbName,
           collectionName = collectionName,
@@ -526,7 +530,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       dbName: String,
       collectionName: String
   ): DescribeCollectionResponse = {
-    return stub.describeCollection(
+    return rpcStub.describeCollection(
       DescribeCollectionRequest(
         dbName = dbName,
         collectionName = collectionName
@@ -630,7 +634,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       compactionProtectionSeconds: Long
   ): Try[MilvusSnapshotInfo] = {
     try {
-      val createStatus = stub.createSnapshot(
+      val createStatus = rpcStub.createSnapshot(
         CreateSnapshotRequest(
           name = snapshotName,
           description = description,
@@ -685,7 +689,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
     var lastFailure = Option.empty[Exception]
     (1 to maxAttempts).foreach { attempt =>
       try {
-        val snapshot = stub.describeSnapshot(
+        val snapshot = rpcStub.describeSnapshot(
           DescribeSnapshotRequest(
             name = snapshotName,
             dbName = dbName,
@@ -725,7 +729,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       snapshotName: String
   ): Try[Unit] = {
     try {
-      val status = stub.dropSnapshot(
+      val status = rpcStub.dropSnapshot(
         DropSnapshotRequest(
           name = snapshotName,
           dbName = dbName,
@@ -744,7 +748,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       collectionName: String
   ): Try[Seq[MilvusSegmentInfo]] = {
     try {
-      val segments = stub.getPersistentSegmentInfo(
+      val segments = rpcStub.getPersistentSegmentInfo(
         GetPersistentSegmentInfoRequest(
           dbName = dbName,
           collectionName = collectionName
@@ -869,7 +873,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       partitionName: String
   ): Try[Long] = {
     try {
-      val partitionInfos = stub.showPartitions(
+      val partitionInfos = rpcStub.showPartitions(
         ShowPartitionsRequest(
           dbName = dbName,
           collectionName = collectionName
@@ -898,7 +902,7 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       collectionName: String
   ): Try[Seq[MilvusPartitionInfo]] = {
     try {
-      val partitionInfos = stub.showPartitions(
+      val partitionInfos = rpcStub.showPartitions(
         ShowPartitionsRequest(
           dbName = dbName,
           collectionName = collectionName
@@ -1140,7 +1144,6 @@ class GrpcRetryInterceptor(
                       (currentDelay * delayMultiplier).toLong,
                       maxDelayMillis
                     )
-                    super.onClose(status, trailers)
                     executeCall()
                   } else {
                     println(

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -37,6 +37,7 @@ import io.milvus.grpc.milvus.{
   DescribeCollectionResponse,
   DescribeSnapshotRequest,
   DropCollectionRequest,
+  DropSnapshotRequest,
   FlushRequest,
   GetImportStateRequest,
   GetImportStateResponse,
@@ -638,33 +639,59 @@ class MilvusClient(params: MilvusConnectionParams) {
       )
       checkStatus("createSnapshot", createStatus).get
 
-      val snapshot = stub.describeSnapshot(
-        DescribeSnapshotRequest(
+      try {
+        val snapshot = stub.describeSnapshot(
+          DescribeSnapshotRequest(
+            name = snapshotName,
+            dbName = dbName,
+            collectionName = collectionName
+          )
+        )
+        checkStatus(
+          "describeSnapshot",
+          snapshot.status.getOrElse(
+            Status(
+              errorCode = ErrorCode.UnexpectedError,
+              reason = "DescribeSnapshot Status is empty"
+            )
+          )
+        ).get
+
+        Success(
+          MilvusSnapshotInfo(
+            name = snapshot.name,
+            description = snapshot.description,
+            collectionName = snapshot.collectionName,
+            partitionNames = snapshot.partitionNames,
+            createTs = snapshot.createTs,
+            s3Location = snapshot.s3Location
+          )
+        )
+      } catch {
+        case e: Exception =>
+          dropSnapshot(dbName, collectionName, snapshotName)
+          throw e
+      }
+    } catch {
+      case e: StatusRuntimeException => Failure(e)
+      case e: Exception              => Failure(e)
+    }
+  }
+
+  def dropSnapshot(
+      dbName: String,
+      collectionName: String,
+      snapshotName: String
+  ): Try[Unit] = {
+    try {
+      val status = stub.dropSnapshot(
+        DropSnapshotRequest(
           name = snapshotName,
           dbName = dbName,
           collectionName = collectionName
         )
       )
-      checkStatus(
-        "describeSnapshot",
-        snapshot.status.getOrElse(
-          Status(
-            errorCode = ErrorCode.UnexpectedError,
-            reason = "DescribeSnapshot Status is empty"
-          )
-        )
-      ).get
-
-      Success(
-        MilvusSnapshotInfo(
-          name = snapshot.name,
-          description = snapshot.description,
-          collectionName = snapshot.collectionName,
-          partitionNames = snapshot.partitionNames,
-          createTs = snapshot.createTs,
-          s3Location = snapshot.s3Location
-        )
-      )
+      checkStatus("dropSnapshot", status).map(_ => ())
     } catch {
       case e: StatusRuntimeException => Failure(e)
       case e: Exception              => Failure(e)

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.module.scala.{
   ScalaObjectMapper
 }
 import com.google.protobuf.ByteString
+import org.apache.spark.internal.Logging
 
 import io.milvus.grpc.common.{
   ClientInfo,
@@ -62,7 +63,6 @@ import io.grpc.{ClientInterceptor, Metadata, Status => GrpcStatus}
 import io.grpc.netty.shaded.io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 import io.grpc.stub.MetadataUtils
 import io.grpc.Status.Code
-import org.apache.spark.internal.Logging
 
 /** A simplified client for interacting with Milvus
   */
@@ -904,8 +904,11 @@ object MilvusClient {
   val ServiceNotImplementedMarker: String = "service not implemented"
 
   def isServiceNotImplemented(t: Throwable): Boolean = {
+    val visited = java.util.Collections.newSetFromMap(
+      new java.util.IdentityHashMap[Throwable, java.lang.Boolean]()
+    )
     var current = t
-    while (current != null) {
+    while (current != null && visited.add(current)) {
       current match {
         case e: StatusRuntimeException
             if e.getStatus.getCode == GrpcStatus.Code.UNIMPLEMENTED =>

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -62,10 +62,11 @@ import io.grpc.{ClientInterceptor, Metadata, Status => GrpcStatus}
 import io.grpc.netty.shaded.io.grpc.netty.{GrpcSslContexts, NettyChannelBuilder}
 import io.grpc.stub.MetadataUtils
 import io.grpc.Status.Code
+import org.apache.spark.internal.Logging
 
 /** A simplified client for interacting with Milvus
   */
-class MilvusClient(params: MilvusConnectionParams) {
+class MilvusClient(params: MilvusConnectionParams) extends Logging {
   private val retryInterceptor = new GrpcRetryInterceptor(
     maxRetries = 5,
     initialDelayMillis = 500,
@@ -669,7 +670,14 @@ class MilvusClient(params: MilvusConnectionParams) {
         )
       } catch {
         case e: Exception =>
-          dropSnapshot(dbName, collectionName, snapshotName)
+          dropSnapshot(dbName, collectionName, snapshotName) match {
+            case Failure(dropErr) =>
+              logWarning(
+                s"Failed to drop snapshot $snapshotName after describeSnapshot failure",
+                dropErr
+              )
+            case Success(_) =>
+          }
           throw e
       }
     } catch {

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -884,7 +884,6 @@ object MilvusClient {
       val message = Option(current.getMessage).getOrElse("").toLowerCase
       if (
         message.contains(ServiceNotImplementedMarker) ||
-        message.contains("unimplemented") ||
         message.contains("unknown method")
       ) {
         return true

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -37,6 +37,7 @@ import io.milvus.grpc.milvus.{
   DescribeCollectionRequest,
   DescribeCollectionResponse,
   DescribeSnapshotRequest,
+  DescribeSnapshotResponse,
   DropCollectionRequest,
   DropSnapshotRequest,
   FlushRequest,
@@ -641,22 +642,11 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       checkStatus("createSnapshot", createStatus).get
 
       try {
-        val snapshot = stub.describeSnapshot(
-          DescribeSnapshotRequest(
-            name = snapshotName,
-            dbName = dbName,
-            collectionName = collectionName
-          )
+        val snapshot = describeSnapshotForReadWithRetry(
+          dbName,
+          collectionName,
+          snapshotName
         )
-        checkStatus(
-          "describeSnapshot",
-          snapshot.status.getOrElse(
-            Status(
-              errorCode = ErrorCode.UnexpectedError,
-              reason = "DescribeSnapshot Status is empty"
-            )
-          )
-        ).get
 
         Success(
           MilvusSnapshotInfo(
@@ -684,6 +674,49 @@ class MilvusClient(params: MilvusConnectionParams) extends Logging {
       case e: StatusRuntimeException => Failure(e)
       case e: Exception              => Failure(e)
     }
+  }
+
+  private def describeSnapshotForReadWithRetry(
+      dbName: String,
+      collectionName: String,
+      snapshotName: String,
+      maxAttempts: Int = 3
+  ): DescribeSnapshotResponse = {
+    var lastFailure = Option.empty[Exception]
+    (1 to maxAttempts).foreach { attempt =>
+      try {
+        val snapshot = stub.describeSnapshot(
+          DescribeSnapshotRequest(
+            name = snapshotName,
+            dbName = dbName,
+            collectionName = collectionName
+          )
+        )
+        checkStatus(
+          "describeSnapshot",
+          snapshot.status.getOrElse(
+            Status(
+              errorCode = ErrorCode.UnexpectedError,
+              reason = "DescribeSnapshot Status is empty"
+            )
+          )
+        ).get
+        return snapshot
+      } catch {
+        case e: Exception =>
+          lastFailure = Some(e)
+          if (attempt < maxAttempts) {
+            logWarning(
+              s"describeSnapshot failed for $snapshotName (attempt $attempt/$maxAttempts)",
+              e
+            )
+            TimeUnit.MILLISECONDS.sleep(200L * attempt)
+          }
+      }
+    }
+    throw lastFailure.getOrElse(
+      new RuntimeException(s"describeSnapshot failed for $snapshotName")
+    )
   }
 
   def dropSnapshot(

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -882,9 +882,11 @@ object MilvusClient {
       }
 
       val message = Option(current.getMessage).getOrElse("").toLowerCase
+      val isGrpcException = current.isInstanceOf[StatusRuntimeException] ||
+        current.isInstanceOf[StatusException]
       if (
         message.contains(ServiceNotImplementedMarker) ||
-        message.contains("unknown method")
+        (isGrpcException && message.contains("unknown method"))
       ) {
         return true
       }

--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -31,9 +31,11 @@ import io.milvus.grpc.milvus.{
   ConnectRequest,
   CreateCollectionRequest,
   CreateDatabaseRequest,
+  CreateSnapshotRequest,
   DeleteRequest,
   DescribeCollectionRequest,
   DescribeCollectionResponse,
+  DescribeSnapshotRequest,
   DropCollectionRequest,
   FlushRequest,
   GetImportStateRequest,
@@ -617,6 +619,58 @@ class MilvusClient(params: MilvusConnectionParams) {
     }
   }
 
+  def createSnapshotForRead(
+      dbName: String,
+      collectionName: String,
+      snapshotName: String,
+      description: String,
+      compactionProtectionSeconds: Long
+  ): Try[MilvusSnapshotInfo] = {
+    try {
+      val createStatus = stub.createSnapshot(
+        CreateSnapshotRequest(
+          name = snapshotName,
+          description = description,
+          dbName = dbName,
+          collectionName = collectionName,
+          compactionProtectionSeconds = compactionProtectionSeconds
+        )
+      )
+      checkStatus("createSnapshot", createStatus).get
+
+      val snapshot = stub.describeSnapshot(
+        DescribeSnapshotRequest(
+          name = snapshotName,
+          dbName = dbName,
+          collectionName = collectionName
+        )
+      )
+      checkStatus(
+        "describeSnapshot",
+        snapshot.status.getOrElse(
+          Status(
+            errorCode = ErrorCode.UnexpectedError,
+            reason = "DescribeSnapshot Status is empty"
+          )
+        )
+      ).get
+
+      Success(
+        MilvusSnapshotInfo(
+          name = snapshot.name,
+          description = snapshot.description,
+          collectionName = snapshot.collectionName,
+          partitionNames = snapshot.partitionNames,
+          createTs = snapshot.createTs,
+          s3Location = snapshot.s3Location
+        )
+      )
+    } catch {
+      case e: StatusRuntimeException => Failure(e)
+      case e: Exception              => Failure(e)
+    }
+  }
+
   def getSegments(
       dbName: String,
       collectionName: String
@@ -812,6 +866,33 @@ object MilvusClient {
   val RateLimitErrorCode: Int = 8
   // Case-insensitive reason marker used as a fallback when error code is not set.
   val RateLimitReasonMarker: String = "rate limit exceeded"
+  val ServiceNotImplementedMarker: String = "service not implemented"
+
+  def isServiceNotImplemented(t: Throwable): Boolean = {
+    var current = t
+    while (current != null) {
+      current match {
+        case e: StatusRuntimeException
+            if e.getStatus.getCode == GrpcStatus.Code.UNIMPLEMENTED =>
+          return true
+        case e: StatusException
+            if e.getStatus.getCode == GrpcStatus.Code.UNIMPLEMENTED =>
+          return true
+        case _ =>
+      }
+
+      val message = Option(current.getMessage).getOrElse("").toLowerCase
+      if (
+        message.contains(ServiceNotImplementedMarker) ||
+        message.contains("unimplemented") ||
+        message.contains("unknown method")
+      ) {
+        return true
+      }
+      current = current.getCause
+    }
+    false
+  }
 
   val mapper: ObjectMapper with ScalaObjectMapper = {
     val m = new ObjectMapper() with ScalaObjectMapper
@@ -855,6 +936,15 @@ case class MilvusCollectionInfo(
     collectionName: String,
     collectionID: Long,
     schema: CollectionSchema
+)
+
+case class MilvusSnapshotInfo(
+    name: String,
+    description: String,
+    collectionName: String,
+    partitionNames: Seq[String],
+    createTs: Long,
+    s3Location: String
 )
 
 case class MilvusSegmentInfo(

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -158,6 +158,7 @@ object MilvusOption extends Logging {
     "milvus.snapshot.schema.json" // Optional: raw schema JSON for building MilvusCollectionInfo
   val SnapshotSchemaBytes =
     "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
+  val SnapshotMaxJsonBytes = "milvus.snapshot.maxJsonBytes"
   val ClientSnapshotName = "milvus.client.snapshot.name"
   val ClientSnapshotDescription = "milvus.client.snapshot.description"
   val ClientSnapshotCompactionProtectionSeconds =

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -8,6 +8,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.fs.s3a.S3AFileSystem
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
+import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.MilvusConnectionException
 
 /** Vector search configuration for Milvus Storage V2
@@ -158,6 +159,51 @@ object MilvusOption {
   val ClientSnapshotDescription = "milvus.client.snapshot.description"
   val ClientSnapshotCompactionProtectionSeconds =
     "milvus.client.snapshot.compactionProtectionSeconds"
+
+  def configureHadoopS3A(
+      conf: Configuration,
+      options: Map[String, String],
+      bucket: String
+  ): Unit = {
+    val prefix = s"fs.s3a.bucket.$bucket"
+
+    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    options.get(Properties.FsConfig.FsAddress).foreach { endpoint =>
+      conf.set(s"$prefix.endpoint", endpoint)
+    }
+    options.get(Properties.FsConfig.FsRegion).foreach { region =>
+      conf.set(s"$prefix.endpoint.region", region)
+      conf.set(s"$prefix.region", region)
+    }
+    conf.set(s"$prefix.path.style.access", "true")
+    conf.set(
+      s"$prefix.connection.ssl.enabled",
+      options.getOrElse(Properties.FsConfig.FsUseSSL, "false")
+    )
+
+    val useIam = options
+      .get(Properties.FsConfig.FsUseIam)
+      .exists(_.equalsIgnoreCase("true"))
+    val accessKey = options.get(Properties.FsConfig.FsAccessKeyId)
+    val secretKey = options.get(Properties.FsConfig.FsAccessKeyValue)
+    if (useIam || accessKey.isEmpty || secretKey.isEmpty) {
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        Seq(
+          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+        ).mkString(",")
+      )
+    } else {
+      conf.set(s"$prefix.access.key", accessKey.get)
+      conf.set(s"$prefix.secret.key", secretKey.get)
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    }
+  }
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -121,6 +121,8 @@ object MilvusOption extends Logging {
     "milvus.writer.commitType" // "addfield" for backfill, default "addfiles"
   val WriterFieldIds =
     "milvus.writer.fieldIds" // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
+  val WriterVariableWidthBytesPerValue =
+    "milvus.writer.variableWidthBytesPerValue"
 
   // Backfill merge mode.
   //   replace   — file is source of truth for target columns: matched rows

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -163,6 +163,18 @@ object MilvusOption extends Logging {
   val ClientSnapshotCompactionProtectionSeconds =
     "milvus.client.snapshot.compactionProtectionSeconds"
 
+  def isSnapshotMode(options: Map[String, String]): Boolean = {
+    options.get(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||
+    options.contains(SnapshotManifests) ||
+    options.contains(SnapshotV2Segments)
+  }
+
+  def isSnapshotMode(options: CaseInsensitiveStringMap): Boolean = {
+    Option(options.get(SnapshotMode)).exists(_.equalsIgnoreCase("true")) ||
+    Option(options.get(SnapshotManifests)).isDefined ||
+    Option(options.get(SnapshotV2Segments)).isDefined
+  }
+
   def configureHadoopS3A(
       conf: Configuration,
       options: Map[String, String],

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -183,7 +183,9 @@ object MilvusOption extends Logging {
   ): Unit = {
     val prefix = s"fs.s3a.bucket.$bucket"
 
-    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    if (Option(conf.get("fs.s3a.impl")).forall(_.trim.isEmpty)) {
+      conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    }
     options.get(Properties.FsConfig.FsAddress).foreach { endpoint =>
       conf.set(s"$prefix.endpoint", endpoint)
     }
@@ -221,21 +223,7 @@ object MilvusOption extends Logging {
     }
   }
 
-  private[connector] def normalizeExtraColumnName(name: String): String = {
-    name match {
-      case "segment_id" =>
-        logWarning(
-          s"Extra column 'segment_id' is deprecated; use '$MilvusExtraColumnSegmentID' instead"
-        )
-        MilvusExtraColumnSegmentID
-      case "row_offset" =>
-        logWarning(
-          s"Extra column 'row_offset' is deprecated; use '$MilvusExtraColumnRowOffset' instead"
-        )
-        MilvusExtraColumnRowOffset
-      case other => other
-    }
-  }
+  private[connector] def normalizeExtraColumnName(name: String): String = name
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -65,13 +65,14 @@ object MilvusOption {
 
   val MilvusExtraColumns = "milvus.extra.columns"
   val MilvusExtraColumnPartition = "partition"
-  val MilvusExtraColumnSegmentID = "segment_id"
-  val MilvusExtraColumnRowOffset = "row_offset"
+  val MilvusExtraColumnSegmentID = "$segment_id"
+  val MilvusExtraColumnRowOffset = "$row_offset"
 
   // reader config
   val ReaderPath = "path"
   val ReaderType = "type"
   val ReaderFieldIDs = "fieldIDs"
+  val ReaderDebug = "milvus.reader.debug"
 
   // vector search config
   val VectorSearchQueryVector = "vector.search.query"
@@ -153,6 +154,10 @@ object MilvusOption {
     "milvus.snapshot.schema.json" // Optional: raw schema JSON for building MilvusCollectionInfo
   val SnapshotSchemaBytes =
     "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
+  val ClientSnapshotName = "milvus.client.snapshot.name"
+  val ClientSnapshotDescription = "milvus.client.snapshot.description"
+  val ClientSnapshotCompactionProtectionSeconds =
+    "milvus.client.snapshot.compactionProtectionSeconds"
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -183,9 +183,14 @@ object MilvusOption extends Logging {
   ): Unit = {
     val prefix = s"fs.s3a.bucket.$bucket"
 
-    if (Option(conf.get("fs.s3a.impl")).forall(_.trim.isEmpty)) {
-      conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    def isMissing(key: String): Boolean =
+      Option(conf.get(key)).forall(_.trim.isEmpty)
+
+    def setIfMissing(key: String, value: String): Unit = {
+      if (isMissing(key)) conf.set(key, value)
     }
+
+    setIfMissing("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
     options.get(Properties.FsConfig.FsAddress).foreach { endpoint =>
       conf.set(s"$prefix.endpoint", endpoint)
     }
@@ -193,18 +198,35 @@ object MilvusOption extends Logging {
       conf.set(s"$prefix.endpoint.region", region)
       conf.set(s"$prefix.region", region)
     }
-    conf.set(s"$prefix.path.style.access", "true")
-    conf.set(
-      s"$prefix.connection.ssl.enabled",
-      options.getOrElse(Properties.FsConfig.FsUseSSL, "false")
-    )
+    options
+      .get(Properties.FsConfig.FsUseVirtualHost)
+      .orElse(options.get(FsUseVirtualHost)) match {
+      case Some(useVirtualHost) =>
+        conf.set(
+          s"$prefix.path.style.access",
+          (!useVirtualHost.toBoolean).toString
+        )
+      case None =>
+        setIfMissing(s"$prefix.path.style.access", "true")
+    }
+    options
+      .get(Properties.FsConfig.FsUseSSL)
+      .orElse(options.get(FsUseSSL)) match {
+      case Some(useSSL) => conf.set(s"$prefix.connection.ssl.enabled", useSSL)
+      case None => setIfMissing(s"$prefix.connection.ssl.enabled", "false")
+    }
 
     val useIam = options
       .get(Properties.FsConfig.FsUseIam)
+      .orElse(options.get(FsUseIam))
       .exists(_.equalsIgnoreCase("true"))
-    val accessKey = options.get(Properties.FsConfig.FsAccessKeyId)
-    val secretKey = options.get(Properties.FsConfig.FsAccessKeyValue)
-    if (useIam || accessKey.isEmpty || secretKey.isEmpty) {
+    val accessKey = options
+      .get(Properties.FsConfig.FsAccessKeyId)
+      .orElse(options.get(FsAccessKeyId))
+    val secretKey = options
+      .get(Properties.FsConfig.FsAccessKeyValue)
+      .orElse(options.get(FsAccessKeyValue))
+    if (useIam) {
       conf.set(
         s"$prefix.aws.credentials.provider",
         Seq(
@@ -213,12 +235,21 @@ object MilvusOption extends Logging {
           "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
         ).mkString(",")
       )
-    } else {
+    } else if (accessKey.nonEmpty && secretKey.nonEmpty) {
       conf.set(s"$prefix.access.key", accessKey.get)
       conf.set(s"$prefix.secret.key", secretKey.get)
       conf.set(
         s"$prefix.aws.credentials.provider",
         "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    } else {
+      setIfMissing(
+        s"$prefix.aws.credentials.provider",
+        Seq(
+          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+        ).mkString(",")
       )
     }
   }

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -206,7 +206,7 @@ object MilvusOption extends Logging {
     }
   }
 
-  private def normalizeExtraColumnName(name: String): String = {
+  private[connector] def normalizeExtraColumnName(name: String): String = {
     name match {
       case "segment_id" =>
         logWarning(

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -6,6 +6,7 @@ import scala.collection.Map
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.fs.s3a.S3AFileSystem
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import com.zilliz.spark.connector.loon.Properties
@@ -44,7 +45,7 @@ case class MilvusOption(
     vectorSearchConfig: Option[VectorSearchConfig] = None
 )
 
-object MilvusOption {
+object MilvusOption extends Logging {
   // Constants for map keys
   val MilvusUri = "milvus.uri"
   val MilvusToken = "milvus.token"
@@ -205,6 +206,22 @@ object MilvusOption {
     }
   }
 
+  private def normalizeExtraColumnName(name: String): String = {
+    name match {
+      case "segment_id" =>
+        logWarning(
+          s"Extra column 'segment_id' is deprecated; use '$MilvusExtraColumnSegmentID' instead"
+        )
+        MilvusExtraColumnSegmentID
+      case "row_offset" =>
+        logWarning(
+          s"Extra column 'row_offset' is deprecated; use '$MilvusExtraColumnRowOffset' instead"
+        )
+        MilvusExtraColumnRowOffset
+      case other => other
+    }
+  }
+
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {
     val uri = options.getOrDefault(MilvusUri, "")
@@ -233,6 +250,7 @@ object MilvusOption {
       .split(",")
       .map(_.trim)
       .filter(_.nonEmpty)
+      .map(normalizeExtraColumnName)
       .toSeq
 
     // Convert CaseInsensitiveStringMap to regular Map for storage

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -42,15 +42,11 @@ object Properties {
     *   MilvusStorageProperties for milvus-storage native library
     */
   def fromMilvusOption(milvusOption: MilvusOption): MilvusStorageProperties = {
-    val props = new MilvusStorageProperties()
     val propsMap = new ju.HashMap[String, String]()
 
     // Extract filesystem configuration with defaults
     val endpoint =
       milvusOption.options.getOrElse(FsConfig.FsAddress, "localhost:9000")
-    val bucket =
-      milvusOption.options.getOrElse(FsConfig.FsBucketName, "a-bucket")
-    val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
     // When use_iam=true the FFI must consult the AWS default credentials
     // chain (env vars / web identity / instance profile). Falling back to
     // hard-coded "minioadmin" defaults under IRSA produces signed requests
@@ -59,6 +55,18 @@ object Properties {
     val useIamFlag = milvusOption.options
       .get(FsConfig.FsUseIam)
       .exists(_.equalsIgnoreCase("true"))
+    val bucket = milvusOption.options
+      .get(FsConfig.FsBucketName)
+      .filter(_.trim.nonEmpty)
+      .getOrElse {
+        if (useIamFlag) {
+          throw new IllegalArgumentException(
+            s"${FsConfig.FsBucketName} must be set when ${FsConfig.FsUseIam}=true"
+          )
+        }
+        "a-bucket"
+      }
+    val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
     val accessKey =
       milvusOption.options.getOrElse(
         FsConfig.FsAccessKeyId,
@@ -119,6 +127,7 @@ object Properties {
       .get(FsConfig.FsUseCustomPartUpload)
       .foreach(propsMap.put(FsConfig.FsUseCustomPartUpload, _))
 
+    val props = new MilvusStorageProperties()
     props.create(propsMap)
     if (!props.isValid) {
       throw new IllegalStateException(

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -216,7 +216,7 @@ object BackfillApp {
           if (BoolFlags.contains(key)) {
             map += (key -> "true")
             i += 1
-          } else if (i + 1 < args.length) {
+          } else if (i + 1 < args.length && !args(i + 1).startsWith("--")) {
             map += (key -> args(i + 1))
             i += 2
           } else {

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -171,7 +171,10 @@ case class BackfillConfig(
       "milvus.token" -> milvusToken,
       "milvus.database.name" -> databaseName,
       "milvus.collection.name" -> collectionName,
-      "milvus.extra.columns" -> "segment_id,row_offset", // this is used to match with the original sequence of rows for each segment
+      "milvus.extra.columns" -> Seq(
+        MilvusOption.MilvusExtraColumnSegmentID,
+        MilvusOption.MilvusExtraColumnRowOffset
+      ).mkString(","),
       "fs.address" -> s3Endpoint,
       "fs.bucket_name" -> s3BucketName,
       "fs.root_path" -> s3RootPath,

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -42,6 +42,8 @@ object MilvusBackfill {
     * function, and stripped from the projection written to parquet.
     */
   private[backfill] val MatchFlagCol = "__bf_matched__"
+  private[backfill] val SegmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
+  private[backfill] val RowOffsetCol = MilvusOption.MilvusExtraColumnRowOffset
 
   /** Per-field flag columns added in any mode that reads source-side target
     * values (coalesce + overwrite). For each new field, one boolean marker
@@ -666,8 +668,8 @@ object MilvusBackfill {
 
           // Add extra columns for segment tracking
           val fullSchema = withExtras
-            .add("segment_id", org.apache.spark.sql.types.LongType, false)
-            .add("row_offset", org.apache.spark.sql.types.LongType, false)
+            .add(SegmentIdCol, org.apache.spark.sql.types.LongType, false)
+            .add(RowOffsetCol, org.apache.spark.sql.types.LongType, false)
 
           logger.info(
             s"Reading with schema: ${fullSchema.fieldNames.mkString(", ")}"
@@ -687,14 +689,13 @@ object MilvusBackfill {
             .load()
       }
 
-      // Validate that segment_id and row_offset are present
       if (
-        !df.columns.contains("segment_id") || !df.columns.contains("row_offset")
+        !df.columns.contains(SegmentIdCol) || !df.columns.contains(RowOffsetCol)
       ) {
         return Left(
           ConnectionError(
             message =
-              "Failed to read collection data with segment_id and row_offset. " +
+              s"Failed to read collection data with $SegmentIdCol and $RowOffsetCol. " +
                 "Ensure milvus.extra.columns is set correctly."
           )
         )
@@ -979,7 +980,7 @@ object MilvusBackfill {
         else Seq.empty
       val preparedDF = joinedDF
         .select(
-          (Seq("segment_id", "row_offset") ++ newFieldNames ++ Seq(
+          (Seq(SegmentIdCol, RowOffsetCol) ++ newFieldNames ++ Seq(
             MatchFlagCol
           ) ++ flagColNames).map(col): _*
         )

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -250,7 +250,7 @@ Override via `customOutputPath` if needed.
    in snapshot mode (FQCN avoids shortName collisions with other connectors).
 6. Validate PK type compatibility, then left-join on the PK.
 7. For each segment, repartition with a custom segment partitioner, sort by
-   `row_offset`, and write per-segment binlogs via `MilvusLoonWriter`.
+   `$row_offset`, and write per-segment binlogs via `MilvusLoonWriter`.
 8. Return a `BackfillResult` with manifest paths and per-segment stats.
 
 ## Testing helper

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -245,7 +245,7 @@ Override via `customOutputPath` if needed.
    Milvus client in client mode).
 4. Read the new-field parquet, configuring S3A credentials for the source
    bucket as needed.
-5. Read the original PK column + `segment_id` / `row_offset` via
+5. Read the original PK column + `$segment_id` / `$row_offset` via
    `spark.read.format("com.zilliz.spark.connector.sources.MilvusDataSource")`
    in snapshot mode (FQCN avoids shortName collisions with other connectors).
 6. Validate PK type compatibility, then left-join on the PK.

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -19,7 +19,7 @@ import com.zilliz.spark.connector.MilvusOption
 case class MilvusStorageV3InputPartition(
     manifestPath: String, // Path to manifest in S3/MinIO
     milvusSchemaBytes: Array[Byte], // Serialized protobuf
-    partitionName: String,
+    partitionName: String, // Snapshot reads store the partition ID string here.
     milvusOption: MilvusOption,
     topK: Option[Int] = None,
     queryVector: Option[Array[Float]] = None,

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -85,7 +85,7 @@ class MilvusLoonPartitionReader(
     .exists(_.equalsIgnoreCase("true"))
 
   private def debugRead(message: => String): Unit = {
-    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+    if (readDebugEnabled) logInfo(s"[MilvusReadDebug] $message")
   }
 
   // Native resource handles. Initialized to safe defaults so a partial-init

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -37,6 +37,35 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
+object MilvusLoonPartitionReader {
+  private[read] val SystemFieldAliases: Seq[(String, Long)] = Seq(
+    "RowID" -> 0L,
+    "row_id" -> 0L,
+    "rowid" -> 0L,
+    "Timestamp" -> 1L,
+    "timestamp" -> 1L
+  )
+
+  private[read] case class VectorSearchResult(
+      row: InternalRow,
+      distance: Double,
+      rowOffset: Long
+  )
+
+  private[read] def buildFieldNameToId(
+      milvusSchema: CollectionSchema
+  ): Map[String, Long] = {
+    val userFieldNames = milvusSchema.fields.map(_.name).toSet
+    val systemFields = SystemFieldAliases.filterNot { case (alias, _) =>
+      userFieldNames.contains(alias)
+    }.toMap
+    val userFields = milvusSchema.fields.map { field =>
+      field.name -> field.fieldID
+    }.toMap
+    systemFields ++ userFields
+  }
+}
+
 // for Milvus 2.6+ version data source and milvus lake data
 class MilvusLoonPartitionReader(
     schema: StructType,
@@ -61,18 +90,8 @@ class MilvusLoonPartitionReader(
 
   private val sourceSchema = schema
 
-  private val fieldNameToId: Map[String, Long] = {
-    val systemFields = Map(
-      "row_id" -> 0L,
-      "RowID" -> 0L,
-      "timestamp" -> 1L,
-      "Timestamp" -> 1L
-    )
-    val userFields = milvusSchema.fields.map { field =>
-      field.name -> field.fieldID
-    }.toMap
-    systemFields ++ userFields
-  }
+  private val fieldNameToId: Map[String, Long] =
+    MilvusLoonPartitionReader.buildFieldNameToId(milvusSchema)
 
   private val fieldNameToIdString: Map[String, String] =
     fieldNameToId.map { case (name, id) => name -> id.toString }
@@ -209,7 +228,9 @@ class MilvusLoonPartitionReader(
 
   // Vector search state
   private val vectorSearchEnabled = topK.isDefined && queryVector.isDefined
-  private var vectorSearchResults: Iterator[(InternalRow, Double)] = _
+  private var vectorSearchResults: Iterator[
+    MilvusLoonPartitionReader.VectorSearchResult
+  ] = _
   private var vectorSearchCompleted = false
 
   override def next(): Boolean = {
@@ -270,11 +291,10 @@ class MilvusLoonPartitionReader(
 
   override def get(): InternalRow = {
     if (vectorSearchEnabled) {
-      // Vector search mode: return row with distance appended
-      val (row, distance) = vectorSearchResults.next()
-      val rowSeq = row.toSeq(sourceSchema)
-      val resultRow = InternalRow.fromSeq(rowSeq :+ distance)
-      resultRow
+      val result = vectorSearchResults.next()
+      _lastReturnedRowOffset = result.rowOffset
+      val rowSeq = result.row.toSeq(sourceSchema)
+      InternalRow.fromSeq(rowSeq :+ result.distance)
     } else {
       // Normal mode
       if (_currentBatch == null) {
@@ -378,19 +398,27 @@ class MilvusLoonPartitionReader(
     // Use priority queue to maintain top-K
     // For L2: min-heap (smaller distance is better, so we keep max at top to evict)
     // For IP/COSINE: max-heap (larger score is better, so we keep min at top to evict)
-    val ordering: Ordering[(InternalRow, Double)] = metric match {
-      case "L2" =>
-        Ordering.by[(InternalRow, Double), Double](_._2) // Max-heap for L2
-      case "IP" | "COSINE" =>
-        Ordering
-          .by[(InternalRow, Double), Double](_._2)
-          .reverse // Min-heap for IP/COSINE
-      case _ => Ordering.by[(InternalRow, Double), Double](_._2)
-    }
+    val ordering: Ordering[MilvusLoonPartitionReader.VectorSearchResult] =
+      metric match {
+        case "L2" =>
+          Ordering.by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+            _.distance
+          )
+        case "IP" | "COSINE" =>
+          Ordering
+            .by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+              _.distance
+            )
+            .reverse
+        case _ =>
+          Ordering.by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+            _.distance
+          )
+      }
 
     val heap = scala.collection.mutable.PriorityQueue
-      .empty[(InternalRow, Double)](ordering)
-    var rowCount = 0
+      .empty[MilvusLoonPartitionReader.VectorSearchResult](ordering)
+    var rowCount = 0L
 
     // Helper function to process a batch
     def processBatch(batch: VectorSchemaRoot): Unit = {
@@ -423,24 +451,26 @@ class MilvusLoonPartitionReader(
           }
 
         if (vector != null) {
-          // Calculate distance
           val distance = calculateDistance(qv, vector, metric)
+          val result = MilvusLoonPartitionReader.VectorSearchResult(
+            row.copy(),
+            distance,
+            rowCount
+          )
 
-          // Maintain top-K heap
           if (heap.size < k) {
-            heap.enqueue((row.copy(), distance))
+            heap.enqueue(result)
           } else {
-            val (_, worstDist) = heap.head
+            val worst = heap.head
             val shouldReplace = metric match {
-              case "L2" => distance < worstDist // Smaller L2 distance is better
-              case "IP" | "COSINE" =>
-                distance > worstDist // Larger IP/COSINE is better
-              case _ => distance < worstDist
+              case "L2"            => distance < worst.distance
+              case "IP" | "COSINE" => distance > worst.distance
+              case _               => distance < worst.distance
             }
 
             if (shouldReplace) {
               heap.dequeue()
-              heap.enqueue((row.copy(), distance))
+              heap.enqueue(result)
             }
           }
         }
@@ -473,13 +503,20 @@ class MilvusLoonPartitionReader(
       s"Per-segment vector search completed: processed $rowCount rows, kept ${heap.size} top-K results"
     )
 
-    // Sort results and create iterator
+    val results = heap.dequeueAll
     val sortedResults = metric match {
       case "L2" =>
-        heap.dequeueAll.sortBy[(Double)](x => x._2) // Ascending for L2
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          result.distance
+        )
       case "IP" | "COSINE" =>
-        heap.dequeueAll.sortBy[(Double)](x => -x._2) // Descending for IP/COSINE
-      case _ => heap.dequeueAll.sortBy[(Double)](x => x._2)
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          -result.distance
+        )
+      case _ =>
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          result.distance
+        )
     }
 
     vectorSearchResults = sortedResults.iterator

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -73,6 +73,15 @@ class MilvusLoonPartitionReader(
     fieldNameToId.map { case (name, id) => name -> id.toString }
 
   private val columnNames = getColumnNames()
+  private val readDebugEnabled = milvusOption.options
+    .get(MilvusOption.ReaderDebug)
+    .exists(_.equalsIgnoreCase("true")) || optionsMap
+    .get(MilvusOption.ReaderDebug)
+    .exists(_.equalsIgnoreCase("true"))
+
+  private def debugRead(message: => String): Unit = {
+    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+  }
 
   // Native resource handles. Initialized to safe defaults so a partial-init
   // failure can roll back whatever was allocated so far via releaseAll().
@@ -106,6 +115,16 @@ class MilvusLoonPartitionReader(
 
     // Reader properties from MilvusOption.
     readerProperties = Properties.fromMilvusOption(milvusOption)
+    debugRead(
+      s"V3 reader opening manifestPath=$manifestPath " +
+        s"requestedReadVersion=$readVersion " +
+        s"requestedColumns=${columnNames.mkString(",")} " +
+        s"sourceSchema=${sourceSchema.fieldNames.mkString(",")} " +
+        s"fieldNameToId=${fieldNameToId.toSeq
+            .sortBy(_._2)
+            .map { case (n, id) => n + ":" + id }
+            .mkString(",")}"
+    )
 
     // Column groups from manifest (specific version if provided, latest otherwise).
     val manifestResult: LatestColumnGroupsResult = if (readVersion > 0) {
@@ -123,6 +142,11 @@ class MilvusLoonPartitionReader(
         readerProperties
       )
     }
+    debugRead(
+      s"V3 manifest resolved manifestPath=$manifestPath " +
+        s"actualReadVersion=${manifestResult.readVersion} " +
+        s"columnGroupsPtr=${manifestResult.columnGroupsPtr}"
+    )
     if (manifestResult.readVersion == 0) {
       throw new IllegalStateException(
         s"No manifest file found at path: $manifestPath. " +
@@ -311,8 +335,7 @@ class MilvusLoonPartitionReader(
   private def getColumnNames(): Array[String] = {
     // Convert column names to field IDs for manifest/reader matching
     // The manifest stores column groups with field IDs (e.g., "100", "101")
-    // Note: System fields (row_id, timestamp) are handled by MilvusPartitionReaderFactory
-    // and should NOT be requested from milvus-storage reader
+    // System fields are mapped to Milvus field IDs 0 and 1 and requested from storage.
     sourceSchema.fieldNames.flatMap { name =>
       fieldNameToId.get(name).map(_.toString)
     }

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -111,6 +111,10 @@ class MilvusLoonPartitionReader(
 
   private var _currentBatch: VectorSchemaRoot = null
   private var _currentRowIndex: Int = 0
+  private var _currentBatchStartRowOffset: Long = 0L
+  private var _lastReturnedRowOffset: Long = -1L
+
+  def lastReturnedRowOffset: Long = _lastReturnedRowOffset
 
   try {
     // Create Arrow schema from Milvus schema.
@@ -244,6 +248,7 @@ class MilvusLoonPartitionReader(
         } else {
           // Try to load next batch
           if (_currentBatch != null) {
+            _currentBatchStartRowOffset += _currentBatch.getRowCount
             _currentBatch.close()
             _currentBatch = null
           }
@@ -276,6 +281,7 @@ class MilvusLoonPartitionReader(
         throw new IllegalStateException("No batch loaded")
       }
 
+      _lastReturnedRowOffset = _currentBatchStartRowOffset + _currentRowIndex
       val row = ArrowConverter.arrowToInternalRow(
         _currentBatch,
         _currentRowIndex,

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -62,7 +62,12 @@ class MilvusLoonPartitionReader(
   private val sourceSchema = schema
 
   private val fieldNameToId: Map[String, Long] = {
-    val systemFields = Map("row_id" -> 0L, "timestamp" -> 1L)
+    val systemFields = Map(
+      "row_id" -> 0L,
+      "RowID" -> 0L,
+      "timestamp" -> 1L,
+      "Timestamp" -> 1L
+    )
     val userFields = milvusSchema.fields.map { field =>
       field.name -> field.fieldID
     }.toMap

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -66,15 +66,13 @@ class MilvusPackedV2PartitionReader(
     systemFields ++ userFields
   }
   private val fieldNameToId: Map[String, Long] =
-    fieldIdToName.map { case (id, name) => name -> id }
+    fieldIdToName.map { case (id, name) => name -> id } ++
+      Map("row_id" -> 0L, "timestamp" -> 1L)
 
-  // V3 readers pass a {sparkName -> fieldId-as-string} map to ArrowConverter
-  // because their on-disk parquet uses fieldId-as-string column names. V2
-  // packed parquet uses LOGICAL names (e.g. "ID"), so we must NOT remap —
-  // ArrowConverter calls `root.getVector(field.name)` directly when the
-  // mapping is empty, which is exactly what we need here. Remapping would
-  // make it look up a non-existent column and silently null every cell.
-  private val fieldNameToArrowColumn: Map[String, String] = Map.empty
+  private val fieldNameToArrowColumn: Map[String, String] = Map(
+    "row_id" -> "RowID",
+    "timestamp" -> "Timestamp"
+  )
 
   // Which column names to ask the packed reader for. Prefer explicit
   // projection from neededColumnFieldIds; fall back to sourceSchema's Spark
@@ -90,6 +88,13 @@ class MilvusPackedV2PartitionReader(
     val declared: Set[String] =
       columnGroups.flatMap(_.fieldIds.flatMap(fieldIdToName.get)).toSet
     explicitNames.filter(name => declared.contains(name)).toArray
+  }
+  private val readDebugEnabled = milvusOption.options
+    .get(MilvusOption.ReaderDebug)
+    .exists(_.equalsIgnoreCase("true"))
+
+  private def debugRead(message: => String): Unit = {
+    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
   }
 
   // Native resource handles. Initialized to safe defaults so a partial-init
@@ -138,6 +143,20 @@ class MilvusPackedV2PartitionReader(
       )
       cg.fileRowCounts.toArray
     }.toArray
+    debugRead(
+      s"V2 reader opening neededColumns=${neededColumns.mkString(",")} " +
+        s"sourceSchema=${sourceSchema.fieldNames.mkString(",")} " +
+        s"columnGroups=${columnGroups.size}"
+    )
+    columnGroups.zipWithIndex.foreach { case (cg, idx) =>
+      debugRead(
+        s"V2 reader columnGroup[$idx] slotFieldId=${cg.slotFieldId} " +
+          s"fieldIds=${cg.fieldIds.mkString(",")} " +
+          s"columns=${cols(idx).mkString(",")} " +
+          s"files=${files(idx).mkString(",")} " +
+          s"rowCounts=${rowCounts(idx).mkString(",")}"
+      )
+    }
     columnGroupsPtr =
       MilvusStorageColumnGroups.createFromGroups(cols, files, rowCounts)
 

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -24,6 +24,39 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
+object MilvusPackedV2PartitionReader {
+  private[read] case class FieldMappings(
+      fieldIdToName: Map[Long, String],
+      fieldNameToId: Map[String, Long],
+      fieldNameToArrowColumn: Map[String, String]
+  )
+
+  private[read] def buildFieldMappings(
+      milvusSchema: CollectionSchema
+  ): FieldMappings = {
+    val systemFields = Map(0L -> "RowID", 1L -> "Timestamp")
+    val userFields = milvusSchema.fields.map(f => f.fieldID -> f.name).toMap
+    val fieldIdToName = systemFields ++ userFields
+    val userFieldNames = milvusSchema.fields.map(_.name).toSet
+    val lowercaseSystemAliases = Seq(
+      "row_id" -> (0L, "RowID"),
+      "timestamp" -> (1L, "Timestamp")
+    ).filterNot { case (alias, _) => userFieldNames.contains(alias) }
+
+    FieldMappings(
+      fieldIdToName,
+      fieldIdToName.map { case (id, name) => name -> id } ++
+        lowercaseSystemAliases.map { case (alias, (id, _)) =>
+          alias -> id
+        }.toMap,
+      Map("RowID" -> "RowID", "Timestamp" -> "Timestamp") ++
+        lowercaseSystemAliases.map { case (alias, (_, column)) =>
+          alias -> column
+        }.toMap
+    )
+  }
+}
+
 /** Spark partition reader for milvus-segment-info `storage_version = 2`
   * (StorageV2, non-manifest packed parquet) segments.
   *
@@ -54,27 +87,11 @@ class MilvusPackedV2PartitionReader(
   private val allocator = ArrowUtils.getAllocator
   private val sourceSchema = schema
 
-  // Field ID -> logical column name. StorageV2 packed-parquet files written
-  // by milvus segcore use the field's logical name in the parquet schema
-  // (with PARQUET:field_id metadata for cross-reference). The packed reader
-  // matches columns by name, so we must pass logical names — NOT
-  // field-id-as-string like the V3 reader does.
-  private val fieldIdToName: Map[Long, String] = {
-    val systemFields = Map(0L -> "RowID", 1L -> "Timestamp")
-    val userFields =
-      milvusSchema.fields.map(f => f.fieldID -> f.name).toMap
-    systemFields ++ userFields
-  }
-  private val fieldNameToId: Map[String, Long] =
-    fieldIdToName.map { case (id, name) => name -> id } ++
-      Map("row_id" -> 0L, "timestamp" -> 1L)
-
-  private val fieldNameToArrowColumn: Map[String, String] = Map(
-    "row_id" -> "RowID",
-    "RowID" -> "RowID",
-    "timestamp" -> "Timestamp",
-    "Timestamp" -> "Timestamp"
-  )
+  private val fieldMappings =
+    MilvusPackedV2PartitionReader.buildFieldMappings(milvusSchema)
+  private val fieldIdToName = fieldMappings.fieldIdToName
+  private val fieldNameToId = fieldMappings.fieldNameToId
+  private val fieldNameToArrowColumn = fieldMappings.fieldNameToArrowColumn
 
   // Which column names to ask the packed reader for. Prefer explicit
   // projection from neededColumnFieldIds; fall back to sourceSchema's Spark

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -96,7 +96,7 @@ class MilvusPackedV2PartitionReader(
     .exists(_.equalsIgnoreCase("true"))
 
   private def debugRead(message: => String): Unit = {
-    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+    if (readDebugEnabled) logInfo(s"[MilvusReadDebug] $message")
   }
 
   // Native resource handles. Initialized to safe defaults so a partial-init

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -71,7 +71,9 @@ class MilvusPackedV2PartitionReader(
 
   private val fieldNameToArrowColumn: Map[String, String] = Map(
     "row_id" -> "RowID",
-    "timestamp" -> "Timestamp"
+    "RowID" -> "RowID",
+    "timestamp" -> "Timestamp",
+    "Timestamp" -> "Timestamp"
   )
 
   // Which column names to ask the packed reader for. Prefer explicit

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -55,6 +55,50 @@ object MilvusPackedV2PartitionReader {
         }.toMap
     )
   }
+
+  private[read] def resolveNeededColumns(
+      sourceSchema: StructType,
+      columnGroups: Seq[V2ColumnGroup],
+      fieldMappings: FieldMappings,
+      neededColumnFieldIds: Seq[Long]
+  ): Array[String] = {
+    val declared: Set[String] = columnGroups
+      .flatMap(_.fieldIds.flatMap(fieldMappings.fieldIdToName.get))
+      .toSet
+    val requestedNames: Seq[String] =
+      if (neededColumnFieldIds.nonEmpty) {
+        val missingIds = neededColumnFieldIds.filterNot(
+          fieldMappings.fieldIdToName.contains
+        )
+        if (missingIds.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"Packed V2 requested unknown field IDs: ${missingIds.distinct.mkString(",")}" +
+              s"; schema field IDs=${fieldMappings.fieldIdToName.keys.toSeq.sorted.mkString(",")}"
+          )
+        }
+        neededColumnFieldIds.flatMap(fieldMappings.fieldIdToName.get)
+      } else {
+        val missingNames = sourceSchema.fieldNames.filterNot(
+          fieldMappings.fieldNameToId.contains
+        )
+        if (missingNames.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"Packed V2 requested unknown columns: ${missingNames.distinct.mkString(",")}" +
+              s"; schema columns=${fieldMappings.fieldNameToId.keys.toSeq.sorted.mkString(",")}"
+          )
+        }
+        sourceSchema.fieldNames.toSeq
+      }
+    val missingColumns = requestedNames.filterNot(declared.contains).distinct
+    if (missingColumns.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"Packed V2 column groups do not contain requested columns: ${missingColumns
+            .mkString(",")}" +
+          s"; declared columns=${declared.toSeq.sorted.mkString(",")}"
+      )
+    }
+    requestedNames.toArray
+  }
 }
 
 /** Spark partition reader for milvus-segment-info `storage_version = 2`
@@ -89,25 +133,19 @@ class MilvusPackedV2PartitionReader(
 
   private val fieldMappings =
     MilvusPackedV2PartitionReader.buildFieldMappings(milvusSchema)
-  private val fieldIdToName = fieldMappings.fieldIdToName
-  private val fieldNameToId = fieldMappings.fieldNameToId
   private val fieldNameToArrowColumn = fieldMappings.fieldNameToArrowColumn
 
   // Which column names to ask the packed reader for. Prefer explicit
   // projection from neededColumnFieldIds; fall back to sourceSchema's Spark
   // field names. In both cases we coerce to logical names that the parquet
   // actually carries.
-  private val neededColumns: Array[String] = {
-    val explicitNames: Seq[String] =
-      if (neededColumnFieldIds.nonEmpty)
-        neededColumnFieldIds.flatMap(fid => fieldIdToName.get(fid))
-      else sourceSchema.fieldNames.toSeq.filter(fieldNameToId.contains)
-    // Drop names that aren't declared by any of the v2 column groups —
-    // `loon_reader_new` would reject unknown columns.
-    val declared: Set[String] =
-      columnGroups.flatMap(_.fieldIds.flatMap(fieldIdToName.get)).toSet
-    explicitNames.filter(name => declared.contains(name)).toArray
-  }
+  private val neededColumns: Array[String] =
+    MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups,
+      fieldMappings,
+      neededColumnFieldIds
+    )
   private val readDebugEnabled = milvusOption.options
     .get(MilvusOption.ReaderDebug)
     .exists(_.equalsIgnoreCase("true"))
@@ -151,7 +189,7 @@ class MilvusPackedV2PartitionReader(
     // from the AVRO's AvroBinlog.entries_num — required because the packed
     // reader rejects negative end indices.
     val cols = columnGroups.map { cg =>
-      cg.fieldIds.flatMap(fieldIdToName.get).toArray
+      cg.fieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
     }.toArray
     val files = columnGroups.map(_.filePaths.toArray).toArray
     val rowCounts = columnGroups.map { cg =>

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -31,6 +31,14 @@ object MilvusPackedV2PartitionReader {
       fieldNameToArrowColumn: Map[String, String]
   )
 
+  private[read] val SystemFieldAliases: Seq[(String, (Long, String))] = Seq(
+    "RowID" -> (0L, "RowID"),
+    "row_id" -> (0L, "RowID"),
+    "rowid" -> (0L, "RowID"),
+    "Timestamp" -> (1L, "Timestamp"),
+    "timestamp" -> (1L, "Timestamp")
+  )
+
   private[read] def buildFieldMappings(
       milvusSchema: CollectionSchema
   ): FieldMappings = {
@@ -38,21 +46,22 @@ object MilvusPackedV2PartitionReader {
     val userFields = milvusSchema.fields.map(f => f.fieldID -> f.name).toMap
     val fieldIdToName = systemFields ++ userFields
     val userFieldNames = milvusSchema.fields.map(_.name).toSet
-    val lowercaseSystemAliases = Seq(
-      "row_id" -> (0L, "RowID"),
-      "timestamp" -> (1L, "Timestamp")
-    ).filterNot { case (alias, _) => userFieldNames.contains(alias) }
+    val systemAliases = SystemFieldAliases.filterNot { case (alias, _) =>
+      userFieldNames.contains(alias)
+    }
+    val userFieldNameToId =
+      milvusSchema.fields.map(f => f.name -> f.fieldID).toMap
+    val systemFieldNameToId = systemAliases.map { case (alias, (id, _)) =>
+      alias -> id
+    }.toMap
+    val systemFieldNameToArrowColumn = systemAliases.map {
+      case (alias, (_, column)) => alias -> column
+    }.toMap
 
     FieldMappings(
       fieldIdToName,
-      fieldIdToName.map { case (id, name) => name -> id } ++
-        lowercaseSystemAliases.map { case (alias, (id, _)) =>
-          alias -> id
-        }.toMap,
-      Map("RowID" -> "RowID", "Timestamp" -> "Timestamp") ++
-        lowercaseSystemAliases.map { case (alias, (_, column)) =>
-          alias -> column
-        }.toMap
+      systemFieldNameToId ++ userFieldNameToId,
+      systemFieldNameToArrowColumn
     )
   }
 
@@ -62,10 +71,8 @@ object MilvusPackedV2PartitionReader {
       fieldMappings: FieldMappings,
       neededColumnFieldIds: Seq[Long]
   ): Array[String] = {
-    val declared: Set[String] = columnGroups
-      .flatMap(_.fieldIds.flatMap(fieldMappings.fieldIdToName.get))
-      .toSet
-    val requestedNames: Seq[String] =
+    val declaredFieldIds = columnGroups.flatMap(_.fieldIds).toSet
+    val requestedFieldIds: Seq[Long] =
       if (neededColumnFieldIds.nonEmpty) {
         val missingIds = neededColumnFieldIds.filterNot(
           fieldMappings.fieldIdToName.contains
@@ -76,7 +83,7 @@ object MilvusPackedV2PartitionReader {
               s"; schema field IDs=${fieldMappings.fieldIdToName.keys.toSeq.sorted.mkString(",")}"
           )
         }
-        neededColumnFieldIds.flatMap(fieldMappings.fieldIdToName.get)
+        neededColumnFieldIds
       } else {
         val missingNames = sourceSchema.fieldNames.filterNot(
           fieldMappings.fieldNameToId.contains
@@ -87,17 +94,24 @@ object MilvusPackedV2PartitionReader {
               s"; schema columns=${fieldMappings.fieldNameToId.keys.toSeq.sorted.mkString(",")}"
           )
         }
-        sourceSchema.fieldNames.toSeq
+        sourceSchema.fieldNames.toSeq.map(fieldMappings.fieldNameToId)
       }
-    val missingColumns = requestedNames.filterNot(declared.contains).distinct
-    if (missingColumns.nonEmpty) {
+    val missingFieldIds = requestedFieldIds.filterNot(declaredFieldIds.contains)
+    if (missingFieldIds.nonEmpty) {
+      val missingColumns = missingFieldIds
+        .flatMap(fieldMappings.fieldIdToName.get)
+        .distinct
+      val declaredColumns = declaredFieldIds
+        .flatMap(fieldMappings.fieldIdToName.get)
+        .toSeq
+        .sorted
       throw new IllegalArgumentException(
         s"Packed V2 column groups do not contain requested columns: ${missingColumns
             .mkString(",")}" +
-          s"; declared columns=${declared.toSeq.sorted.mkString(",")}"
+          s"; declared columns=${declaredColumns.mkString(",")}"
       )
     }
-    requestedNames.toArray
+    requestedFieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
   }
 }
 

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -39,6 +39,7 @@ class MilvusPartitionReaderFactory(
         )
 
         val v2Schema = StructType(schema.fields.filter { field =>
+          field.name != MilvusOption.MilvusExtraColumnPartition &&
           field.name != MilvusOption.MilvusExtraColumnSegmentID &&
           field.name != MilvusOption.MilvusExtraColumnRowOffset
         })
@@ -68,6 +69,9 @@ class MilvusPartitionReaderFactory(
           p.readVersion
         )
 
+        val hasPartition = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnPartition
+        )
         val hasSegmentId = schema.fieldNames.contains(
           MilvusOption.MilvusExtraColumnSegmentID
         )
@@ -75,7 +79,7 @@ class MilvusPartitionReaderFactory(
           MilvusOption.MilvusExtraColumnRowOffset
         )
 
-        if (hasSegmentId || hasRowOffset) {
+        if (hasPartition || hasSegmentId || hasRowOffset) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -88,6 +92,8 @@ class MilvusPartitionReaderFactory(
 
               schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
                 field.name match {
+                  case MilvusOption.MilvusExtraColumnPartition =>
+                    resultValues(writeIdx) = p.partitionName
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     resultValues(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>
@@ -115,6 +121,7 @@ class MilvusPartitionReaderFactory(
         )
 
         val innerSchema = StructType(schema.fields.filter { f =>
+          f.name != MilvusOption.MilvusExtraColumnPartition &&
           f.name != MilvusOption.MilvusExtraColumnSegmentID &&
           f.name != MilvusOption.MilvusExtraColumnRowOffset
         })
@@ -136,6 +143,9 @@ class MilvusPartitionReaderFactory(
           p.neededColumnFieldIds
         )
 
+        val hasPartition = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnPartition
+        )
         val hasSegmentId = schema.fieldNames.contains(
           MilvusOption.MilvusExtraColumnSegmentID
         )
@@ -143,7 +153,7 @@ class MilvusPartitionReaderFactory(
           MilvusOption.MilvusExtraColumnRowOffset
         )
 
-        if (hasSegmentId || hasRowOffset) {
+        if (hasPartition || hasSegmentId || hasRowOffset) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -156,6 +166,8 @@ class MilvusPartitionReaderFactory(
 
               schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
                 field.name match {
+                  case MilvusOption.MilvusExtraColumnPartition =>
+                    out(writeIdx) = p.partitionID.toString
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     out(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -26,7 +26,7 @@ class MilvusPartitionReaderFactory(
     .exists(_.equalsIgnoreCase("true"))
 
   private def debugRead(message: => String): Unit = {
-    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+    if (readDebugEnabled) logInfo(s"[MilvusReadDebug] $message")
   }
 
   override def createReader(

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -81,8 +81,6 @@ class MilvusPartitionReaderFactory(
 
         if (hasPartition || hasSegmentId || hasRowOffset) {
           new PartitionReader[InternalRow] {
-            private var rowOffset: Long = 0L
-
             override def next(): Boolean = underlyingReader.next()
 
             override def get(): InternalRow = {
@@ -97,13 +95,13 @@ class MilvusPartitionReaderFactory(
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     resultValues(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>
-                    resultValues(writeIdx) = rowOffset
+                    resultValues(writeIdx) =
+                      underlyingReader.lastReturnedRowOffset
                   case _ =>
                     resultValues(writeIdx) = row.get(readIdx, field.dataType)
                     readIdx += 1
                 }
               }
-              rowOffset += 1
 
               InternalRow.fromSeq(resultValues.toSeq)
             }

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.connector.read.{
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
+import com.zilliz.spark.connector.MilvusOption
 import io.milvus.grpc.schema.CollectionSchema
 
 // PartitionReaderFactory for Storage V2 (Milvus 2.6+)
@@ -20,6 +21,14 @@ class MilvusPartitionReaderFactory(
 ) extends PartitionReaderFactory
     with Logging {
 
+  private val readDebugEnabled = optionsMap
+    .get(MilvusOption.ReaderDebug)
+    .exists(_.equalsIgnoreCase("true"))
+
+  private def debugRead(message: => String): Unit = {
+    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+  }
+
   override def createReader(
       partition: InputPartition
   ): PartitionReader[InternalRow] = {
@@ -29,17 +38,20 @@ class MilvusPartitionReaderFactory(
           s"Creating V3 reader for partition with segmentID=${p.segmentID}"
         )
 
-        // Storage V3 doesn't support system fields (row_id, timestamp) and extra metadata columns (segment_id, row_offset)
-        // Filter them out from the schema for the underlying reader
         val v2Schema = StructType(schema.fields.filter { field =>
-          field.name != "row_id" &&
-          field.name != "timestamp" &&
-          field.name != "segment_id" &&
-          field.name != "row_offset"
+          field.name != MilvusOption.MilvusExtraColumnSegmentID &&
+          field.name != MilvusOption.MilvusExtraColumnRowOffset
         })
 
         // Deserialize the protobuf schema
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
+        debugRead(
+          s"factory creating readerType=V3 segmentID=${p.segmentID} " +
+            s"partition=${p.partitionName} manifestPath=${p.manifestPath} " +
+            s"readVersion=${p.readVersion} " +
+            s"requestedSchema=${schema.fieldNames.mkString(",")} " +
+            s"innerSchema=${v2Schema.fieldNames.mkString(",")}"
+        )
 
         // Create MilvusLoonPartitionReader directly
         val underlyingReader = new MilvusLoonPartitionReader(
@@ -56,13 +68,14 @@ class MilvusPartitionReaderFactory(
           p.readVersion
         )
 
-        // If the expected schema includes system/metadata fields, wrap the reader to add them
-        val hasRowId = schema.fieldNames.contains("row_id")
-        val hasTimestamp = schema.fieldNames.contains("timestamp")
-        val hasSegmentId = schema.fieldNames.contains("segment_id")
-        val hasRowOffset = schema.fieldNames.contains("row_offset")
+        val hasSegmentId = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnSegmentID
+        )
+        val hasRowOffset = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnRowOffset
+        )
 
-        if (hasRowId || hasTimestamp || hasSegmentId || hasRowOffset) {
+        if (hasSegmentId || hasRowOffset) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -70,42 +83,21 @@ class MilvusPartitionReaderFactory(
 
             override def get(): InternalRow = {
               val row = underlyingReader.get()
-
-              // Build result row with system/metadata fields
-              val numFields = schema.fields.length
-              val resultValues = new Array[Any](numFields)
-
-              var writeIdx = 0
+              val resultValues = new Array[Any](schema.fields.length)
               var readIdx = 0
 
-              // Add system fields with null values
-              if (hasRowId) {
-                resultValues(writeIdx) = null
-                writeIdx += 1
+              schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
+                field.name match {
+                  case MilvusOption.MilvusExtraColumnSegmentID =>
+                    resultValues(writeIdx) = p.segmentID
+                  case MilvusOption.MilvusExtraColumnRowOffset =>
+                    resultValues(writeIdx) = rowOffset
+                  case _ =>
+                    resultValues(writeIdx) = row.get(readIdx, field.dataType)
+                    readIdx += 1
+                }
               }
-              if (hasTimestamp) {
-                resultValues(writeIdx) = null
-                writeIdx += 1
-              }
-
-              // Copy actual data from underlying reader
-              while (readIdx < v2Schema.fields.length) {
-                val value = row.get(readIdx, v2Schema.fields(readIdx).dataType)
-                resultValues(writeIdx) = value
-                readIdx += 1
-                writeIdx += 1
-              }
-
-              // Add metadata fields (segment_id and row_offset)
-              if (hasSegmentId) {
-                resultValues(writeIdx) = p.segmentID
-                writeIdx += 1
-              }
-              if (hasRowOffset) {
-                resultValues(writeIdx) = rowOffset
-                rowOffset += 1
-                writeIdx += 1
-              }
+              rowOffset += 1
 
               InternalRow.fromSeq(resultValues.toSeq)
             }
@@ -122,14 +114,19 @@ class MilvusPartitionReaderFactory(
             s"with ${p.columnGroups.size} column group(s)"
         )
 
-        // V2 reader does not emit system/metadata columns itself; same
-        // masking rule as V3.
         val innerSchema = StructType(schema.fields.filter { f =>
-          f.name != "row_id" && f.name != "timestamp" &&
-          f.name != "segment_id" && f.name != "row_offset"
+          f.name != MilvusOption.MilvusExtraColumnSegmentID &&
+          f.name != MilvusOption.MilvusExtraColumnRowOffset
         })
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
+        debugRead(
+          s"factory creating readerType=V2 segmentID=${p.segmentID} " +
+            s"partitionID=${p.partitionID} columnGroups=${p.columnGroups.size} " +
+            s"neededColumnFieldIds=${p.neededColumnFieldIds.mkString(",")} " +
+            s"requestedSchema=${schema.fieldNames.mkString(",")} " +
+            s"innerSchema=${innerSchema.fieldNames.mkString(",")}"
+        )
 
         val underlying = new MilvusPackedV2PartitionReader(
           innerSchema,
@@ -139,12 +136,14 @@ class MilvusPartitionReaderFactory(
           p.neededColumnFieldIds
         )
 
-        val hasSegmentId = schema.fieldNames.contains("segment_id")
-        val hasRowOffset = schema.fieldNames.contains("row_offset")
-        val hasRowId = schema.fieldNames.contains("row_id")
-        val hasTimestamp = schema.fieldNames.contains("timestamp")
+        val hasSegmentId = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnSegmentID
+        )
+        val hasRowOffset = schema.fieldNames.contains(
+          MilvusOption.MilvusExtraColumnRowOffset
+        )
 
-        if (hasRowId || hasTimestamp || hasSegmentId || hasRowOffset) {
+        if (hasSegmentId || hasRowOffset) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -152,27 +151,21 @@ class MilvusPartitionReaderFactory(
 
             override def get(): InternalRow = {
               val row = underlying.get()
-              val numFields = schema.fields.length
-              val out = new Array[Any](numFields)
-              var writeIdx = 0
+              val out = new Array[Any](schema.fields.length)
               var readIdx = 0
 
-              if (hasRowId) { out(writeIdx) = null; writeIdx += 1 }
-              if (hasTimestamp) { out(writeIdx) = null; writeIdx += 1 }
-
-              while (readIdx < innerSchema.fields.length) {
-                out(writeIdx) =
-                  row.get(readIdx, innerSchema.fields(readIdx).dataType)
-                readIdx += 1
-                writeIdx += 1
+              schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
+                field.name match {
+                  case MilvusOption.MilvusExtraColumnSegmentID =>
+                    out(writeIdx) = p.segmentID
+                  case MilvusOption.MilvusExtraColumnRowOffset =>
+                    out(writeIdx) = rowOffset
+                  case _ =>
+                    out(writeIdx) = row.get(readIdx, field.dataType)
+                    readIdx += 1
+                }
               }
-
-              if (hasSegmentId) { out(writeIdx) = p.segmentID; writeIdx += 1 }
-              if (hasRowOffset) {
-                out(writeIdx) = rowOffset
-                rowOffset += 1
-                writeIdx += 1
-              }
+              rowOffset += 1
 
               InternalRow.fromSeq(out.toSeq)
             }

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -569,13 +569,8 @@ object MilvusSnapshotReader {
         !includeSystemFields && (f.name == "RowID" || f.name == "Timestamp")
       )
       .map { field =>
-        val sparkFieldName = field.name match {
-          case "RowID"     => "row_id"
-          case "Timestamp" => "timestamp"
-          case other       => other
-        }
         StructField(
-          sparkFieldName,
+          field.name,
           dataTypeToSparkType(field.dataType, field.typeParams),
           nullable = true
         )

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -622,7 +622,7 @@ object MilvusSnapshotReader {
       case 28  => ArrayType(FloatType) // Array[Float]
       case 29  => ArrayType(DoubleType) // Array[Double]
       case 30  => ArrayType(StringType) // Array[VarChar]
-      case 100 => ArrayType(ByteType) // BinaryVector
+      case 100 => BinaryType // BinaryVector
       case 101 => ArrayType(FloatType) // FloatVector
       case 102 => ArrayType(FloatType) // Float16Vector
       case 103 => ArrayType(FloatType) // BFloat16Vector

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -1,5 +1,8 @@
 package com.zilliz.spark.connector.read
 
+import java.io.{ByteArrayOutputStream, FileInputStream, InputStream}
+import java.nio.charset.StandardCharsets
+
 import com.fasterxml.jackson.annotation.{JsonAlias, JsonProperty}
 import com.fasterxml.jackson.databind.{
   DeserializationFeature,
@@ -383,6 +386,30 @@ case class SnapshotMetadata(
   */
 object MilvusSnapshotReader {
 
+  val MaxSnapshotJsonBytes: Long = 64L * 1024L * 1024L
+
+  def readUtf8WithLimit(
+      in: InputStream,
+      path: String,
+      maxBytes: Long = MaxSnapshotJsonBytes
+  ): String = {
+    val out = new ByteArrayOutputStream()
+    val buf = new Array[Byte](8192)
+    var total = 0L
+    var n = in.read(buf)
+    while (n >= 0) {
+      total += n
+      if (total > maxBytes) {
+        throw new IllegalArgumentException(
+          s"Snapshot metadata file exceeds maximum supported size of $maxBytes bytes: $path"
+        )
+      }
+      out.write(buf, 0, n)
+      n = in.read(buf)
+    }
+    new String(out.toByteArray, StandardCharsets.UTF_8)
+  }
+
   private val mapper: ObjectMapper with ScalaObjectMapper = {
     val m = new ObjectMapper() with ScalaObjectMapper
     m.registerModule(DefaultScalaModule)
@@ -428,12 +455,11 @@ object MilvusSnapshotReader {
       path: String
   ): Either[Throwable, SnapshotMetadata] = {
     try {
-      val source = scala.io.Source.fromFile(path)
+      val in = new FileInputStream(path)
       try {
-        val json = source.mkString
-        parseSnapshotMetadata(json)
+        parseSnapshotMetadata(readUtf8WithLimit(in, path))
       } finally {
-        source.close()
+        in.close()
       }
     } catch {
       case e: Exception => Left(e)
@@ -543,8 +569,13 @@ object MilvusSnapshotReader {
         !includeSystemFields && (f.name == "RowID" || f.name == "Timestamp")
       )
       .map { field =>
+        val sparkFieldName = field.name match {
+          case "RowID"     => "row_id"
+          case "Timestamp" => "timestamp"
+          case other       => other
+        }
         StructField(
-          field.name,
+          sparkFieldName,
           dataTypeToSparkType(field.dataType, field.typeParams),
           nullable = true
         )

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -622,7 +622,7 @@ object MilvusSnapshotReader {
       case 28  => ArrayType(FloatType) // Array[Float]
       case 29  => ArrayType(DoubleType) // Array[Double]
       case 30  => ArrayType(StringType) // Array[VarChar]
-      case 100 => ArrayType(BinaryType) // BinaryVector
+      case 100 => ArrayType(ByteType) // BinaryVector
       case 101 => ArrayType(FloatType) // FloatVector
       case 102 => ArrayType(FloatType) // Float16Vector
       case 103 => ArrayType(FloatType) // BFloat16Vector

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -158,7 +158,8 @@ object Field {
     "FloatVector" -> 101,
     "Float16Vector" -> 102,
     "BFloat16Vector" -> 103,
-    "SparseFloatVector" -> 104
+    "SparseFloatVector" -> 104,
+    "Int8Vector" -> 105
   )
 
   def dataTypeNameToCode(name: String): Int = {
@@ -621,11 +622,12 @@ object MilvusSnapshotReader {
       case 28  => ArrayType(FloatType) // Array[Float]
       case 29  => ArrayType(DoubleType) // Array[Double]
       case 30  => ArrayType(StringType) // Array[VarChar]
+      case 100 => ArrayType(BinaryType) // BinaryVector
       case 101 => ArrayType(FloatType) // FloatVector
-      case 102 => ArrayType(ByteType) // BinaryVector
-      case 103 => ArrayType(ShortType) // Float16Vector
-      case 104 => ArrayType(ShortType) // BFloat16Vector
-      case 105 => MapType(LongType, FloatType) // SparseFloatVector
+      case 102 => ArrayType(FloatType) // Float16Vector
+      case 103 => ArrayType(FloatType) // BFloat16Vector
+      case 104 => MapType(LongType, FloatType) // SparseFloatVector
+      case 105 => ArrayType(ShortType) // Int8Vector
       case _   => BinaryType // Unknown types as binary
     }
   }

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -233,13 +233,6 @@ object ArrowConverter extends Logging {
           case _ => arrayFromListVector(vector, rowIndex, FloatType)
         }
 
-      case ArrayType(BinaryType, _) =>
-        vector match {
-          case v: FixedSizeBinaryVector =>
-            ArrayData.toArrayData(Array(v.get(rowIndex)))
-          case _ => arrayFromListVector(vector, rowIndex, BinaryType)
-        }
-
       case ArrayType(ByteType, _) =>
         vector match {
           case v: FixedSizeBinaryVector =>

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -15,6 +15,20 @@ import org.apache.spark.unsafe.types.UTF8String
   */
 object ArrowConverter extends Logging {
 
+  private def variableWidthBytes(
+      vector: FieldVector,
+      rowIndex: Int
+  ): Array[Byte] = {
+    vector match {
+      case v: VarCharVector   => v.get(rowIndex)
+      case v: VarBinaryVector => v.get(rowIndex)
+      case other =>
+        throw new IllegalArgumentException(
+          s"Expected variable-width Arrow vector, got ${other.getClass.getName}"
+        )
+    }
+  }
+
   /** Convert an Arrow VectorSchemaRoot row to Spark InternalRow
     *
     * @param root
@@ -90,8 +104,7 @@ object ArrowConverter extends Logging {
         vector.asInstanceOf[BitVector].get(rowIndex) != 0
 
       case StringType =>
-        val bytes = vector.asInstanceOf[VarCharVector].get(rowIndex)
-        UTF8String.fromBytes(bytes)
+        UTF8String.fromBytes(variableWidthBytes(vector, rowIndex))
 
       case ArrayType(FloatType, _) =>
         // FloatVector stored as FixedSizeBinaryVector
@@ -121,8 +134,7 @@ object ArrowConverter extends Logging {
         ArrayData.toArrayData(arrayElements)
 
       case BinaryType =>
-        val bytes = vector.asInstanceOf[VarBinaryVector].get(rowIndex)
-        bytes
+        variableWidthBytes(vector, rowIndex)
 
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -7,6 +7,7 @@ import java.nio.charset.{
   StandardCharsets
 }
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
@@ -16,9 +17,16 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
+import com.zilliz.spark.connector.FloatConverter
+
 /** Utilities for converting between Spark InternalRow and Arrow vectors
   */
 object ArrowConverter extends Logging {
+
+  private val MilvusDataTypeMetadataKeys = Seq(
+    "milvus_data_type",
+    "milvus.data_type"
+  )
 
   private def variableWidthBytes(
       vector: FieldVector,
@@ -30,6 +38,20 @@ object ArrowConverter extends Logging {
       case other =>
         throw new IllegalArgumentException(
           s"Expected variable-width Arrow vector, got ${other.getClass.getName}"
+        )
+    }
+  }
+
+  private def binaryBytes(
+      vector: FieldVector,
+      rowIndex: Int
+  ): Array[Byte] = {
+    vector match {
+      case v: VarBinaryVector       => v.get(rowIndex)
+      case v: FixedSizeBinaryVector => v.get(rowIndex)
+      case other =>
+        throw new IllegalArgumentException(
+          s"Expected binary Arrow vector, got ${other.getClass.getName}"
         )
     }
   }
@@ -57,6 +79,71 @@ object ArrowConverter extends Logging {
       case _ =>
     }
     UTF8String.fromBytes(bytes)
+  }
+
+  private def milvusDataTypeCode(vector: FieldVector): Option[Int] = {
+    Option(vector.getField)
+      .flatMap(field => Option(field.getMetadata))
+      .flatMap { metadata =>
+        MilvusDataTypeMetadataKeys.iterator
+          .flatMap(key => Option(metadata.get(key)))
+          .find(_.trim.nonEmpty)
+      }
+      .flatMap(value => Try(value.trim.toInt).toOption)
+  }
+
+  private def floatArrayFromFixedSizeBinary(
+      vector: FixedSizeBinaryVector,
+      rowIndex: Int
+  ): Array[Float] = {
+    val bytes = vector.get(rowIndex)
+    milvusDataTypeCode(vector) match {
+      case Some(102) =>
+        if (bytes.length % 2 != 0) {
+          throw new IllegalArgumentException(
+            s"Float16Vector column ${vector.getName} has odd byte length ${bytes.length}"
+          )
+        }
+        bytes.grouped(2).map(b => FloatConverter.fromFloat16Bytes(b)).toArray
+      case Some(103) =>
+        if (bytes.length % 2 != 0) {
+          throw new IllegalArgumentException(
+            s"BFloat16Vector column ${vector.getName} has odd byte length ${bytes.length}"
+          )
+        }
+        bytes.grouped(2).map(b => FloatConverter.fromBFloat16Bytes(b)).toArray
+      case _ =>
+        if (bytes.length % 4 != 0) {
+          throw new IllegalArgumentException(
+            s"FloatVector column ${vector.getName} byte length ${bytes.length} is not divisible by 4"
+          )
+        }
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+    }
+  }
+
+  private def arrayFromListVector(
+      vector: FieldVector,
+      rowIndex: Int,
+      elementType: DataType
+  ): ArrayData = {
+    val listVector = vector.asInstanceOf[ListVector]
+    val dataVector = listVector.getDataVector
+    val startIndex = listVector.getElementStartIndex(rowIndex)
+    val endIndex = listVector.getElementEndIndex(rowIndex)
+    val length = endIndex - startIndex
+
+    val arrayElements = (0 until length).map { i =>
+      val elemIndex = startIndex + i
+      if (dataVector.isNull(elemIndex)) {
+        null
+      } else {
+        arrowValueToSparkValue(dataVector, elemIndex, elementType)
+      }
+    }.toArray
+
+    ArrayData.toArrayData(arrayElements)
   }
 
   /** Convert an Arrow VectorSchemaRoot row to Spark InternalRow
@@ -121,6 +208,9 @@ object ArrowConverter extends Logging {
       case IntegerType =>
         vector.asInstanceOf[IntVector].get(rowIndex)
 
+      case ByteType =>
+        vector.asInstanceOf[TinyIntVector].get(rowIndex)
+
       case ShortType =>
         vector.asInstanceOf[SmallIntVector].get(rowIndex)
 
@@ -137,34 +227,38 @@ object ArrowConverter extends Logging {
         utf8StringFromVariableWidth(vector, rowIndex)
 
       case ArrayType(FloatType, _) =>
-        // FloatVector stored as FixedSizeBinaryVector
-        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
-        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        val floats =
-          (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
-        ArrayData.toArrayData(floats)
+        vector match {
+          case v: FixedSizeBinaryVector =>
+            ArrayData.toArrayData(floatArrayFromFixedSizeBinary(v, rowIndex))
+          case _ => arrayFromListVector(vector, rowIndex, FloatType)
+        }
+
+      case ArrayType(BinaryType, _) =>
+        vector match {
+          case v: FixedSizeBinaryVector =>
+            ArrayData.toArrayData(Array(v.get(rowIndex)))
+          case _ => arrayFromListVector(vector, rowIndex, BinaryType)
+        }
+
+      case ArrayType(ByteType, _) =>
+        vector match {
+          case v: FixedSizeBinaryVector =>
+            ArrayData.toArrayData(v.get(rowIndex))
+          case _ => arrayFromListVector(vector, rowIndex, ByteType)
+        }
+
+      case ArrayType(ShortType, _) =>
+        vector match {
+          case v: FixedSizeBinaryVector =>
+            ArrayData.toArrayData(v.get(rowIndex).map(_.toShort))
+          case _ => arrayFromListVector(vector, rowIndex, ShortType)
+        }
 
       case ArrayType(elementType, _) =>
-        // Generic array handling
-        val listVector = vector.asInstanceOf[ListVector]
-        val dataVector = listVector.getDataVector
-        val startIndex = listVector.getElementStartIndex(rowIndex)
-        val endIndex = listVector.getElementEndIndex(rowIndex)
-        val length = endIndex - startIndex
-
-        val arrayElements = (0 until length).map { i =>
-          val elemIndex = startIndex + i
-          if (dataVector.isNull(elemIndex)) {
-            null
-          } else {
-            arrowValueToSparkValue(dataVector, elemIndex, elementType)
-          }
-        }.toArray
-
-        ArrayData.toArrayData(arrayElements)
+        arrayFromListVector(vector, rowIndex, elementType)
 
       case BinaryType =>
-        variableWidthBytes(vector, rowIndex)
+        binaryBytes(vector, rowIndex)
 
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -1,6 +1,11 @@
 package com.zilliz.spark.connector.serde
 
 import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.{
+  CharacterCodingException,
+  CodingErrorAction,
+  StandardCharsets
+}
 import scala.collection.JavaConverters._
 
 import org.apache.arrow.vector._
@@ -27,6 +32,31 @@ object ArrowConverter extends Logging {
           s"Expected variable-width Arrow vector, got ${other.getClass.getName}"
         )
     }
+  }
+
+  private def utf8StringFromVariableWidth(
+      vector: FieldVector,
+      rowIndex: Int
+  ): UTF8String = {
+    val bytes = variableWidthBytes(vector, rowIndex)
+    vector match {
+      case _: VarBinaryVector =>
+        try {
+          StandardCharsets.UTF_8
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes))
+        } catch {
+          case e: CharacterCodingException =>
+            throw new IllegalArgumentException(
+              s"Arrow VarBinary value in column ${vector.getName} at row $rowIndex is not valid UTF-8",
+              e
+            )
+        }
+      case _ =>
+    }
+    UTF8String.fromBytes(bytes)
   }
 
   /** Convert an Arrow VectorSchemaRoot row to Spark InternalRow
@@ -104,7 +134,7 @@ object ArrowConverter extends Logging {
         vector.asInstanceOf[BitVector].get(rowIndex) != 0
 
       case StringType =>
-        UTF8String.fromBytes(variableWidthBytes(vector, rowIndex))
+        utf8StringFromVariableWidth(vector, rowIndex)
 
       case ArrayType(FloatType, _) =>
         // FloatVector stored as FixedSizeBinaryVector

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -85,7 +85,7 @@ object DataTypeUtil {
       case MilvusDataType.FloatVector =>
         DataTypes.createArrayType(DataTypes.FloatType)
       case MilvusDataType.BinaryVector =>
-        DataTypes.createArrayType(DataTypes.BinaryType)
+        DataTypes.createArrayType(DataTypes.ByteType)
       case MilvusDataType.Int8Vector =>
         DataTypes.createArrayType(DataTypes.ShortType)
       case MilvusDataType.Float16Vector =>

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -84,8 +84,7 @@ object DataTypeUtil {
         ) // TODO: fubang support geometry
       case MilvusDataType.FloatVector =>
         DataTypes.createArrayType(DataTypes.FloatType)
-      case MilvusDataType.BinaryVector =>
-        DataTypes.createArrayType(DataTypes.ByteType)
+      case MilvusDataType.BinaryVector => DataTypes.BinaryType
       case MilvusDataType.Int8Vector =>
         DataTypes.createArrayType(DataTypes.ShortType)
       case MilvusDataType.Float16Vector =>

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -34,6 +34,14 @@ object MilvusSchemaUtil {
     )
   }
 
+  private def systemFieldNameAliases(field: FieldSchema): Set[String] = {
+    field.fieldID match {
+      case 0 => Set("rowid", "row_id")
+      case 1 => Set("timestamp")
+      case _ => Set(field.name.toLowerCase)
+    }
+  }
+
   /** Convert Milvus FieldSchema to Arrow Field
     */
   def convertToArrowField(
@@ -136,15 +144,14 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    val existingNames = collectionSchema.fields.map(_.name).toSet
+    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
     val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
     val systemFields = Seq(
       FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
       FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
     ).filterNot(field =>
-      existingNames.contains(field.name) || existingFieldIds.contains(
-        field.fieldID
-      )
+      systemFieldNameAliases(field).exists(existingNames.contains) ||
+        existingFieldIds.contains(field.fieldID)
     )
 
     (systemFields ++ collectionSchema.fields).foreach { field =>
@@ -223,15 +230,14 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    val existingNames = collectionSchema.fields.map(_.name).toSet
+    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
     val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
     val systemFields = Seq(
       FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
       FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
     ).filterNot(field =>
-      existingNames.contains(field.name) || existingFieldIds.contains(
-        field.fieldID
-      )
+      systemFieldNameAliases(field).exists(existingNames.contains) ||
+        existingFieldIds.contains(field.fieldID)
     )
 
     (systemFields ++ collectionSchema.fields).foreach { field =>
@@ -309,8 +315,8 @@ object MilvusSchemaUtil {
           )
       }
 
-      // Use explicit field ID if provided, otherwise fall back to idx + 1
-      val fieldId = fieldIds.getOrElse(field.name, (idx + 1).toLong)
+      // Use explicit field ID if provided, otherwise avoid Milvus system IDs 0/1.
+      val fieldId = fieldIds.getOrElse(field.name, (idx + 100).toLong)
       val metadata = Map("PARQUET:field_id" -> fieldId.toString).asJava
 
       val fieldType = new FieldType(true, arrowType, null, metadata)

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -43,7 +43,8 @@ object MilvusSchemaUtil {
     import scala.collection.JavaConverters._
 
     val metadata = Map(
-      "PARQUET:field_id" -> field.fieldID.toString
+      "PARQUET:field_id" -> field.fieldID.toString,
+      "milvus_data_type" -> field.dataType.value.toString
     ).asJava
 
     // Create FieldType with metadata included
@@ -201,7 +202,8 @@ object MilvusSchemaUtil {
       // Create metadata with both field_id and original name for reference
       val metadata = Map(
         "PARQUET:field_id" -> field.fieldID.toString,
-        "original_name" -> field.name
+        "original_name" -> field.name,
+        "milvus_data_type" -> field.dataType.value.toString
       ).asJava
 
       val fieldType = new FieldType(

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -135,8 +135,18 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    // Process all fields in the collection schema
-    collectionSchema.fields.foreach { field =>
+    val existingNames = collectionSchema.fields.map(_.name).toSet
+    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
+    val systemFields = Seq(
+      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
+      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
+    ).filterNot(field =>
+      existingNames.contains(field.name) || existingFieldIds.contains(
+        field.fieldID
+      )
+    )
+
+    (systemFields ++ collectionSchema.fields).foreach { field =>
       appendArrowField(field)
     }
 
@@ -152,8 +162,8 @@ object MilvusSchemaUtil {
     * the Arrow schema must use field IDs as field names for the reader to
     * correctly match requested columns with column groups.
     *
-    * Note: System fields (row_id, timestamp) are NOT included here. They are
-    * handled by MilvusPartitionReaderFactory.
+    * System fields (RowID=0, Timestamp=1) are included when the Milvus schema
+    * does not already declare them, so readers can project row_id/timestamp.
     *
     * @param collectionSchema
     *   The Milvus collection schema
@@ -211,8 +221,18 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    // Process all fields in the collection schema
-    collectionSchema.fields.foreach { field =>
+    val existingNames = collectionSchema.fields.map(_.name).toSet
+    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
+    val systemFields = Seq(
+      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
+      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
+    ).filterNot(field =>
+      existingNames.contains(field.name) || existingFieldIds.contains(
+        field.fieldID
+      )
+    )
+
+    (systemFields ++ collectionSchema.fields).foreach { field =>
       appendArrowFieldWithIdName(field)
     }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -10,7 +10,6 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
-import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
 import org.apache.spark.sql.connector.catalog.{
   SupportsRead,
   SupportsWrite,
@@ -29,6 +28,7 @@ import org.apache.spark.sql.connector.read.{
   SupportsPushDownRequiredColumns
 }
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
   DataTypes => SparkDataTypes,
@@ -37,7 +37,10 @@ import org.apache.spark.sql.types.{
   StructField,
   StructType
 }
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.util.{
+  CaseInsensitiveStringMap,
+  QueryExecutionListener
+}
 import org.apache.spark.sql.SparkSession
 
 import com.zilliz.spark.connector.{
@@ -485,9 +488,10 @@ class MilvusScanBuilder(
 
     fieldNames = fieldNames.sortBy(fieldName => fieldName2ID(fieldName))
     logInfo(s"fieldNames after sort: $fieldNames")
-    if (fieldNames.isEmpty) {
-      fieldNames = fieldNames :+ "row_id"
-      logInfo(s"fieldNames after add row_id: $fieldNames")
+    if (fieldNames.isEmpty && fieldName2ID.nonEmpty) {
+      val fallbackFieldName = fieldName2ID.toSeq.sortBy(_._2).head._1
+      fieldNames = fieldNames :+ fallbackFieldName
+      logInfo(s"fieldNames after add fallback field: $fieldNames")
     }
 
     val tmpMap = new HashMap[String, String]()
@@ -630,6 +634,7 @@ class MilvusScanBuilder(
 
 object MilvusScan extends Logging {
   private val SnapshotOptionKeys = Seq(
+    MilvusOption.SnapshotMode,
     MilvusOption.SnapshotManifests,
     MilvusOption.SnapshotV2Segments,
     MilvusOption.SnapshotCollectionId,
@@ -673,21 +678,68 @@ object MilvusScan extends Logging {
     )).distinct
   }
 
-  def parseInsertLogPathIds(basePath: String): Option[(String, Long)] = {
+  def parseInsertLogPathIds(basePath: String): (String, Long) = {
     val parts = Option(basePath)
       .getOrElse("")
       .split("/")
       .map(_.trim)
       .filter(_.nonEmpty)
     val insertLogIndex = parts.lastIndexOf("insert_log")
-    if (insertLogIndex < 0 || parts.length <= insertLogIndex + 3) {
-      None
-    } else {
-      val partitionId = parts(insertLogIndex + 2)
-      val segmentIdText = parts(insertLogIndex + 3)
-      try Some(partitionId -> segmentIdText.toLong)
-      catch { case _: NumberFormatException => None }
+    if (insertLogIndex < 0) {
+      throw new IllegalArgumentException(
+        s"Snapshot manifest base_path does not contain insert_log: '$basePath'"
+      )
     }
+    if (parts.length <= insertLogIndex + 3) {
+      throw new IllegalArgumentException(
+        s"Snapshot manifest base_path is missing partition/segment IDs: '$basePath'"
+      )
+    }
+
+    val partitionId = parts(insertLogIndex + 2)
+    val segmentIdText = parts(insertLogIndex + 3)
+    val segmentId =
+      try segmentIdText.toLong
+      catch {
+        case e: NumberFormatException =>
+          throw new IllegalArgumentException(
+            s"Snapshot manifest base_path has non-numeric segment ID '$segmentIdText': '$basePath'",
+            e
+          )
+      }
+    partitionId -> segmentId
+  }
+
+  def dropClientReadSnapshot(
+      client: MilvusClient,
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String,
+      reason: String,
+      maxAttempts: Int = 3
+  ): Boolean = {
+    var lastFailure = Option.empty[Throwable]
+    (1 to maxAttempts).foreach { attempt =>
+      client.dropSnapshot(databaseName, collectionName, snapshotName) match {
+        case scala.util.Success(_) =>
+          logInfo(s"Dropped client read snapshot $snapshotName after $reason")
+          return true
+        case scala.util.Failure(e) =>
+          lastFailure = Some(e)
+          logWarning(
+            s"Failed to drop client read snapshot $snapshotName after $reason " +
+              s"(attempt $attempt/$maxAttempts)",
+            e
+          )
+      }
+    }
+    lastFailure.foreach { e =>
+      logWarning(
+        s"Giving up dropping client read snapshot $snapshotName after $maxAttempts attempt(s)",
+        e
+      )
+    }
+    false
   }
 
   def registerClientSnapshotCleanup(
@@ -695,22 +747,20 @@ object MilvusScan extends Logging {
       databaseName: String,
       collectionName: String,
       snapshotName: String
-  ): Unit = {
+  ): Boolean = {
     val dropped = new AtomicBoolean(false)
 
     def dropSnapshot(reason: String): Unit = {
       if (!dropped.compareAndSet(false, true)) return
       val client = MilvusClient(MilvusOption(baseOptions))
       try {
-        client.dropSnapshot(databaseName, collectionName, snapshotName) match {
-          case scala.util.Success(_) =>
-            logInfo(s"Dropped client read snapshot $snapshotName after $reason")
-          case scala.util.Failure(e) =>
-            logWarning(
-              s"Failed to drop client read snapshot $snapshotName after $reason",
-              e
-            )
-        }
+        dropClientReadSnapshot(
+          client,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        )
       } finally {
         client.close()
       }
@@ -718,15 +768,31 @@ object MilvusScan extends Logging {
 
     SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
       case Some(session) =>
-        session.sparkContext.addSparkListener(new SparkListener {
-          override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
-            dropSnapshot(s"Spark job ${jobEnd.jobId} ended")
+        val listener = new QueryExecutionListener {
+          private def cleanup(reason: String): Unit = {
+            try dropSnapshot(reason)
+            finally session.listenerManager.unregister(this)
           }
-        })
+
+          override def onSuccess(
+              funcName: String,
+              qe: QueryExecution,
+              durationNs: Long
+          ): Unit = cleanup(s"Spark query '$funcName' succeeded")
+
+          override def onFailure(
+              funcName: String,
+              qe: QueryExecution,
+              exception: Exception
+          ): Unit = cleanup(s"Spark query '$funcName' failed")
+        }
+        session.listenerManager.register(listener)
+        true
       case None =>
         logWarning(
           s"No active SparkSession; client read snapshot $snapshotName cannot be auto-dropped"
         )
+        false
     }
   }
 
@@ -875,27 +941,38 @@ class MilvusScan(
           val partitions = planInputPartitionsFromClientSnapshotPath(
             snapshotPath
           )
-          MilvusScan.registerClientSnapshotCleanup(
+          val cleanupRegistered = MilvusScan.registerClientSnapshotCleanup(
             options.asScala.toMap,
             milvusOption.databaseName,
             milvusOption.collectionName,
             snapshot.name
           )
-          Some(partitions)
-        } catch {
-          case e: Throwable =>
-            client.dropSnapshot(
+          if (cleanupRegistered) {
+            Some(partitions)
+          } else {
+            val dropped = MilvusScan.dropClientReadSnapshot(
+              client,
               milvusOption.databaseName,
               milvusOption.collectionName,
-              snapshot.name
-            ) match {
-              case scala.util.Failure(dropErr) =>
-                logWarning(
-                  s"Failed to drop client read snapshot ${snapshot.name} after planning failure",
-                  dropErr
-                )
-              case _ =>
+              snapshot.name,
+              "missing SparkSession"
+            )
+            if (!dropped) {
+              throw new IllegalStateException(
+                s"Failed to drop client read snapshot ${snapshot.name} when no SparkSession was available"
+              )
             }
+            None
+          }
+        } catch {
+          case e: Throwable =>
+            MilvusScan.dropClientReadSnapshot(
+              client,
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name,
+              "planning failure"
+            )
             throw e
         }
 
@@ -1093,10 +1170,15 @@ class MilvusScan(
   }
 
   private def readAllBytes(conf: Configuration, path: String): String = {
+    val maxBytes = milvusOption.options
+      .get(MilvusOption.SnapshotMaxJsonBytes)
+      .filter(_.trim.nonEmpty)
+      .map(_.toLong)
+      .getOrElse(MilvusSnapshotReader.MaxSnapshotJsonBytes)
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)
     val in = fs.open(new Path(uri))
-    try MilvusSnapshotReader.readUtf8WithLimit(in, path)
+    try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
     finally in.close()
   }
 
@@ -1203,30 +1285,17 @@ class MilvusScan(
             ) // Backward compatible: plain basePath, latest version
         }
 
-      val parsedPathIds = MilvusScan.parseInsertLogPathIds(basePath)
-      val partitionId = parsedPathIds.map(_._1).getOrElse {
-        if (partitionIds.length <= 1) defaultPartitionId
-        else {
-          throw new IllegalArgumentException(
-            s"Cannot determine partition ID from snapshot manifest base_path '$basePath'"
-          )
-        }
-      }
+      val (partitionId, parsedSegmentId) =
+        MilvusScan.parseInsertLogPathIds(basePath)
       val segmentID = if (item.segmentID != 0L) {
-        parsedPathIds.foreach { case (_, parsedSegmentId) =>
-          if (parsedSegmentId != item.segmentID) {
-            throw new IllegalArgumentException(
-              s"Snapshot manifest segmentID ${item.segmentID} does not match base_path segment $parsedSegmentId in '$basePath'"
-            )
-          }
+        if (parsedSegmentId != item.segmentID) {
+          throw new IllegalArgumentException(
+            s"Snapshot manifest segmentID ${item.segmentID} does not match base_path segment $parsedSegmentId in '$basePath'"
+          )
         }
         item.segmentID
       } else {
-        parsedPathIds.map(_._2).getOrElse {
-          throw new IllegalArgumentException(
-            s"Cannot determine segment ID from snapshot manifest base_path '$basePath'"
-          )
-        }
+        parsedSegmentId
       }
       logInfo(
         s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -538,12 +538,12 @@ class MilvusScanBuilder(
   }
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
-    // V2 packed reader does not apply filters server-side yet — return all
-    // as unsupported so Spark applies them post-read.
-    // TODO: implement filter pushdown for V2 packed reader in a separate PR.
-    val isPackedV2 = Option(options.get(MilvusOption.SnapshotV2Segments))
-      .exists(_.nonEmpty)
-    if (isPackedV2) {
+    // Snapshot planning can mix V3 and packed V2 readers, and client mode may
+    // pivot into snapshot mode after Spark has already asked about pushdown.
+    val milvusOption = MilvusOption(options)
+    val shouldReadViaSnapshot = MilvusOption.isSnapshotMode(options) ||
+      MilvusScan.canUseClientSnapshotFastPath(milvusOption)
+    if (shouldReadViaSnapshot) {
       pushedFilterArray = Array.empty
       return filters
     }
@@ -1044,7 +1044,7 @@ class MilvusScan(
     new MilvusScan(
       schema,
       new CaseInsensitiveStringMap(snapshotOptions.asJava),
-      pushedFilters
+      Array.empty[Filter]
     ).planInputPartitions()
   }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1269,12 +1269,6 @@ class MilvusScan(
         }
         .getOrElse(Seq.empty)
 
-    if (manifestList.isEmpty && packedV2Segments.isEmpty) {
-      throw new IllegalArgumentException(
-        "Snapshot mode has no StorageV3 manifests or StorageV2 segments; refusing to return an empty read"
-      )
-    }
-
     // Get partition IDs from options (comma-separated)
     val partitionIds = Option(options.get(MilvusOption.SnapshotPartitionIds))
       .map(_.split(",").map(_.trim).filter(_.nonEmpty))

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -658,6 +658,23 @@ object MilvusScan {
     }
   }
 
+  def snapshotBucket(location: String): Option[String] = {
+    val trimmed = Option(location).map(_.trim).getOrElse("")
+    if (trimmed.startsWith("s3://") || trimmed.startsWith("s3a://")) {
+      Option(new URI(resolveClientSnapshotLocation(trimmed, "")).getHost)
+        .filter(_.nonEmpty)
+    } else {
+      None
+    }
+  }
+
+  def snapshotBucketsToConfigure(
+      snapshotPath: String,
+      connectorBucket: String
+  ): Seq[String] = {
+    (Seq(connectorBucket).filter(_.nonEmpty) ++ snapshotBucket(snapshotPath)).distinct
+  }
+
   def canUseClientSnapshotFastPath(milvusOption: MilvusOption): Boolean = {
     milvusOption.partitionName.isEmpty &&
     milvusOption.partitionID.isEmpty &&
@@ -705,7 +722,7 @@ class MilvusScan(
     .exists(_.equalsIgnoreCase("true"))
 
   private def debugRead(message: => String): Unit = {
-    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+    if (readDebugEnabled) logInfo(s"[MilvusReadDebug] $message")
   }
 
   // Get vector search configuration from MilvusOption
@@ -839,7 +856,7 @@ class MilvusScan(
   private def planInputPartitionsFromClientSnapshotPath(
       snapshotPath: String
   ): Array[InputPartition] = {
-    val hadoopConf = buildSnapshotHadoopConf()
+    val hadoopConf = buildSnapshotHadoopConf(snapshotPath)
     val snapshotJson = readAllBytes(hadoopConf, snapshotPath)
     val metadata =
       MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
@@ -1000,13 +1017,15 @@ class MilvusScan(
     partitions
   }
 
-  private def buildSnapshotHadoopConf(): Configuration = {
+  private def buildSnapshotHadoopConf(snapshotPath: String): Configuration = {
     val conf = new Configuration()
     val bucket = milvusOption.options.getOrElse(
       Properties.FsConfig.FsBucketName,
       "a-bucket"
     )
-    MilvusOption.configureHadoopS3A(conf, milvusOption.options, bucket)
+    MilvusScan.snapshotBucketsToConfigure(snapshotPath, bucket).foreach { b =>
+      MilvusOption.configureHadoopS3A(conf, milvusOption.options, b)
+    }
     conf
   }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -3,12 +3,14 @@ package com.zilliz.spark.connector.sources
 import java.{util => ju}
 import java.net.URI
 import java.util.{Base64, HashMap, Map => JMap, UUID}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.{SparkListener, SparkListenerJobEnd}
 import org.apache.spark.sql.connector.catalog.{
   SupportsRead,
   SupportsWrite,
@@ -36,6 +38,7 @@ import org.apache.spark.sql.types.{
   StructType
 }
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.SparkSession
 
 import com.zilliz.spark.connector.{
   DataTypeUtil,
@@ -66,9 +69,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
   ): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val milvusOption = MilvusOption(options)
-    val isSnapshotMode =
-      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode = MilvusOption.isSnapshotMode(options)
     if (milvusOption.uri.isEmpty && !isSnapshotMode) {
       throw new IllegalArgumentException(
         s"Option '${MilvusOption.MilvusUri}' is required for reading milvus data."
@@ -84,9 +85,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
     val milvusOption = MilvusOption(options)
 
     // Check for snapshot mode - use snapshot schema if provided
-    val isSnapshotMode =
-      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode = MilvusOption.isSnapshotMode(options)
 
     if (isSnapshotMode) {
       // Try to get schema from snapshot JSON
@@ -193,11 +192,8 @@ case class MilvusTable(
     * [[MilvusOption.SnapshotV2Segments]] is sufficient to take the
     * snapshot-only path and skip all Milvus client calls.
     */
-  private def isSnapshotMode: Boolean = {
-    milvusOption.options.get(MilvusOption.SnapshotMode).contains("true") &&
-    (milvusOption.options.contains(MilvusOption.SnapshotManifests) ||
-      milvusOption.options.contains(MilvusOption.SnapshotV2Segments))
-  }
+  private def isSnapshotMode: Boolean =
+    MilvusOption.isSnapshotMode(milvusOption.options)
 
   def initInfo(): Unit = {
     // Check for snapshot mode first - skip client calls if snapshot data is provided
@@ -632,7 +628,7 @@ class MilvusScanBuilder(
   }
 }
 
-object MilvusScan {
+object MilvusScan extends Logging {
   private val SnapshotOptionKeys = Seq(
     MilvusOption.SnapshotManifests,
     MilvusOption.SnapshotV2Segments,
@@ -672,7 +668,66 @@ object MilvusScan {
       snapshotPath: String,
       connectorBucket: String
   ): Seq[String] = {
-    (Seq(connectorBucket).filter(_.nonEmpty) ++ snapshotBucket(snapshotPath)).distinct
+    (Seq(connectorBucket).filter(_.nonEmpty) ++ snapshotBucket(
+      snapshotPath
+    )).distinct
+  }
+
+  def parseInsertLogPathIds(basePath: String): Option[(String, Long)] = {
+    val parts = Option(basePath)
+      .getOrElse("")
+      .split("/")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+    val insertLogIndex = parts.lastIndexOf("insert_log")
+    if (insertLogIndex < 0 || parts.length <= insertLogIndex + 3) {
+      None
+    } else {
+      val partitionId = parts(insertLogIndex + 2)
+      val segmentIdText = parts(insertLogIndex + 3)
+      try Some(partitionId -> segmentIdText.toLong)
+      catch { case _: NumberFormatException => None }
+    }
+  }
+
+  def registerClientSnapshotCleanup(
+      baseOptions: Map[String, String],
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String
+  ): Unit = {
+    val dropped = new AtomicBoolean(false)
+
+    def dropSnapshot(reason: String): Unit = {
+      if (!dropped.compareAndSet(false, true)) return
+      val client = MilvusClient(MilvusOption(baseOptions))
+      try {
+        client.dropSnapshot(databaseName, collectionName, snapshotName) match {
+          case scala.util.Success(_) =>
+            logInfo(s"Dropped client read snapshot $snapshotName after $reason")
+          case scala.util.Failure(e) =>
+            logWarning(
+              s"Failed to drop client read snapshot $snapshotName after $reason",
+              e
+            )
+        }
+      } finally {
+        client.close()
+      }
+    }
+
+    SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
+      case Some(session) =>
+        session.sparkContext.addSparkListener(new SparkListener {
+          override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+            dropSnapshot(s"Spark job ${jobEnd.jobId} ended")
+          }
+        })
+      case None =>
+        logWarning(
+          s"No active SparkSession; client read snapshot $snapshotName cannot be auto-dropped"
+        )
+    }
   }
 
   def canUseClientSnapshotFastPath(milvusOption: MilvusOption): Boolean = {
@@ -743,8 +798,7 @@ class MilvusScan(
 
   override def planInputPartitions(): Array[InputPartition] = {
     val snapshotManifests = Option(options.get(MilvusOption.SnapshotManifests))
-    val snapshotV2 = Option(options.get(MilvusOption.SnapshotV2Segments))
-    if (snapshotManifests.isDefined || snapshotV2.isDefined) {
+    if (MilvusOption.isSnapshotMode(options)) {
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
     }
 
@@ -818,7 +872,16 @@ class MilvusScan(
             s"protectionSeconds=$protectionSeconds"
         )
         try {
-          Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+          val partitions = planInputPartitionsFromClientSnapshotPath(
+            snapshotPath
+          )
+          MilvusScan.registerClientSnapshotCleanup(
+            options.asScala.toMap,
+            milvusOption.databaseName,
+            milvusOption.collectionName,
+            snapshot.name
+          )
+          Some(partitions)
         } catch {
           case e: Throwable =>
             client.dropSnapshot(
@@ -1078,6 +1141,27 @@ class MilvusScan(
             )
         }
 
+    val packedV2Segments: Seq[V2SegmentInfo] =
+      Option(options.get(MilvusOption.SnapshotV2Segments))
+        .filter(_.nonEmpty)
+        .map { json =>
+          MilvusSnapshotReader.deserializeV2Segments(json) match {
+            case Right(segs) => segs
+            case Left(e) =>
+              throw new Exception(
+                s"Failed to parse SnapshotV2Segments: ${e.getMessage}",
+                e
+              )
+          }
+        }
+        .getOrElse(Seq.empty)
+
+    if (manifestList.isEmpty && packedV2Segments.isEmpty) {
+      throw new IllegalArgumentException(
+        "Snapshot mode has no StorageV3 manifests or StorageV2 segments; refusing to return an empty read"
+      )
+    }
+
     // Get partition IDs from options (comma-separated)
     val partitionIds = Option(options.get(MilvusOption.SnapshotPartitionIds))
       .map(_.split(",").map(_.trim).filter(_.nonEmpty))
@@ -1119,33 +1203,43 @@ class MilvusScan(
             ) // Backward compatible: plain basePath, latest version
         }
 
-      // Extract segmentID from manifest path if item.segmentID is 0
-      // Path format: files/insert_log/{collectionID}/{partitionID}/{segmentID}
+      val parsedPathIds = MilvusScan.parseInsertLogPathIds(basePath)
+      val partitionId = parsedPathIds.map(_._1).getOrElse {
+        if (partitionIds.length <= 1) defaultPartitionId
+        else {
+          throw new IllegalArgumentException(
+            s"Cannot determine partition ID from snapshot manifest base_path '$basePath'"
+          )
+        }
+      }
       val segmentID = if (item.segmentID != 0L) {
+        parsedPathIds.foreach { case (_, parsedSegmentId) =>
+          if (parsedSegmentId != item.segmentID) {
+            throw new IllegalArgumentException(
+              s"Snapshot manifest segmentID ${item.segmentID} does not match base_path segment $parsedSegmentId in '$basePath'"
+            )
+          }
+        }
         item.segmentID
       } else {
-        // Try to extract from basePath
-        val pathParts = basePath.split("/")
-        if (pathParts.length >= 1) {
-          try {
-            pathParts.last.toLong
-          } catch {
-            case _: NumberFormatException => 0L
-          }
-        } else 0L
+        parsedPathIds.map(_._2).getOrElse {
+          throw new IllegalArgumentException(
+            s"Cannot determine segment ID from snapshot manifest base_path '$basePath'"
+          )
+        }
       }
       logInfo(
         s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"
       )
       debugRead(
         s"snapshot segment reader=V3 segmentID=$segmentID " +
-          s"partitionID=$defaultPartitionId basePath=$basePath " +
+          s"partitionID=$partitionId basePath=$basePath " +
           s"readVersion=$readVersion rawManifest=${item.manifest}"
       )
       MilvusStorageV3InputPartition(
         basePath, // The basePath extracted from manifest JSON
         schemaBytes, // Protobuf CollectionSchema bytes from snapshot
-        defaultPartitionId, // Partition name/ID
+        partitionId, // Partition name/ID
         milvusOption,
         vectorSearchConfig.map(_.topK),
         vectorSearchConfig.map(_.queryVector),
@@ -1162,49 +1256,39 @@ class MilvusScan(
 
     // Additional partitions from pre-materialized packed-V2 segments (if any).
     val packedV2Partitions: Seq[InputPartition] =
-      Option(options.get(MilvusOption.SnapshotV2Segments))
-        .filter(_.nonEmpty)
-        .map { json =>
-          MilvusSnapshotReader.deserializeV2Segments(json) match {
-            case Right(segs) if segs.nonEmpty =>
-              logInfo(
-                s"Creating ${segs.size} packed-V2 partition(s) from " +
-                  s"SnapshotV2Segments option"
-              )
-              segs.map { seg =>
-                debugRead(
-                  s"snapshot segment reader=V2 segmentID=${seg.segmentId} " +
-                    s"partitionID=${seg.partitionId} numRows=${seg.numOfRows} " +
-                    s"storageVersion=${seg.storageVersion} " +
-                    s"columnGroups=${seg.columnGroups.size}"
-                )
-                seg.columnGroups.zipWithIndex.foreach { case (cg, idx) =>
-                  debugRead(
-                    s"snapshot V2 columnGroup[$idx] segmentID=${seg.segmentId} " +
-                      s"slotFieldId=${cg.slotFieldId} " +
-                      s"fieldIds=${cg.fieldIds.mkString(",")} " +
-                      s"files=${cg.filePaths.mkString(",")} " +
-                      s"rowCounts=${cg.fileRowCounts.mkString(",")}"
-                  )
-                }
-                MilvusPackedV2InputPartition(
-                  segmentID = seg.segmentId,
-                  partitionID = seg.partitionId,
-                  columnGroups = seg.columnGroups,
-                  milvusSchemaBytes = schemaBytes,
-                  milvusOption = milvusOption,
-                  neededColumnFieldIds = Seq.empty
-                ): InputPartition
-              }
-            case Right(_) => Seq.empty[InputPartition]
-            case Left(e) =>
-              throw new Exception(
-                s"Failed to parse SnapshotV2Segments: ${e.getMessage}",
-                e
-              )
+      if (packedV2Segments.nonEmpty) {
+        logInfo(
+          s"Creating ${packedV2Segments.size} packed-V2 partition(s) from " +
+            s"SnapshotV2Segments option"
+        )
+        packedV2Segments.map { seg =>
+          debugRead(
+            s"snapshot segment reader=V2 segmentID=${seg.segmentId} " +
+              s"partitionID=${seg.partitionId} numRows=${seg.numOfRows} " +
+              s"storageVersion=${seg.storageVersion} " +
+              s"columnGroups=${seg.columnGroups.size}"
+          )
+          seg.columnGroups.zipWithIndex.foreach { case (cg, idx) =>
+            debugRead(
+              s"snapshot V2 columnGroup[$idx] segmentID=${seg.segmentId} " +
+                s"slotFieldId=${cg.slotFieldId} " +
+                s"fieldIds=${cg.fieldIds.mkString(",")} " +
+                s"files=${cg.filePaths.mkString(",")} " +
+                s"rowCounts=${cg.fileRowCounts.mkString(",")}"
+            )
           }
+          MilvusPackedV2InputPartition(
+            segmentID = seg.segmentId,
+            partitionID = seg.partitionId,
+            columnGroups = seg.columnGroups,
+            milvusSchemaBytes = schemaBytes,
+            milvusOption = milvusOption,
+            neededColumnFieldIds = Seq.empty
+          ): InputPartition
         }
-        .getOrElse(Seq.empty[InputPartition])
+      } else {
+        Seq.empty[InputPartition]
+      }
 
     (v2Partitions ++ packedV2Partitions).toArray
   }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -435,6 +435,7 @@ class MilvusScanBuilder(
     .split(",")
     .map(_.trim)
     .filter(_.nonEmpty)
+    .map(MilvusOption.normalizeExtraColumnName)
     .toSeq
 
   // Store the filters that can be pushed down
@@ -657,6 +658,12 @@ object MilvusScan {
     }
   }
 
+  def canUseClientSnapshotFastPath(milvusOption: MilvusOption): Boolean = {
+    milvusOption.partitionName.isEmpty &&
+    milvusOption.partitionID.isEmpty &&
+    milvusOption.segmentID.isEmpty
+  }
+
   def buildClientSnapshotOptions(
       baseOptions: Map[String, String],
       collectionName: String,
@@ -730,7 +737,16 @@ class MilvusScan(
 
     val client = MilvusClient(milvusOption)
     try {
-      planInputPartitionsFromClientSnapshot(client).getOrElse {
+      val clientSnapshotPartitions =
+        if (MilvusScan.canUseClientSnapshotFastPath(milvusOption)) {
+          planInputPartitionsFromClientSnapshot(client)
+        } else {
+          debugRead(
+            "client snapshot fast path disabled because partition/segment selector is set"
+          )
+          None
+        }
+      clientSnapshotPartitions.getOrElse {
         val collectionInfo = client
           .getCollectionInfo(
             milvusOption.databaseName,

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1,10 +1,14 @@
 package com.zilliz.spark.connector.sources
 
 import java.{util => ju}
-import java.util.{HashMap, Map => JMap}
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.util.{Base64, HashMap, Map => JMap, UUID}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.catalog.{
   SupportsRead,
@@ -45,7 +49,11 @@ import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusPackedV2InputPartition,
   MilvusPartitionReaderFactory,
-  MilvusStorageV3InputPartition
+  MilvusSnapshotReader,
+  MilvusStorageV3InputPartition,
+  StorageV2ManifestItem,
+  V2SegmentInfo,
+  V2SegmentLoader
 }
 import com.zilliz.spark.connector.write.{MilvusWrite, MilvusWriteBuilder}
 import io.milvus.grpc.schema.CollectionSchema
@@ -392,14 +400,22 @@ case class MilvusTable(
         MilvusOption.MilvusExtraColumnSegmentID
       )
     ) {
-      fields = fields :+ StructField("segment_id", LongType, false)
+      fields = fields :+ StructField(
+        MilvusOption.MilvusExtraColumnSegmentID,
+        LongType,
+        false
+      )
     }
     if (
       milvusOption.extraColumns.contains(
         MilvusOption.MilvusExtraColumnRowOffset
       )
     ) {
-      fields = fields :+ StructField("row_offset", LongType, false)
+      fields = fields :+ StructField(
+        MilvusOption.MilvusExtraColumnRowOffset,
+        LongType,
+        false
+      )
     }
     StructType(fields)
   }
@@ -506,15 +522,15 @@ class MilvusScanBuilder(
     }
     if (
       extraColumns.contains(MilvusOption.MilvusExtraColumnSegmentID) &&
-      !fieldNames.contains("segment_id")
+      !fieldNames.contains(MilvusOption.MilvusExtraColumnSegmentID)
     ) {
-      fieldNames = fieldNames :+ "segment_id"
+      fieldNames = fieldNames :+ MilvusOption.MilvusExtraColumnSegmentID
     }
     if (
       extraColumns.contains(MilvusOption.MilvusExtraColumnRowOffset) &&
-      !fieldNames.contains("row_offset")
+      !fieldNames.contains(MilvusOption.MilvusExtraColumnRowOffset)
     ) {
-      fieldNames = fieldNames :+ "row_offset"
+      fieldNames = fieldNames :+ MilvusOption.MilvusExtraColumnRowOffset
     }
 
     currentOptions = new CaseInsensitiveStringMap(tmpMap)
@@ -622,6 +638,61 @@ class MilvusScanBuilder(
   }
 }
 
+object MilvusScan {
+  private val SnapshotOptionKeys = Seq(
+    MilvusOption.SnapshotManifests,
+    MilvusOption.SnapshotV2Segments,
+    MilvusOption.SnapshotCollectionId,
+    MilvusOption.SnapshotPartitionIds,
+    MilvusOption.SnapshotSchemaJson,
+    MilvusOption.SnapshotSchemaBytes
+  )
+
+  def resolveClientSnapshotLocation(
+      location: String,
+      bucket: String
+  ): String = {
+    val trimmed = Option(location).map(_.trim).getOrElse("")
+    if (trimmed.isEmpty) {
+      throw new IllegalArgumentException("snapshot s3_location is empty")
+    } else if (trimmed.startsWith("s3a://")) {
+      trimmed
+    } else if (trimmed.startsWith("s3://")) {
+      "s3a://" + trimmed.stripPrefix("s3://")
+    } else {
+      s"s3a://${bucket}/${trimmed.stripPrefix("/")}"
+    }
+  }
+
+  def buildClientSnapshotOptions(
+      baseOptions: Map[String, String],
+      collectionName: String,
+      collectionId: Long,
+      partitionIds: Seq[Long],
+      snapshotJson: String,
+      schemaBytesBase64: String,
+      manifestList: Seq[StorageV2ManifestItem],
+      v2Segments: Seq[V2SegmentInfo]
+  ): Map[String, String] = {
+    var out = baseOptions -- SnapshotOptionKeys
+    out = out ++ Map(
+      MilvusOption.SnapshotMode -> "true",
+      MilvusOption.MilvusCollectionName -> collectionName,
+      MilvusOption.SnapshotCollectionId -> collectionId.toString,
+      MilvusOption.SnapshotPartitionIds -> partitionIds.mkString(","),
+      MilvusOption.SnapshotSchemaJson -> snapshotJson,
+      MilvusOption.SnapshotSchemaBytes -> schemaBytesBase64,
+      MilvusOption.SnapshotManifests ->
+        MilvusSnapshotReader.serializeManifestList(manifestList)
+    )
+    if (v2Segments.nonEmpty) {
+      out += MilvusOption.SnapshotV2Segments ->
+        MilvusSnapshotReader.serializeV2Segments(v2Segments)
+    }
+    out
+  }
+}
+
 class MilvusScan(
     schema: StructType,
     options: CaseInsensitiveStringMap,
@@ -630,6 +701,12 @@ class MilvusScan(
     with Batch
     with Logging {
   private val milvusOption = MilvusOption(options)
+  private val readDebugEnabled = Option(options.get(MilvusOption.ReaderDebug))
+    .exists(_.equalsIgnoreCase("true"))
+
+  private def debugRead(message: => String): Unit = {
+    if (readDebugEnabled) System.err.println(s"[MilvusReadDebug] $message")
+  }
 
   // Get vector search configuration from MilvusOption
   private val vectorSearchConfig = milvusOption.vectorSearchConfig
@@ -648,55 +725,170 @@ class MilvusScan(
   override def toBatch: Batch = this
 
   override def planInputPartitions(): Array[InputPartition] = {
-    // Check if snapshot data is provided (offline/snapshot mode).
-    // Either legacy manifest-based (V3) or packed-parquet (V2) segments.
     val snapshotManifests = Option(options.get(MilvusOption.SnapshotManifests))
     val snapshotV2 = Option(options.get(MilvusOption.SnapshotV2Segments))
     if (snapshotManifests.isDefined || snapshotV2.isDefined) {
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
     }
 
-    // Validate required parameters
     if (milvusOption.collectionName.isEmpty) {
       throw new IllegalArgumentException("collectionName cannot be empty")
     }
 
-    val collection = milvusOption.collectionID
-    val partition = milvusOption.partitionID
-    val segment = milvusOption.segmentID
-
     val client = MilvusClient(milvusOption)
+    try {
+      planInputPartitionsFromClientSnapshot(client).getOrElse {
+        val collectionInfo = client
+          .getCollectionInfo(
+            milvusOption.databaseName,
+            milvusOption.collectionName
+          )
+          .getOrElse(
+            throw new Exception(
+              s"Collection ${milvusOption.collectionName} not found"
+            )
+          )
+        planInputPartitionsFromLegacyClient(client, collectionInfo)
+      }
+    } finally {
+      client.close()
+    }
+  }
 
-    // Get collection schema and S3 config for manifest building
-    val collectionInfo = client
-      .getCollectionInfo(
-        milvusOption.databaseName,
-        milvusOption.collectionName
-      )
-      .getOrElse(
-        throw new Exception(
-          s"Collection ${milvusOption.collectionName} not found"
-        )
-      )
+  private def planInputPartitionsFromClientSnapshot(
+      client: MilvusClient
+  ): Option[Array[InputPartition]] = {
     val s3Bucket = milvusOption.options.getOrElse(
       Properties.FsConfig.FsBucketName,
       "a-bucket"
     )
+    val snapshotName = Option(options.get(MilvusOption.ClientSnapshotName))
+      .filter(_.trim.nonEmpty)
+      .getOrElse(
+        s"spark_read_${milvusOption.collectionName}_${System
+            .currentTimeMillis()}_${UUID.randomUUID().toString.replace("-", "")}"
+      )
+    val description = Option(
+      options.get(MilvusOption.ClientSnapshotDescription)
+    ).filter(_.trim.nonEmpty).getOrElse("spark connector client read snapshot")
+    val protectionSeconds = Option(
+      options.get(MilvusOption.ClientSnapshotCompactionProtectionSeconds)
+    ).filter(_.trim.nonEmpty).map(_.toLong).getOrElse(86400L)
+
+    client.createSnapshotForRead(
+      milvusOption.databaseName,
+      milvusOption.collectionName,
+      snapshotName,
+      description,
+      protectionSeconds
+    ) match {
+      case scala.util.Success(snapshot) =>
+        val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
+          snapshot.s3Location,
+          s3Bucket
+        )
+        debugRead(
+          s"client snapshot created name=${snapshot.name} path=$snapshotPath " +
+            s"protectionSeconds=$protectionSeconds"
+        )
+        Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+
+      case scala.util.Failure(e) if MilvusClient.isServiceNotImplemented(e) =>
+        logWarning(
+          "CreateSnapshot/DescribeSnapshot is not implemented by this Milvus " +
+            "service; falling back to legacy GetPersistentSegmentInfo read path"
+        )
+        debugRead(s"client snapshot unavailable: ${e.getMessage}")
+        None
+
+      case scala.util.Failure(e) =>
+        throw new RuntimeException(
+          s"Failed to create client read snapshot for collection " +
+            s"${milvusOption.collectionName}: ${e.getMessage}",
+          e
+        )
+    }
+  }
+
+  private def planInputPartitionsFromClientSnapshotPath(
+      snapshotPath: String
+  ): Array[InputPartition] = {
+    val hadoopConf = buildSnapshotHadoopConf()
+    val snapshotJson = readAllBytes(hadoopConf, snapshotPath)
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
+        case Right(value) => value
+        case Left(err) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse client-created snapshot metadata: ${err.getMessage}",
+            err
+          )
+      }
+
+    val s3Bucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
+    )
+    val v2Segments = if (metadata.manifestList.nonEmpty) {
+      V2SegmentLoader.loadV2Segments(
+        metadata.manifestList,
+        s3Bucket,
+        hadoopConf
+      ) match {
+        case Right(segs) => segs
+        case Left(err) =>
+          throw new IllegalStateException(
+            s"Failed to load StorageV2 segments from client-created snapshot: ${err.getMessage}",
+            err
+          )
+      }
+    } else Seq.empty
+
+    val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
+      metadata.collection.schema
+    )
+    val snapshotOptions = MilvusScan.buildClientSnapshotOptions(
+      options.asScala.toMap,
+      collectionName = metadata.collection.schema.name,
+      collectionId = metadata.snapshotInfo.collectionId,
+      partitionIds = metadata.snapshotInfo.partitionIds,
+      snapshotJson = snapshotJson,
+      schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
+      manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
+      v2Segments = v2Segments
+    )
+
+    new MilvusScan(
+      schema,
+      new CaseInsensitiveStringMap(snapshotOptions.asJava),
+      pushedFilters
+    ).planInputPartitions()
+  }
+
+  private def planInputPartitionsFromLegacyClient(
+      client: MilvusClient,
+      collectionInfo: MilvusCollectionInfo
+  ): Array[InputPartition] = {
+    val collection = milvusOption.collectionID
+    val partition = milvusOption.partitionID
+    val segment = milvusOption.segmentID
     val s3RootPath =
       milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
 
-    // Helper function to create InputPartition from segment info
     def createPartition(
         segmentID: String,
         partitionID: String
     ): InputPartition = {
-      // Build segment path where manifest files exist
-      // StorageV3 segments have manifest files at:
-      //   rootPath/insert_log/collectionID/partitionID/segmentID/_metadata/
       val segmentPath =
         s"$s3RootPath/insert_log/$collection/$partitionID/$segmentID"
       logInfo(
         s"Creating V3 partition: segmentID=$segmentID, segmentPath=$segmentPath"
+      )
+      debugRead(
+        s"planner selected reader=V3 segmentID=$segmentID " +
+          s"partitionID=$partitionID collectionID=$collection " +
+          s"segmentPath=$segmentPath " +
+          "note=fallback-old-client-grpc-path"
       )
 
       val segmentIDLong =
@@ -715,11 +907,7 @@ class MilvusScan(
       )
     }
 
-    // Get all segments with storage_version >= 2 (StorageV2 packed parquet
-    // without manifest, or StorageV3 packed parquet with loon manifest).
-    // NOTE: current planner treats every >= 2 segment as StorageV3; a separate
-    // task is tracking client-mode StorageV2 (non-manifest) dispatch.
-    val allPackedSegments = client
+    val allSegments = client
       .getSegments(
         milvusOption.databaseName,
         milvusOption.collectionName
@@ -727,7 +915,23 @@ class MilvusScan(
       .getOrElse(
         throw new Exception("Failed to get segments")
       )
-      .filter(_.storageVersion >= 2)
+    debugRead(
+      s"client planner collection=${milvusOption.collectionName} " +
+        s"collectionID=$collection requestedPartition=$partition " +
+        s"requestedSegment=$segment totalSegments=${allSegments.size}"
+    )
+    allSegments.foreach { seg =>
+      debugRead(
+        s"client segment segmentID=${seg.segmentID} " +
+          s"partitionID=${seg.partitionID} collectionID=${seg.collectionID} " +
+          s"numRows=${seg.numRows} state=${seg.state} level=${seg.level} " +
+          s"storageVersion=${seg.storageVersion}"
+      )
+    }
+    val allPackedSegments = allSegments.filter(_.storageVersion >= 2)
+    debugRead(
+      s"client planner selected packedSegments=${allPackedSegments.size}"
+    )
 
     if (allPackedSegments.isEmpty) {
       throw new IllegalArgumentException(
@@ -739,45 +943,102 @@ class MilvusScan(
     }
 
     val partitions: Array[InputPartition] =
-      if (!partition.isEmpty() && !segment.isEmpty()) {
-        // Case 1: Specific segment specified - validate segment belongs to partition
-        val segmentInfo =
-          allPackedSegments.find(_.segmentID.toString == segment)
-        segmentInfo match {
-          case Some(seg) =>
-            if (seg.partitionID.toString != partition) {
-              throw new IllegalArgumentException(
-                s"Segment $segment belongs to partition ${seg.partitionID}, not $partition"
-              )
-            }
+      if (partition.nonEmpty && segment.nonEmpty) {
+        allPackedSegments.find(_.segmentID.toString == segment) match {
+          case Some(seg) if seg.partitionID.toString == partition =>
             Array(createPartition(segment, partition))
+          case Some(seg) =>
+            throw new IllegalArgumentException(
+              s"Segment $segment belongs to partition ${seg.partitionID}, not $partition"
+            )
           case None =>
             throw new IllegalArgumentException(
               s"Segment $segment not found or has storage_version < 2 " +
                 "(StorageV2/V3 packed parquet required)"
             )
         }
-
-      } else if (!partition.isEmpty()) {
-        // Case 2: Partition specified - only process packed segments in this partition
+      } else if (partition.nonEmpty) {
         allPackedSegments
           .filter(_.partitionID.toString == partition)
           .map(seg => createPartition(seg.segmentID.toString, partition))
           .toArray
-
       } else {
-        // Case 3: No partition specified - process all packed segments
         allPackedSegments.map { seg =>
           createPartition(seg.segmentID.toString, seg.partitionID.toString)
         }.toArray
       }
 
     logInfo(
-      s"Created ${partitions.length} partitions (treating all StorageV2/V3 " +
-        "segments as V3; see V2 dispatch TODO)"
+      s"Created ${partitions.length} partitions via legacy client path"
     )
-    client.close()
     partitions
+  }
+
+  private def buildSnapshotHadoopConf(): Configuration = {
+    val conf = new Configuration()
+    val bucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
+    )
+    val prefix = s"fs.s3a.bucket.$bucket"
+
+    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    milvusOption.options.get(Properties.FsConfig.FsAddress).foreach {
+      endpoint =>
+        conf.set(s"$prefix.endpoint", endpoint)
+    }
+    milvusOption.options.get(Properties.FsConfig.FsRegion).foreach { region =>
+      conf.set(s"$prefix.endpoint.region", region)
+      conf.set(s"$prefix.region", region)
+    }
+    conf.set(s"$prefix.path.style.access", "true")
+    conf.set(
+      s"$prefix.connection.ssl.enabled",
+      milvusOption.options.getOrElse(Properties.FsConfig.FsUseSSL, "false")
+    )
+
+    val useIam = milvusOption.options
+      .get(Properties.FsConfig.FsUseIam)
+      .exists(_.equalsIgnoreCase("true"))
+    val accessKey = milvusOption.options.get(Properties.FsConfig.FsAccessKeyId)
+    val secretKey =
+      milvusOption.options.get(Properties.FsConfig.FsAccessKeyValue)
+    if (useIam || accessKey.isEmpty || secretKey.isEmpty) {
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        Seq(
+          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+        ).mkString(",")
+      )
+    } else {
+      conf.set(s"$prefix.access.key", accessKey.get)
+      conf.set(s"$prefix.secret.key", secretKey.get)
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    }
+    conf
+  }
+
+  private def readAllBytes(conf: Configuration, path: String): String = {
+    val uri = new URI(path)
+    val fs = FileSystem.get(uri, conf)
+    val in = fs.open(new Path(uri))
+    try {
+      val out = new ByteArrayOutputStream()
+      val buf = new Array[Byte](8192)
+      var n = in.read(buf)
+      while (n >= 0) {
+        out.write(buf, 0, n)
+        n = in.read(buf)
+      }
+      new String(out.toByteArray, "UTF-8")
+    } finally {
+      in.close()
+    }
   }
 
   /** Plan input partitions from snapshot manifests (offline mode - no client
@@ -842,6 +1103,11 @@ class MilvusScan(
     logInfo(
       s"Using schema bytes (${schemaBytes.length} bytes) for V2 partitions"
     )
+    debugRead(
+      s"snapshot planner v3ManifestCount=${manifestList.size} " +
+        s"partitionIds=${partitionIds.mkString(",")} " +
+        s"defaultPartitionId=$defaultPartitionId schemaBytes=${schemaBytes.length}"
+    )
 
     // Create V2 input partitions from snapshot manifests
     val v2Partitions = manifestList.map { item =>
@@ -875,6 +1141,11 @@ class MilvusScan(
       logInfo(
         s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"
       )
+      debugRead(
+        s"snapshot segment reader=V3 segmentID=$segmentID " +
+          s"partitionID=$defaultPartitionId basePath=$basePath " +
+          s"readVersion=$readVersion rawManifest=${item.manifest}"
+      )
       MilvusStorageV3InputPartition(
         basePath, // The basePath extracted from manifest JSON
         schemaBytes, // Protobuf CollectionSchema bytes from snapshot
@@ -905,6 +1176,21 @@ class MilvusScan(
                   s"SnapshotV2Segments option"
               )
               segs.map { seg =>
+                debugRead(
+                  s"snapshot segment reader=V2 segmentID=${seg.segmentId} " +
+                    s"partitionID=${seg.partitionId} numRows=${seg.numOfRows} " +
+                    s"storageVersion=${seg.storageVersion} " +
+                    s"columnGroups=${seg.columnGroups.size}"
+                )
+                seg.columnGroups.zipWithIndex.foreach { case (cg, idx) =>
+                  debugRead(
+                    s"snapshot V2 columnGroup[$idx] segmentID=${seg.segmentId} " +
+                      s"slotFieldId=${cg.slotFieldId} " +
+                      s"fieldIds=${cg.fieldIds.mkString(",")} " +
+                      s"files=${cg.filePaths.mkString(",")} " +
+                      s"rowCounts=${cg.fileRowCounts.mkString(",")}"
+                  )
+                }
                 MilvusPackedV2InputPartition(
                   segmentID = seg.segmentId,
                   partitionID = seg.partitionId,

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1,7 +1,6 @@
 package com.zilliz.spark.connector.sources
 
 import java.{util => ju}
-import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.util.{Base64, HashMap, Map => JMap, UUID}
 import scala.collection.mutable
@@ -163,6 +162,29 @@ case class MilvusTable(
       Seq[String]()
     }
   logInfo(s"MilvusTable fieldIDs: $fieldIDs")
+
+  private def appendExtraColumns(schema: StructType): StructType = {
+    var fields = schema.fields.toSeq
+    def addIfRequested(name: String, field: StructField): Unit = {
+      if (
+        milvusOption.extraColumns
+          .contains(name) && !fields.exists(_.name == name)
+      ) {
+        fields = fields :+ field
+      }
+    }
+
+    addIfRequested("partition", StructField("partition", StringType, true))
+    addIfRequested(
+      MilvusOption.MilvusExtraColumnSegmentID,
+      StructField(MilvusOption.MilvusExtraColumnSegmentID, LongType, false)
+    )
+    addIfRequested(
+      MilvusOption.MilvusExtraColumnRowOffset,
+      StructField(MilvusOption.MilvusExtraColumnRowOffset, LongType, false)
+    )
+    StructType(fields)
+  }
 
   /** Check if snapshot mode is enabled (data comes from snapshot, not client).
     *
@@ -349,7 +371,7 @@ case class MilvusTable(
       logInfo(
         s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
       )
-      return sparkSchema.get
+      return appendExtraColumns(sparkSchema.get)
     }
 
     // Client-based mode or snapshot mode without provided schema: compute from milvusCollection
@@ -388,36 +410,7 @@ case class MilvusTable(
     ) {
       fields = fields :+ StructField("$meta", StringType, true)
     }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnPartition
-      )
-    ) {
-      fields = fields :+ StructField("partition", StringType, true)
-    }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnSegmentID
-      )
-    ) {
-      fields = fields :+ StructField(
-        MilvusOption.MilvusExtraColumnSegmentID,
-        LongType,
-        false
-      )
-    }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnRowOffset
-      )
-    ) {
-      fields = fields :+ StructField(
-        MilvusOption.MilvusExtraColumnRowOffset,
-        LongType,
-        false
-      )
-    }
-    StructType(fields)
+    appendExtraColumns(StructType(fields))
   }
 
   override def capabilities(): ju.Set[TableCapability] = {
@@ -980,46 +973,7 @@ class MilvusScan(
       Properties.FsConfig.FsBucketName,
       "a-bucket"
     )
-    val prefix = s"fs.s3a.bucket.$bucket"
-
-    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-    milvusOption.options.get(Properties.FsConfig.FsAddress).foreach {
-      endpoint =>
-        conf.set(s"$prefix.endpoint", endpoint)
-    }
-    milvusOption.options.get(Properties.FsConfig.FsRegion).foreach { region =>
-      conf.set(s"$prefix.endpoint.region", region)
-      conf.set(s"$prefix.region", region)
-    }
-    conf.set(s"$prefix.path.style.access", "true")
-    conf.set(
-      s"$prefix.connection.ssl.enabled",
-      milvusOption.options.getOrElse(Properties.FsConfig.FsUseSSL, "false")
-    )
-
-    val useIam = milvusOption.options
-      .get(Properties.FsConfig.FsUseIam)
-      .exists(_.equalsIgnoreCase("true"))
-    val accessKey = milvusOption.options.get(Properties.FsConfig.FsAccessKeyId)
-    val secretKey =
-      milvusOption.options.get(Properties.FsConfig.FsAccessKeyValue)
-    if (useIam || accessKey.isEmpty || secretKey.isEmpty) {
-      conf.set(
-        s"$prefix.aws.credentials.provider",
-        Seq(
-          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
-          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
-          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
-        ).mkString(",")
-      )
-    } else {
-      conf.set(s"$prefix.access.key", accessKey.get)
-      conf.set(s"$prefix.secret.key", secretKey.get)
-      conf.set(
-        s"$prefix.aws.credentials.provider",
-        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
-      )
-    }
+    MilvusOption.configureHadoopS3A(conf, milvusOption.options, bucket)
     conf
   }
 
@@ -1027,18 +981,8 @@ class MilvusScan(
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)
     val in = fs.open(new Path(uri))
-    try {
-      val out = new ByteArrayOutputStream()
-      val buf = new Array[Byte](8192)
-      var n = in.read(buf)
-      while (n >= 0) {
-        out.write(buf, 0, n)
-        n = in.read(buf)
-      }
-      new String(out.toByteArray, "UTF-8")
-    } finally {
-      in.close()
-    }
+    try MilvusSnapshotReader.readUtf8WithLimit(in, path)
+    finally in.close()
   }
 
   /** Plan input partitions from snapshot manifests (offline mode - no client

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -10,6 +10,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.connector.catalog.{
   SupportsRead,
   SupportsWrite,
@@ -28,7 +29,7 @@ import org.apache.spark.sql.connector.read.{
   SupportsPushDownRequiredColumns
 }
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
-import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
   DataTypes => SparkDataTypes,
@@ -37,10 +38,7 @@ import org.apache.spark.sql.types.{
   StructField,
   StructType
 }
-import org.apache.spark.sql.util.{
-  CaseInsensitiveStringMap,
-  QueryExecutionListener
-}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.SparkSession
 
 import com.zilliz.spark.connector.{
@@ -439,6 +437,7 @@ class MilvusScanBuilder(
 
   // Store the filters that can be pushed down
   private var pushedFilterArray: Array[Filter] = Array.empty[Filter]
+  private var readerFilterArray: Array[Filter] = Array.empty[Filter]
 
   override def pruneColumns(requiredSchema: StructType): Unit = {
     if (currentOptions.getOrDefault(MilvusOption.ReaderFieldIDs, "").nonEmpty) {
@@ -543,13 +542,15 @@ class MilvusScanBuilder(
     val milvusOption = MilvusOption(options)
     val shouldReadViaSnapshot = MilvusOption.isSnapshotMode(options) ||
       MilvusScan.canUseClientSnapshotFastPath(milvusOption)
-    if (shouldReadViaSnapshot) {
-      pushedFilterArray = Array.empty
-      return filters
-    }
     val (supportedFilters, unsupportedFilters) =
       filters.partition(isSupportedFilter)
+    if (shouldReadViaSnapshot) {
+      pushedFilterArray = Array.empty
+      readerFilterArray = supportedFilters
+      return filters
+    }
     pushedFilterArray = supportedFilters
+    readerFilterArray = supportedFilters
     unsupportedFilters
   }
 
@@ -628,11 +629,17 @@ class MilvusScanBuilder(
   }
 
   override def build(): Scan = {
-    new MilvusScan(currentSchema, currentOptions, pushedFilterArray)
+    new MilvusScan(
+      currentSchema,
+      currentOptions,
+      pushedFilterArray,
+      readerFilterArray
+    )
   }
 }
 
 object MilvusScan extends Logging {
+  private val SparkSqlExecutionIdKey = "spark.sql.execution.id"
   private val SnapshotOptionKeys = Seq(
     MilvusOption.SnapshotMode,
     MilvusOption.SnapshotManifests,
@@ -716,10 +723,12 @@ object MilvusScan extends Logging {
       collectionName: String,
       snapshotName: String,
       reason: String,
-      maxAttempts: Int = 3
+      maxAttempts: Int = 3,
+      retryDelayMillis: Long = 500
   ): Boolean = {
     var lastFailure = Option.empty[Throwable]
-    (1 to maxAttempts).foreach { attempt =>
+    var attempt = 1
+    while (attempt <= maxAttempts) {
       client.dropSnapshot(databaseName, collectionName, snapshotName) match {
         case scala.util.Success(_) =>
           logInfo(s"Dropped client read snapshot $snapshotName after $reason")
@@ -731,7 +740,16 @@ object MilvusScan extends Logging {
               s"(attempt $attempt/$maxAttempts)",
             e
           )
+          if (attempt < maxAttempts && retryDelayMillis > 0) {
+            try Thread.sleep(retryDelayMillis)
+            catch {
+              case _: InterruptedException =>
+                Thread.currentThread().interrupt()
+                return false
+            }
+          }
       }
+      attempt += 1
     }
     lastFailure.foreach { e =>
       logWarning(
@@ -768,26 +786,32 @@ object MilvusScan extends Logging {
 
     SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
       case Some(session) =>
-        val listener = new QueryExecutionListener {
-          private def cleanup(reason: String): Unit = {
-            try dropSnapshot(reason)
-            finally session.listenerManager.unregister(this)
-          }
+        Option(session.sparkContext.getLocalProperty(SparkSqlExecutionIdKey))
+          .filter(_.trim.nonEmpty) match {
+          case Some(executionId) =>
+            val listener = new SparkListener {
+              private def cleanup(reason: String): Unit = {
+                try dropSnapshot(reason)
+                finally session.sparkContext.removeSparkListener(this)
+              }
 
-          override def onSuccess(
-              funcName: String,
-              qe: QueryExecution,
-              durationNs: Long
-          ): Unit = cleanup(s"Spark query '$funcName' succeeded")
-
-          override def onFailure(
-              funcName: String,
-              qe: QueryExecution,
-              exception: Exception
-          ): Unit = cleanup(s"Spark query '$funcName' failed")
+              override def onOtherEvent(event: SparkListenerEvent): Unit = {
+                event match {
+                  case e: SparkListenerSQLExecutionEnd
+                      if e.executionId.toString == executionId =>
+                    cleanup(s"Spark SQL execution $executionId ended")
+                  case _ =>
+                }
+              }
+            }
+            session.sparkContext.addSparkListener(listener)
+            true
+          case None =>
+            logWarning(
+              s"No active Spark SQL execution id; client read snapshot $snapshotName cannot be safely auto-dropped"
+            )
+            false
         }
-        session.listenerManager.register(listener)
-        true
       case None =>
         logWarning(
           s"No active SparkSession; client read snapshot $snapshotName cannot be auto-dropped"
@@ -834,7 +858,8 @@ object MilvusScan extends Logging {
 class MilvusScan(
     schema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter] = Array.empty[Filter]
+    pushedFilters: Array[Filter] = Array.empty[Filter],
+    readerFilters: Array[Filter] = Array.empty[Filter]
 ) extends Scan
     with Batch
     with Logging {
@@ -855,6 +880,8 @@ class MilvusScan(
       s"Vector search enabled: topK=${config.topK}, metric=${config.metricType}, column=${config.vectorColumn}"
     )
   }
+
+  private[sources] def readerFiltersForPlanning: Array[Filter] = readerFilters
 
   override def readSchema(): StructType = {
     schema
@@ -1365,6 +1392,6 @@ class MilvusScan(
   override def createReaderFactory(): PartitionReaderFactory = {
     // Convert CaseInsensitiveStringMap to regular Map for serialization
     val optionsMap = options.asScala.toMap
-    new MilvusPartitionReaderFactory(schema, optionsMap, pushedFilters)
+    new MilvusPartitionReaderFactory(schema, optionsMap, readerFilters)
   }
 }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -800,7 +800,24 @@ class MilvusScan(
           s"client snapshot created name=${snapshot.name} path=$snapshotPath " +
             s"protectionSeconds=$protectionSeconds"
         )
-        Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+        try {
+          Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+        } catch {
+          case e: Throwable =>
+            client.dropSnapshot(
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name
+            ) match {
+              case scala.util.Failure(dropErr) =>
+                logWarning(
+                  s"Failed to drop client read snapshot ${snapshot.name} after planning failure",
+                  dropErr
+                )
+              case _ =>
+            }
+            throw e
+        }
 
       case scala.util.Failure(e) if MilvusClient.isServiceNotImplemented(e) =>
         logWarning(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -975,6 +975,10 @@ class MilvusScan(
             snapshot.name
           )
           if (cleanupRegistered) {
+            logWarning(
+              s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
+                "an unclean driver exit can leave it behind and require manual cleanup."
+            )
             Some(partitions)
           } else {
             val dropped = MilvusScan.dropClientReadSnapshot(
@@ -1335,7 +1339,7 @@ class MilvusScan(
       MilvusStorageV3InputPartition(
         basePath, // The basePath extracted from manifest JSON
         schemaBytes, // Protobuf CollectionSchema bytes from snapshot
-        partitionId, // Partition name/ID
+        partitionId, // Partition ID string for the extra column
         milvusOption,
         vectorSearchConfig.map(_.topK),
         vectorSearchConfig.map(_.queryVector),

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -1,0 +1,441 @@
+package com.zilliz.spark.connector.tools
+
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.util.Base64
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import com.zilliz.spark.connector.loon.Properties
+import com.zilliz.spark.connector.read.{
+  MilvusSnapshotReader,
+  SnapshotMetadata,
+  V2SegmentInfo,
+  V2SegmentLoader
+}
+import com.zilliz.spark.connector.MilvusOption
+
+object MilvusReadApp {
+
+  private[tools] val DataSourceFqcn =
+    "com.zilliz.spark.connector.sources.MilvusDataSource"
+
+  private[tools] case class ReadArgs(
+      mode: String = "client",
+      milvusUri: String = "",
+      milvusToken: String = "",
+      database: String = "default",
+      collection: String = "",
+      partitionName: Option[String] = None,
+      snapshot: Option[String] = None,
+      s3Endpoint: String = "",
+      s3Bucket: String = "",
+      s3RootPath: String = "files",
+      s3AccessKey: String = "",
+      s3SecretKey: String = "",
+      s3Region: String = "us-east-1",
+      s3UseSSL: Boolean = false,
+      useIam: Boolean = false,
+      fieldIds: Option[String] = None,
+      extraColumns: Option[String] = None,
+      show: Option[Int] = None,
+      count: Boolean = false,
+      printSchema: Boolean = false,
+      debugRead: Boolean = false,
+      select: Option[String] = None,
+      where: Option[String] = None,
+      outputParquet: Option[String] = None
+  )
+
+  private[tools] val BoolFlags: Set[String] = Set(
+    "count",
+    "print-schema",
+    "debug-read",
+    "s3-use-ssl",
+    "use-iam"
+  )
+
+  private[tools] val KvFlags: Set[String] = Set(
+    "mode",
+    "milvus-uri",
+    "milvus-token",
+    "database",
+    "collection",
+    "partition-name",
+    "snapshot",
+    "s3-endpoint",
+    "s3-bucket",
+    "s3-root-path",
+    "s3-access-key",
+    "s3-secret-key",
+    "s3-region",
+    "field-ids",
+    "extra-columns",
+    "show",
+    "select",
+    "where",
+    "output-parquet"
+  )
+
+  private[tools] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
+
+  private[tools] def parseArgs(args: Array[String]): ReadArgs = {
+    val parsed = scala.collection.mutable.Map.empty[String, String]
+    var i = 0
+    while (i < args.length) {
+      val token = args(i)
+      if (!token.startsWith("--")) {
+        throw new IllegalArgumentException(
+          s"Unexpected positional argument: $token"
+        )
+      }
+      val key = token.stripPrefix("--")
+      if (!KnownFlags.contains(key)) {
+        throw new IllegalArgumentException(s"Unknown option: --$key")
+      }
+      if (BoolFlags.contains(key)) {
+        parsed(key) = "true"
+        i += 1
+      } else {
+        if (i + 1 >= args.length || args(i + 1).startsWith("--")) {
+          throw new IllegalArgumentException(s"Missing value for --$key")
+        }
+        parsed(key) = args(i + 1)
+        i += 2
+      }
+    }
+
+    val mode = parsed.getOrElse("mode", "client")
+    if (mode != "client" && mode != "snapshot") {
+      throw new IllegalArgumentException(
+        "--mode must be either 'client' or 'snapshot'"
+      )
+    }
+
+    ReadArgs(
+      mode = mode,
+      milvusUri = parsed.getOrElse("milvus-uri", ""),
+      milvusToken = parsed.getOrElse("milvus-token", ""),
+      database = parsed.getOrElse("database", "default"),
+      collection = parsed.getOrElse("collection", ""),
+      partitionName = parsed.get("partition-name"),
+      snapshot = parsed.get("snapshot"),
+      s3Endpoint = parsed.getOrElse("s3-endpoint", ""),
+      s3Bucket = parsed.getOrElse("s3-bucket", ""),
+      s3RootPath = parsed.getOrElse("s3-root-path", "files"),
+      s3AccessKey = parsed.getOrElse("s3-access-key", ""),
+      s3SecretKey = parsed.getOrElse("s3-secret-key", ""),
+      s3Region = parsed.getOrElse("s3-region", "us-east-1"),
+      s3UseSSL = parsed.contains("s3-use-ssl"),
+      useIam = parsed.contains("use-iam"),
+      fieldIds = parsed.get("field-ids"),
+      extraColumns = parsed.get("extra-columns"),
+      show = parsed.get("show").map(_.toInt),
+      count = parsed.contains("count"),
+      printSchema = parsed.contains("print-schema"),
+      debugRead = parsed.contains("debug-read"),
+      select = parsed.get("select"),
+      where = parsed.get("where"),
+      outputParquet = parsed.get("output-parquet")
+    )
+  }
+
+  private[tools] def buildStorageOptions(
+      args: ReadArgs
+  ): Map[String, String] = {
+    require(args.s3Bucket.nonEmpty, "--s3-bucket is required")
+
+    val opts = scala.collection.mutable.Map[String, String](
+      Properties.FsConfig.FsBucketName -> args.s3Bucket,
+      Properties.FsConfig.FsRootPath -> args.s3RootPath,
+      Properties.FsConfig.FsRegion -> args.s3Region,
+      Properties.FsConfig.FsUseSSL -> args.s3UseSSL.toString
+    )
+
+    if (args.s3Endpoint.nonEmpty) {
+      opts += Properties.FsConfig.FsAddress -> args.s3Endpoint
+    }
+    if (args.s3AccessKey.nonEmpty) {
+      opts += Properties.FsConfig.FsAccessKeyId -> args.s3AccessKey
+    }
+    if (args.s3SecretKey.nonEmpty) {
+      opts += Properties.FsConfig.FsAccessKeyValue -> args.s3SecretKey
+    }
+    if (args.useIam) {
+      opts += Properties.FsConfig.FsUseIam -> "true"
+    }
+
+    opts.toMap
+  }
+
+  private[tools] def buildClientOptions(args: ReadArgs): Map[String, String] = {
+    require(args.milvusUri.nonEmpty, "--milvus-uri is required in client mode")
+    require(args.collection.nonEmpty, "--collection is required in client mode")
+
+    val opts = scala.collection.mutable.Map[String, String](
+      MilvusOption.MilvusUri -> args.milvusUri,
+      MilvusOption.MilvusToken -> args.milvusToken,
+      MilvusOption.MilvusDatabaseName -> args.database,
+      MilvusOption.MilvusCollectionName -> args.collection
+    )
+
+    args.partitionName.foreach(v =>
+      opts += MilvusOption.MilvusPartitionName -> v
+    )
+    args.fieldIds.foreach(v => opts += MilvusOption.ReaderFieldIDs -> v)
+    args.extraColumns.foreach(v => opts += MilvusOption.MilvusExtraColumns -> v)
+    if (args.debugRead) opts += MilvusOption.ReaderDebug -> "true"
+
+    opts.toMap ++ buildStorageOptions(args)
+  }
+
+  private[tools] def buildSnapshotOptionsFromMetadata(
+      args: ReadArgs,
+      metadata: SnapshotMetadata,
+      snapshotJson: String,
+      v2Segments: Seq[V2SegmentInfo]
+  ): Map[String, String] = {
+    require(args.snapshot.nonEmpty, "--snapshot is required in snapshot mode")
+
+    val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
+      metadata.collection.schema
+    )
+
+    val opts = scala.collection.mutable.Map[String, String](
+      MilvusOption.SnapshotMode -> "true",
+      MilvusOption.MilvusUri -> "dummy://snapshot-mode",
+      MilvusOption.MilvusDatabaseName -> args.database,
+      MilvusOption.MilvusCollectionName -> metadata.collection.schema.name,
+      MilvusOption.SnapshotCollectionId -> metadata.snapshotInfo.collectionId.toString,
+      MilvusOption.SnapshotPartitionIds -> metadata.snapshotInfo.partitionIds
+        .mkString(","),
+      MilvusOption.SnapshotSchemaJson -> snapshotJson,
+      MilvusOption.SnapshotSchemaBytes -> Base64.getEncoder.encodeToString(
+        schemaBytes
+      )
+    )
+
+    metadata.storageV2ManifestList.foreach { manifestList =>
+      if (manifestList.nonEmpty) {
+        opts += MilvusOption.SnapshotManifests ->
+          MilvusSnapshotReader.serializeManifestList(manifestList)
+      }
+    }
+
+    if (v2Segments.nonEmpty) {
+      opts += MilvusOption.SnapshotV2Segments ->
+        MilvusSnapshotReader.serializeV2Segments(v2Segments)
+    }
+
+    args.fieldIds.foreach(v => opts += MilvusOption.ReaderFieldIDs -> v)
+    args.extraColumns.foreach(v => opts += MilvusOption.MilvusExtraColumns -> v)
+    if (args.debugRead) opts += MilvusOption.ReaderDebug -> "true"
+
+    opts.toMap ++ buildStorageOptions(args)
+  }
+
+  private[tools] def buildSnapshotOptions(
+      args: ReadArgs,
+      hadoopConf: Configuration
+  ): Map[String, String] = {
+    val snapshotPath = args.snapshot.getOrElse(
+      throw new IllegalArgumentException(
+        "--snapshot is required in snapshot mode"
+      )
+    )
+    configureHadoopS3A(hadoopConf, args)
+
+    val snapshotJson = readSnapshotJson(snapshotPath, hadoopConf)
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
+        case Right(value) => value
+        case Left(err) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse snapshot metadata: ${err.getMessage}",
+            err
+          )
+      }
+
+    val v2Segments = if (metadata.manifestList.nonEmpty) {
+      V2SegmentLoader.loadV2Segments(
+        metadata.manifestList,
+        args.s3Bucket,
+        hadoopConf
+      ) match {
+        case Right(segs) => segs
+        case Left(err) =>
+          throw new IllegalStateException(
+            s"Failed to load StorageV2 segments from snapshot: ${err.getMessage}",
+            err
+          )
+      }
+    } else {
+      Seq.empty
+    }
+
+    buildSnapshotOptionsFromMetadata(args, metadata, snapshotJson, v2Segments)
+  }
+
+  private[tools] def normalizeSnapshotPath(path: String): String = {
+    if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else path
+  }
+
+  private[tools] def readLocalSnapshotJson(path: String): String = {
+    val source = scala.io.Source.fromFile(path)
+    try source.mkString
+    finally source.close()
+  }
+
+  private[tools] def readSnapshotJson(
+      path: String,
+      hadoopConf: Configuration
+  ): String = {
+    val normalized = normalizeSnapshotPath(path)
+    if (!normalized.contains("://")) {
+      readLocalSnapshotJson(normalized)
+    } else {
+      val uri = new URI(normalized)
+      val fs = FileSystem.get(uri, hadoopConf)
+      val in = fs.open(new Path(uri))
+      try {
+        val out = new ByteArrayOutputStream()
+        val buf = new Array[Byte](8192)
+        var n = in.read(buf)
+        while (n >= 0) {
+          out.write(buf, 0, n)
+          n = in.read(buf)
+        }
+        new String(out.toByteArray, "UTF-8")
+      } finally {
+        in.close()
+      }
+    }
+  }
+
+  private[tools] def configureHadoopS3A(
+      conf: Configuration,
+      args: ReadArgs
+  ): Unit = {
+    if (args.s3Bucket.isEmpty) return
+
+    val bucket = args.s3Bucket
+    val prefix = s"fs.s3a.bucket.$bucket"
+
+    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    if (args.s3Endpoint.nonEmpty) conf.set(s"$prefix.endpoint", args.s3Endpoint)
+    if (args.s3Region.nonEmpty) {
+      conf.set(s"$prefix.endpoint.region", args.s3Region)
+      conf.set(s"$prefix.region", args.s3Region)
+    }
+    conf.set(s"$prefix.path.style.access", "true")
+    conf.set(s"$prefix.connection.ssl.enabled", args.s3UseSSL.toString)
+
+    if (args.useIam || (args.s3AccessKey.isEmpty && args.s3SecretKey.isEmpty)) {
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        Seq(
+          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+        ).mkString(",")
+      )
+    } else {
+      conf.set(s"$prefix.access.key", args.s3AccessKey)
+      conf.set(s"$prefix.secret.key", args.s3SecretKey)
+      conf.set(
+        s"$prefix.aws.credentials.provider",
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    }
+  }
+
+  private[tools] def applyTransformations(
+      df: DataFrame,
+      args: ReadArgs
+  ): DataFrame = {
+    val selected = args.select match {
+      case Some(raw) if raw.trim.nonEmpty =>
+        val cols = raw.split(",").map(_.trim).filter(_.nonEmpty)
+        require(cols.nonEmpty, "--select must contain at least one column")
+        df.select(cols.head, cols.tail: _*)
+      case _ => df
+    }
+
+    args.where match {
+      case Some(expr) if expr.trim.nonEmpty => selected.where(expr)
+      case _                                => selected
+    }
+  }
+
+  private[tools] def readDataFrame(
+      spark: SparkSession,
+      args: ReadArgs
+  ): DataFrame = {
+    val options = args.mode match {
+      case "client" => buildClientOptions(args)
+      case "snapshot" =>
+        buildSnapshotOptions(args, spark.sparkContext.hadoopConfiguration)
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported mode: $other")
+    }
+
+    val df = spark.read
+      .format(DataSourceFqcn)
+      .options(options)
+      .load()
+
+    applyTransformations(df, args)
+  }
+
+  private[tools] def runActions(df: DataFrame, args: ReadArgs): Unit = {
+    if (args.printSchema) {
+      println("\n=== Schema ===")
+      df.printSchema()
+    }
+
+    args.show.foreach { n =>
+      println(s"\n=== Showing $n row(s) ===")
+      df.show(n, truncate = false)
+    }
+
+    if (args.count) {
+      println("\n=== Count ===")
+      println(df.count())
+    }
+
+    args.outputParquet.foreach { path =>
+      println(s"\n=== Writing parquet output to $path ===")
+      df.write.mode("overwrite").parquet(path)
+      println(s"Wrote parquet output to $path")
+    }
+  }
+
+  def main(rawArgs: Array[String]): Unit = {
+    val args = parseArgs(rawArgs)
+    val spark = SparkSession.builder
+      .appName("MilvusReadApp")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    try {
+      println(s"MilvusReadApp mode=${args.mode}")
+      val df = readDataFrame(spark, args)
+      val hasAction = args.printSchema || args.show.nonEmpty || args.count ||
+        args.outputParquet.nonEmpty
+      if (hasAction) {
+        runActions(df, args)
+      } else {
+        println(
+          "No action selected; defaulting to --print-schema and --show 20"
+        )
+        df.printSchema()
+        df.show(20, truncate = false)
+      }
+    } finally {
+      spark.stop()
+    }
+  }
+}

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -1,6 +1,6 @@
 package com.zilliz.spark.connector.tools
 
-import java.io.ByteArrayOutputStream
+import java.io.FileInputStream
 import java.net.URI
 import java.util.Base64
 
@@ -284,9 +284,9 @@ object MilvusReadApp {
   }
 
   private[tools] def readLocalSnapshotJson(path: String): String = {
-    val source = scala.io.Source.fromFile(path)
-    try source.mkString
-    finally source.close()
+    val in = new FileInputStream(path)
+    try MilvusSnapshotReader.readUtf8WithLimit(in, path)
+    finally in.close()
   }
 
   private[tools] def readSnapshotJson(
@@ -300,18 +300,8 @@ object MilvusReadApp {
       val uri = new URI(normalized)
       val fs = FileSystem.get(uri, hadoopConf)
       val in = fs.open(new Path(uri))
-      try {
-        val out = new ByteArrayOutputStream()
-        val buf = new Array[Byte](8192)
-        var n = in.read(buf)
-        while (n >= 0) {
-          out.write(buf, 0, n)
-          n = in.read(buf)
-        }
-        new String(out.toByteArray, "UTF-8")
-      } finally {
-        in.close()
-      }
+      try MilvusSnapshotReader.readUtf8WithLimit(in, normalized)
+      finally in.close()
     }
   }
 
@@ -321,35 +311,11 @@ object MilvusReadApp {
   ): Unit = {
     if (args.s3Bucket.isEmpty) return
 
-    val bucket = args.s3Bucket
-    val prefix = s"fs.s3a.bucket.$bucket"
-
-    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-    if (args.s3Endpoint.nonEmpty) conf.set(s"$prefix.endpoint", args.s3Endpoint)
-    if (args.s3Region.nonEmpty) {
-      conf.set(s"$prefix.endpoint.region", args.s3Region)
-      conf.set(s"$prefix.region", args.s3Region)
-    }
-    conf.set(s"$prefix.path.style.access", "true")
-    conf.set(s"$prefix.connection.ssl.enabled", args.s3UseSSL.toString)
-
-    if (args.useIam || (args.s3AccessKey.isEmpty && args.s3SecretKey.isEmpty)) {
-      conf.set(
-        s"$prefix.aws.credentials.provider",
-        Seq(
-          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
-          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
-          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
-        ).mkString(",")
-      )
-    } else {
-      conf.set(s"$prefix.access.key", args.s3AccessKey)
-      conf.set(s"$prefix.secret.key", args.s3SecretKey)
-      conf.set(
-        s"$prefix.aws.credentials.provider",
-        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
-      )
-    }
+    MilvusOption.configureHadoopS3A(
+      conf,
+      buildStorageOptions(args),
+      args.s3Bucket
+    )
   }
 
   private[tools] def applyTransformations(

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -45,9 +45,14 @@ object MilvusReadApp {
       count: Boolean = false,
       printSchema: Boolean = false,
       debugRead: Boolean = false,
+      clientSnapshotName: Option[String] = None,
+      clientSnapshotDescription: Option[String] = None,
+      clientSnapshotCompactionProtectionSeconds: Option[Long] = None,
+      snapshotMaxJsonBytes: Option[Long] = None,
       select: Option[String] = None,
       where: Option[String] = None,
-      outputParquet: Option[String] = None
+      outputParquet: Option[String] = None,
+      sparkLogLevel: Option[String] = None
   )
 
   private[tools] val BoolFlags: Set[String] = Set(
@@ -75,9 +80,14 @@ object MilvusReadApp {
     "field-ids",
     "extra-columns",
     "show",
+    "client-snapshot-name",
+    "client-snapshot-description",
+    "client-snapshot-compaction-protection-seconds",
+    "snapshot-max-json-bytes",
     "select",
     "where",
-    "output-parquet"
+    "output-parquet",
+    "spark-log-level"
   )
 
   private[tools] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
@@ -98,7 +108,10 @@ object MilvusReadApp {
           "--milvus-uri" -> args.milvusUri.nonEmpty,
           "--milvus-token" -> args.milvusToken.nonEmpty,
           "--collection" -> args.collection.nonEmpty,
-          "--partition-name" -> args.partitionName.nonEmpty
+          "--partition-name" -> args.partitionName.nonEmpty,
+          "--client-snapshot-name" -> args.clientSnapshotName.nonEmpty,
+          "--client-snapshot-description" -> args.clientSnapshotDescription.nonEmpty,
+          "--client-snapshot-compaction-protection-seconds" -> args.clientSnapshotCompactionProtectionSeconds.nonEmpty
         ).collect { case (flag, true) => flag }
         require(
           clientOnly.isEmpty,
@@ -106,6 +119,15 @@ object MilvusReadApp {
         )
       case other =>
         throw new IllegalArgumentException(s"Unsupported mode: $other")
+    }
+    args.clientSnapshotCompactionProtectionSeconds.foreach { seconds =>
+      require(
+        seconds > 0,
+        "--client-snapshot-compaction-protection-seconds must be positive"
+      )
+    }
+    args.snapshotMaxJsonBytes.foreach { bytes =>
+      require(bytes > 0, "--snapshot-max-json-bytes must be positive")
     }
   }
 
@@ -164,9 +186,17 @@ object MilvusReadApp {
       count = parsed.contains("count"),
       printSchema = parsed.contains("print-schema"),
       debugRead = parsed.contains("debug-read"),
+      clientSnapshotName = parsed.get("client-snapshot-name"),
+      clientSnapshotDescription = parsed.get("client-snapshot-description"),
+      clientSnapshotCompactionProtectionSeconds = parsed
+        .get("client-snapshot-compaction-protection-seconds")
+        .map(_.toLong),
+      snapshotMaxJsonBytes =
+        parsed.get("snapshot-max-json-bytes").map(_.toLong),
       select = parsed.get("select"),
       where = parsed.get("where"),
-      outputParquet = parsed.get("output-parquet")
+      outputParquet = parsed.get("output-parquet"),
+      sparkLogLevel = parsed.get("spark-log-level")
     )
     validateModeArgs(readArgs)
     readArgs
@@ -216,6 +246,18 @@ object MilvusReadApp {
     )
     args.fieldIds.foreach(v => opts += MilvusOption.ReaderFieldIDs -> v)
     args.extraColumns.foreach(v => opts += MilvusOption.MilvusExtraColumns -> v)
+    args.clientSnapshotName.foreach(v =>
+      opts += MilvusOption.ClientSnapshotName -> v
+    )
+    args.clientSnapshotDescription.foreach(v =>
+      opts += MilvusOption.ClientSnapshotDescription -> v
+    )
+    args.clientSnapshotCompactionProtectionSeconds.foreach(v =>
+      opts += MilvusOption.ClientSnapshotCompactionProtectionSeconds -> v.toString
+    )
+    args.snapshotMaxJsonBytes.foreach(v =>
+      opts += MilvusOption.SnapshotMaxJsonBytes -> v.toString
+    )
     if (args.debugRead) opts += MilvusOption.ReaderDebug -> "true"
 
     opts.toMap ++ buildStorageOptions(args)
@@ -258,6 +300,9 @@ object MilvusReadApp {
 
     args.fieldIds.foreach(v => opts += MilvusOption.ReaderFieldIDs -> v)
     args.extraColumns.foreach(v => opts += MilvusOption.MilvusExtraColumns -> v)
+    args.snapshotMaxJsonBytes.foreach(v =>
+      opts += MilvusOption.SnapshotMaxJsonBytes -> v.toString
+    )
     if (args.debugRead) opts += MilvusOption.ReaderDebug -> "true"
 
     opts.toMap ++ buildStorageOptions(args)
@@ -274,7 +319,10 @@ object MilvusReadApp {
     )
     configureHadoopS3A(hadoopConf, args)
 
-    val snapshotJson = readSnapshotJson(snapshotPath, hadoopConf)
+    val maxBytes = args.snapshotMaxJsonBytes.getOrElse(
+      MilvusSnapshotReader.MaxSnapshotJsonBytes
+    )
+    val snapshotJson = readSnapshotJson(snapshotPath, hadoopConf, maxBytes)
     val metadata =
       MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
         case Right(value) => value
@@ -310,24 +358,28 @@ object MilvusReadApp {
     else path
   }
 
-  private[tools] def readLocalSnapshotJson(path: String): String = {
+  private[tools] def readLocalSnapshotJson(
+      path: String,
+      maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes
+  ): String = {
     val in = new FileInputStream(path)
-    try MilvusSnapshotReader.readUtf8WithLimit(in, path)
+    try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
     finally in.close()
   }
 
   private[tools] def readSnapshotJson(
       path: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes
   ): String = {
     val normalized = normalizeSnapshotPath(path)
     if (!normalized.contains("://")) {
-      readLocalSnapshotJson(normalized)
+      readLocalSnapshotJson(normalized, maxBytes)
     } else {
       val uri = new URI(normalized)
       val fs = FileSystem.get(uri, hadoopConf)
       val in = fs.open(new Path(uri))
-      try MilvusSnapshotReader.readUtf8WithLimit(in, normalized)
+      try MilvusSnapshotReader.readUtf8WithLimit(in, normalized, maxBytes)
       finally in.close()
     }
   }
@@ -429,7 +481,7 @@ object MilvusReadApp {
     val spark = SparkSession.builder
       .appName("MilvusReadApp")
       .getOrCreate()
-    spark.sparkContext.setLogLevel("WARN")
+    args.sparkLogLevel.foreach(level => spark.sparkContext.setLogLevel(level))
 
     try {
       println(s"MilvusReadApp mode=${args.mode}")

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -322,17 +322,17 @@ object MilvusReadApp {
       df: DataFrame,
       args: ReadArgs
   ): DataFrame = {
-    val selected = args.select match {
+    val filtered = args.where match {
+      case Some(expr) if expr.trim.nonEmpty => df.where(expr)
+      case _                                => df
+    }
+
+    args.select match {
       case Some(raw) if raw.trim.nonEmpty =>
         val cols = raw.split(",").map(_.trim).filter(_.nonEmpty)
         require(cols.nonEmpty, "--select must contain at least one column")
-        df.select(cols.head, cols.tail: _*)
-      case _ => df
-    }
-
-    args.where match {
-      case Some(expr) if expr.trim.nonEmpty => selected.where(expr)
-      case _                                => selected
+        filtered.select(cols.head, cols.tail: _*)
+      case _ => filtered
     }
   }
 

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -7,6 +7,7 @@ import java.util.Base64
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.storage.StorageLevel
 
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
@@ -81,6 +82,33 @@ object MilvusReadApp {
 
   private[tools] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
 
+  private[tools] def validateModeArgs(args: ReadArgs): Unit = {
+    args.mode match {
+      case "client" =>
+        require(
+          args.snapshot.isEmpty,
+          "--snapshot is only valid in snapshot mode"
+        )
+      case "snapshot" =>
+        require(
+          args.snapshot.nonEmpty,
+          "--snapshot is required in snapshot mode"
+        )
+        val clientOnly = Seq(
+          "--milvus-uri" -> args.milvusUri.nonEmpty,
+          "--milvus-token" -> args.milvusToken.nonEmpty,
+          "--collection" -> args.collection.nonEmpty,
+          "--partition-name" -> args.partitionName.nonEmpty
+        ).collect { case (flag, true) => flag }
+        require(
+          clientOnly.isEmpty,
+          s"Snapshot mode does not accept client-only option(s): ${clientOnly.mkString(", ")}"
+        )
+      case other =>
+        throw new IllegalArgumentException(s"Unsupported mode: $other")
+    }
+  }
+
   private[tools] def parseArgs(args: Array[String]): ReadArgs = {
     val parsed = scala.collection.mutable.Map.empty[String, String]
     var i = 0
@@ -114,7 +142,7 @@ object MilvusReadApp {
       )
     }
 
-    ReadArgs(
+    val readArgs = ReadArgs(
       mode = mode,
       milvusUri = parsed.getOrElse("milvus-uri", ""),
       milvusToken = parsed.getOrElse("milvus-token", ""),
@@ -140,6 +168,8 @@ object MilvusReadApp {
       where = parsed.get("where"),
       outputParquet = parsed.get("output-parquet")
     )
+    validateModeArgs(readArgs)
+    readArgs
   }
 
   private[tools] def buildStorageOptions(
@@ -205,7 +235,6 @@ object MilvusReadApp {
 
     val opts = scala.collection.mutable.Map[String, String](
       MilvusOption.SnapshotMode -> "true",
-      MilvusOption.MilvusUri -> "dummy://snapshot-mode",
       MilvusOption.MilvusDatabaseName -> args.database,
       MilvusOption.MilvusCollectionName -> metadata.collection.schema.name,
       MilvusOption.SnapshotCollectionId -> metadata.snapshotInfo.collectionId.toString,
@@ -355,25 +384,43 @@ object MilvusReadApp {
   }
 
   private[tools] def runActions(df: DataFrame, args: ReadArgs): Unit = {
-    if (args.printSchema) {
-      println("\n=== Schema ===")
-      df.printSchema()
-    }
+    val dataActionCount = Seq(
+      args.show.map(_ => 1).getOrElse(0),
+      if (args.count) 1 else 0,
+      if (args.outputParquet.nonEmpty) 1 else 0
+    ).sum
+    val shouldCache = dataActionCount > 1
+    val actionDf =
+      if (shouldCache) df.persist(StorageLevel.MEMORY_AND_DISK) else df
+    var materializedCount = Option.empty[Long]
 
-    args.show.foreach { n =>
-      println(s"\n=== Showing $n row(s) ===")
-      df.show(n, truncate = false)
-    }
+    try {
+      if (shouldCache) {
+        materializedCount = Some(actionDf.count())
+      }
 
-    if (args.count) {
-      println("\n=== Count ===")
-      println(df.count())
-    }
+      if (args.printSchema) {
+        println("\n=== Schema ===")
+        actionDf.printSchema()
+      }
 
-    args.outputParquet.foreach { path =>
-      println(s"\n=== Writing parquet output to $path ===")
-      df.write.mode("overwrite").parquet(path)
-      println(s"Wrote parquet output to $path")
+      args.show.foreach { n =>
+        println(s"\n=== Showing $n row(s) ===")
+        actionDf.show(n, truncate = false)
+      }
+
+      if (args.count) {
+        println("\n=== Count ===")
+        println(materializedCount.getOrElse(actionDf.count()))
+      }
+
+      args.outputParquet.foreach { path =>
+        println(s"\n=== Writing parquet output to $path ===")
+        actionDf.write.mode("overwrite").parquet(path)
+        println(s"Wrote parquet output to $path")
+      }
+    } finally {
+      if (shouldCache) actionDf.unpersist()
     }
   }
 

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -217,12 +217,10 @@ object MilvusReadApp {
       )
     )
 
-    metadata.storageV2ManifestList.foreach { manifestList =>
-      if (manifestList.nonEmpty) {
-        opts += MilvusOption.SnapshotManifests ->
-          MilvusSnapshotReader.serializeManifestList(manifestList)
-      }
-    }
+    opts += MilvusOption.SnapshotManifests ->
+      MilvusSnapshotReader.serializeManifestList(
+        metadata.storageV2ManifestList.getOrElse(Seq.empty)
+      )
 
     if (v2Segments.nonEmpty) {
       opts += MilvusOption.SnapshotV2Segments ->

--- a/src/main/scala/tools/MilvusReadApp.scala
+++ b/src/main/scala/tools/MilvusReadApp.scala
@@ -202,6 +202,16 @@ object MilvusReadApp {
     readArgs
   }
 
+  private[tools] def credentialWarning(args: ReadArgs): Option[String] = {
+    if (args.s3AccessKey.nonEmpty || args.s3SecretKey.nonEmpty) {
+      Some(
+        "WARNING: S3 credentials passed on the command line may be visible in process listings and shell history; prefer --use-iam or environment credentials when possible."
+      )
+    } else {
+      None
+    }
+  }
+
   private[tools] def buildStorageOptions(
       args: ReadArgs
   ): Map[String, String] = {
@@ -210,10 +220,12 @@ object MilvusReadApp {
     val opts = scala.collection.mutable.Map[String, String](
       Properties.FsConfig.FsBucketName -> args.s3Bucket,
       Properties.FsConfig.FsRootPath -> args.s3RootPath,
-      Properties.FsConfig.FsRegion -> args.s3Region,
-      Properties.FsConfig.FsUseSSL -> args.s3UseSSL.toString
+      Properties.FsConfig.FsRegion -> args.s3Region
     )
 
+    if (args.s3UseSSL) {
+      opts += Properties.FsConfig.FsUseSSL -> "true"
+    }
     if (args.s3Endpoint.nonEmpty) {
       opts += Properties.FsConfig.FsAddress -> args.s3Endpoint
     }
@@ -478,6 +490,7 @@ object MilvusReadApp {
 
   def main(rawArgs: Array[String]): Unit = {
     val args = parseArgs(rawArgs)
+    credentialWarning(args).foreach(System.err.println)
     val spark = SparkSession.builder
       .appName("MilvusReadApp")
       .getOrCreate()

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -218,6 +218,11 @@ class MilvusLoonPartitionWriter(
 
   // Batch size configuration
   private val batchSize = milvusOption.insertMaxBatchSize
+  private val variableWidthBytesPerValue =
+    parsePositiveDoubleOption(
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 256.0
+    )
   private var currentBatchSize = 0
   private var totalRecordCount = 0L
 
@@ -444,12 +449,18 @@ class MilvusLoonPartitionWriter(
           // Second arg is density (bytes per value), NOT total bytes. Arrow
           // computes the initial data buffer size as valueCount × density
           // internally. Passing `batchSize * 32` here gave batchSize² × 32 —
-          // a quadratic over-allocation (~32 MiB per column at batch=1024)
-          // that exploded into GiB-scale peaks and caused direct-memory OOM.
-          varCharVector.setInitialCapacity(batchSize, 32.0)
+          // a quadratic over-allocation. Use a bounded per-value default that
+          // can be raised for wide JSON/VARCHAR workloads.
+          varCharVector.setInitialCapacity(
+            batchSize,
+            variableWidthBytesPerValue
+          )
 
         case baseVarVector: BaseVariableWidthVector =>
-          baseVarVector.setInitialCapacity(batchSize, 32.0)
+          baseVarVector.setInitialCapacity(
+            batchSize,
+            variableWidthBytesPerValue
+          )
 
         case _ =>
           // For fixed-width vectors, just set row capacity
@@ -459,6 +470,30 @@ class MilvusLoonPartitionWriter(
 
     r.allocateNew()
     r.setRowCount(0)
+  }
+
+  private def parsePositiveDoubleOption(
+      key: String,
+      defaultValue: Double
+  ): Double = {
+    milvusOption.options
+      .get(key)
+      .orElse(milvusOption.options.get(key.toLowerCase))
+      .filter(_.trim.nonEmpty)
+      .map { value =>
+        val parsed = Try(value.trim.toDouble).getOrElse {
+          throw new IllegalArgumentException(
+            s"$key must be a positive number, got '$value'"
+          )
+        }
+        if (parsed <= 0.0) {
+          throw new IllegalArgumentException(
+            s"$key must be a positive number, got '$value'"
+          )
+        }
+        parsed
+      }
+      .getOrElse(defaultValue)
   }
 
   /** Generate S3 base path for this writer

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -221,7 +221,7 @@ class MilvusLoonPartitionWriter(
   private val variableWidthBytesPerValue =
     parsePositiveDoubleOption(
       MilvusOption.WriterVariableWidthBytesPerValue,
-      defaultValue = 256.0
+      defaultValue = 32.0
     )
   private var currentBatchSize = 0
   private var totalRecordCount = 0L

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -477,8 +477,7 @@ class MilvusLoonPartitionWriter(
       defaultValue: Double
   ): Double = {
     milvusOption.options
-      .get(key)
-      .orElse(milvusOption.options.get(key.toLowerCase))
+      .get(key.toLowerCase)
       .filter(_.trim.nonEmpty)
       .map { value =>
         val parsed = Try(value.trim.toDouble).getOrElse {

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -176,6 +176,30 @@ object MilvusLoonPartitionWriter {
       doWrite
     }
   }
+
+  private[connector] def parsePositiveDoubleOption(
+      options: scala.collection.Map[String, String],
+      key: String,
+      defaultValue: Double
+  ): Double = {
+    options
+      .get(key.toLowerCase)
+      .filter(_.trim.nonEmpty)
+      .map { value =>
+        val parsed = Try(value.trim.toDouble).getOrElse {
+          throw new IllegalArgumentException(
+            s"$key must be a finite positive number, got '$value'"
+          )
+        }
+        if (!java.lang.Double.isFinite(parsed) || parsed <= 0.0) {
+          throw new IllegalArgumentException(
+            s"$key must be a finite positive number, got '$value'"
+          )
+        }
+        parsed
+      }
+      .getOrElse(defaultValue)
+  }
 }
 
 /** Partition writer using Storage V2 FFI
@@ -219,7 +243,8 @@ class MilvusLoonPartitionWriter(
   // Batch size configuration
   private val batchSize = milvusOption.insertMaxBatchSize
   private val variableWidthBytesPerValue =
-    parsePositiveDoubleOption(
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      milvusOption.options,
       MilvusOption.WriterVariableWidthBytesPerValue,
       defaultValue = 32.0
     )
@@ -472,29 +497,6 @@ class MilvusLoonPartitionWriter(
     r.setRowCount(0)
   }
 
-  private def parsePositiveDoubleOption(
-      key: String,
-      defaultValue: Double
-  ): Double = {
-    milvusOption.options
-      .get(key.toLowerCase)
-      .filter(_.trim.nonEmpty)
-      .map { value =>
-        val parsed = Try(value.trim.toDouble).getOrElse {
-          throw new IllegalArgumentException(
-            s"$key must be a positive number, got '$value'"
-          )
-        }
-        if (parsed <= 0.0) {
-          throw new IllegalArgumentException(
-            s"$key must be a positive number, got '$value'"
-          )
-        }
-        parsed
-      }
-      .getOrElse(defaultValue)
-  }
-
   /** Generate S3 base path for this writer
     *
     * For S3FileSystem, the path format should be: bucket/root_path/... Arrow
@@ -636,6 +638,8 @@ object MilvusLoonWriter extends Logging {
     *   - fs.root_path: Root path in bucket (default: "files")
     *   - milvus.collection.name: Collection name for path generation
     *   - vector.{field_name}.dim: Vector dimension for float array fields
+    *   - milvus.writer.variableWidthBytesPerValue: initial bytes per
+    *     variable-width value (default: 32.0)
     * @return
     *   Try containing manifest paths on success
     */

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -107,11 +107,11 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     assert(MilvusClient.isServiceNotImplemented(err))
   }
 
-  test("classifies textual service not implemented errors") {
+  test("does not classify non-grpc service-not-implemented text") {
     val err = new RuntimeException(
       "Failed to createSnapshot: service not implemented"
     )
-    assert(MilvusClient.isServiceNotImplemented(err))
+    assert(!MilvusClient.isServiceNotImplemented(err))
   }
 
   test("does not classify ordinary errors as service not implemented") {

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -126,4 +126,16 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
       new RuntimeException("Feature X is unimplemented for storage backend Y")
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
+
+  test("does not classify non-grpc unknown method text as service not implemented") {
+    val err = new RuntimeException("proxy returned unknown method in response body")
+    assert(!MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test("classifies grpc unknown method text as service not implemented") {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNKNOWN.withDescription("unknown method CreateSnapshot")
+    )
+    assert(MilvusClient.isServiceNotImplemented(err))
+  }
 }

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import io.milvus.grpc.common.{ErrorCode, Status}
 
+import io.grpc.{Status => GrpcStatus, StatusRuntimeException}
+
 /** Unit tests for MilvusClient.checkStatus classification logic.
   *
   * Covers the review feedback on ordering, NPE safety, success-path
@@ -96,5 +98,24 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
       reason = "something broke"
     )
     assert(client.checkStatus("insert", status).isFailure)
+  }
+
+  test("classifies grpc UNIMPLEMENTED as service not implemented") {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNIMPLEMENTED.withDescription("unknown method CreateSnapshot")
+    )
+    assert(MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test("classifies textual service not implemented errors") {
+    val err = new RuntimeException(
+      "Failed to createSnapshot: service not implemented"
+    )
+    assert(MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test("does not classify ordinary errors as service not implemented") {
+    val err = new RuntimeException("permission denied")
+    assert(!MilvusClient.isServiceNotImplemented(err))
   }
 }

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -135,11 +135,40 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
 
-  test("classifies grpc unknown method text as service not implemented") {
+  test("classifies grpc snapshot unknown method as service not implemented") {
     val err = new StatusRuntimeException(
       GrpcStatus.UNKNOWN.withDescription("unknown method CreateSnapshot")
     )
     assert(MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test(
+    "classifies grpc snapshot method-not-registered as service not implemented"
+  ) {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNKNOWN.withDescription(
+        "method not registered: DescribeSnapshot"
+      )
+    )
+    assert(MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test("does not classify grpc unknown method for unrelated RPC") {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNKNOWN.withDescription("unknown method SomeOtherMethod")
+    )
+    assert(!MilvusClient.isServiceNotImplemented(err))
+  }
+
+  test(
+    "does not classify unrelated grpc UNKNOWN text as service not implemented"
+  ) {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNKNOWN.withDescription(
+        "service not implemented for health check"
+      )
+    )
+    assert(!MilvusClient.isServiceNotImplemented(err))
   }
 
   test("service-not-implemented detection stops on cyclic causes") {

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -127,8 +127,11 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
 
-  test("does not classify non-grpc unknown method text as service not implemented") {
-    val err = new RuntimeException("proxy returned unknown method in response body")
+  test(
+    "does not classify non-grpc unknown method text as service not implemented"
+  ) {
+    val err =
+      new RuntimeException("proxy returned unknown method in response body")
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
 

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -118,4 +118,12 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     val err = new RuntimeException("permission denied")
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
+
+  test(
+    "does not classify unrelated unimplemented messages as service not implemented"
+  ) {
+    val err =
+      new RuntimeException("Feature X is unimplemented for storage backend Y")
+    assert(!MilvusClient.isServiceNotImplemented(err))
+  }
 }

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -141,4 +141,11 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     )
     assert(MilvusClient.isServiceNotImplemented(err))
   }
+
+  test("service-not-implemented detection stops on cyclic causes") {
+    val err = new RuntimeException("ordinary error") {
+      override def getCause: Throwable = this
+    }
+    assert(!MilvusClient.isServiceNotImplemented(err))
+  }
 }

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -75,6 +75,19 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     milvusOption.extraColumns.size shouldBe 3
   }
 
+  test("Normalize legacy extra column names") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusExtraColumns -> "partition, segment_id, row_offset"
+    )
+
+    val milvusOption = MilvusOption(options)
+
+    milvusOption.extraColumns should contain allOf ("partition", "$segment_id", "$row_offset")
+    milvusOption.extraColumns should not contain "segment_id"
+    milvusOption.extraColumns should not contain "row_offset"
+  }
+
   test("Parse empty extra columns") {
     val options = Map(
       MilvusOption.MilvusUri -> "http://localhost:19530",

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -78,7 +78,7 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     milvusOption.extraColumns.size shouldBe 3
   }
 
-  test("Normalize legacy extra column names") {
+  test("Parse extra columns without rewriting user field names") {
     val options = Map(
       MilvusOption.MilvusUri -> "http://localhost:19530",
       MilvusOption.MilvusExtraColumns -> "partition, segment_id, row_offset"
@@ -86,9 +86,9 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     val milvusOption = MilvusOption(options)
 
-    milvusOption.extraColumns should contain allOf ("partition", "$segment_id", "$row_offset")
-    milvusOption.extraColumns should not contain "segment_id"
-    milvusOption.extraColumns should not contain "row_offset"
+    milvusOption.extraColumns should contain allOf ("partition", "segment_id", "row_offset")
+    milvusOption.extraColumns should not contain "$segment_id"
+    milvusOption.extraColumns should not contain "$row_offset"
   }
 
   test("Parse empty extra columns") {
@@ -249,6 +249,19 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     milvusOption.options should contain key "custom.option"
     milvusOption.options("custom.option") shouldBe "custom_value"
+  }
+
+  test("configureHadoopS3A preserves existing global S3A implementation") {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set("fs.s3a.impl", "com.example.CustomS3AFileSystem")
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(MilvusOption.FsBucketName -> "bucket"),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.impl") shouldBe "com.example.CustomS3AFileSystem"
   }
 }
 

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -1,5 +1,8 @@
 package com.zilliz.spark.connector
 
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -213,6 +216,26 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     milvusOption.clientKeyPath shouldBe "/path/to/client.key"
     milvusOption.clientPemPath shouldBe "/path/to/client.pem"
     milvusOption.caPemPath shouldBe "/path/to/ca.pem"
+  }
+
+  test("isSnapshotMode recognizes all snapshot mode hints") {
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotMode -> "true")
+    ) shouldBe true
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotManifests -> "[]")
+    ) shouldBe true
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotV2Segments -> "[]")
+    ) shouldBe true
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.MilvusUri -> "http://localhost:19530")
+    ) shouldBe false
+
+    val caseInsensitive = new CaseInsensitiveStringMap(
+      Map(MilvusOption.SnapshotMode.toUpperCase -> "TRUE").asJava
+    )
+    MilvusOption.isSnapshotMode(caseInsensitive) shouldBe true
   }
 
   test("Options map is preserved") {

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -66,12 +66,12 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
   test("Parse extra columns configuration") {
     val options = Map(
       MilvusOption.MilvusUri -> "http://localhost:19530",
-      MilvusOption.MilvusExtraColumns -> "partition, segment_id, row_offset"
+      MilvusOption.MilvusExtraColumns -> "partition, $segment_id, $row_offset"
     )
 
     val milvusOption = MilvusOption(options)
 
-    milvusOption.extraColumns should contain allOf ("partition", "segment_id", "row_offset")
+    milvusOption.extraColumns should contain allOf ("partition", "$segment_id", "$row_offset")
     milvusOption.extraColumns.size shouldBe 3
   }
 

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -263,6 +263,92 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     conf.get("fs.s3a.impl") shouldBe "com.example.CustomS3AFileSystem"
   }
+
+  test("configureHadoopS3A preserves existing bucket path style") {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set("fs.s3a.bucket.bucket.path.style.access", "false")
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(MilvusOption.FsBucketName -> "bucket"),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.bucket.bucket.path.style.access") shouldBe "false"
+  }
+
+  test("configureHadoopS3A preserves existing bucket SSL setting") {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set("fs.s3a.bucket.bucket.connection.ssl.enabled", "true")
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(MilvusOption.FsBucketName -> "bucket"),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.bucket.bucket.connection.ssl.enabled") shouldBe "true"
+  }
+
+  test(
+    "configureHadoopS3A explicit SSL option overrides existing bucket setting"
+  ) {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set("fs.s3a.bucket.bucket.connection.ssl.enabled", "true")
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(
+        MilvusOption.FsBucketName -> "bucket",
+        com.zilliz.spark.connector.loon.Properties.FsConfig.FsUseSSL -> "false"
+      ),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.bucket.bucket.connection.ssl.enabled") shouldBe "false"
+  }
+
+  test(
+    "configureHadoopS3A preserves existing credentials provider when implicit"
+  ) {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set(
+      "fs.s3a.bucket.bucket.aws.credentials.provider",
+      "com.example.CustomCredentialsProvider"
+    )
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(MilvusOption.FsBucketName -> "bucket"),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.bucket.bucket.aws.credentials.provider") shouldBe
+      "com.example.CustomCredentialsProvider"
+  }
+
+  test("configureHadoopS3A explicit static credentials override provider") {
+    val conf = new org.apache.hadoop.conf.Configuration()
+    conf.set(
+      "fs.s3a.bucket.bucket.aws.credentials.provider",
+      "com.example.CustomCredentialsProvider"
+    )
+
+    MilvusOption.configureHadoopS3A(
+      conf,
+      Map(
+        MilvusOption.FsBucketName -> "bucket",
+        com.zilliz.spark.connector.loon.Properties.FsConfig.FsAccessKeyId -> "ak",
+        com.zilliz.spark.connector.loon.Properties.FsConfig.FsAccessKeyValue -> "sk"
+      ),
+      "bucket"
+    )
+
+    conf.get("fs.s3a.bucket.bucket.access.key") shouldBe "ak"
+    conf.get("fs.s3a.bucket.bucket.secret.key") shouldBe "sk"
+    conf.get("fs.s3a.bucket.bucket.aws.credentials.provider") shouldBe
+      "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  }
 }
 
 /** Unit tests for MilvusS3Option

--- a/src/test/scala/loon/MilvusLoonWriterTest.scala
+++ b/src/test/scala/loon/MilvusLoonWriterTest.scala
@@ -6,10 +6,35 @@ import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import com.zilliz.spark.connector.write.MilvusLoonWriter
+import com.zilliz.spark.connector.write.{
+  MilvusLoonPartitionWriter,
+  MilvusLoonWriter
+}
 import com.zilliz.spark.connector.MilvusOption
 
 class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
+
+  test("parsePositiveDoubleOption rejects NaN and Infinity") {
+    Seq("NaN", "Infinity", "-Infinity").foreach { value =>
+      an[IllegalArgumentException] should be thrownBy {
+        MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+          Map(
+            MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> value
+          ),
+          MilvusOption.WriterVariableWidthBytesPerValue,
+          defaultValue = 32.0
+        )
+      }
+    }
+  }
+
+  test("parsePositiveDoubleOption accepts finite positive values") {
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      Map(MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> "64.5"),
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 32.0
+    ) shouldBe 64.5
+  }
 
   test("Write DataFrame using Loon Writer to Minio") {
     val spark = SparkSession

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -196,4 +196,18 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     Properties.FsConfig.FsUseSSL should not be empty
     Properties.FsConfig.FsRegion should not be empty
   }
+
+  test("fromMilvusOption requires bucket name in IAM mode") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      Properties.FsConfig.FsUseIam -> "true"
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      Properties.fromMilvusOption(MilvusOption(options))
+    }
+
+    err.getMessage should include(Properties.FsConfig.FsBucketName)
+    err.getMessage should include(Properties.FsConfig.FsUseIam)
+  }
 }

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -84,6 +84,12 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     }
   }
 
+  test("parseArgs throws when key flag value is another flag") {
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.parseArgs(Array("--mode", "--snapshot"))
+    }
+  }
+
   test("parseArgs throws on unexpected positional arg") {
     an[IllegalArgumentException] should be thrownBy {
       BackfillApp.parseArgs(Array("oops"))

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -243,7 +243,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     options("milvus.token") shouldBe "root:Milvus"
     options("milvus.database.name") shouldBe "my_database"
     options("milvus.collection.name") shouldBe "test_collection"
-    options("milvus.extra.columns") shouldBe "segment_id,row_offset"
+    options("milvus.extra.columns") shouldBe "$segment_id,$row_offset"
     options("fs.address") shouldBe "localhost:9000"
     options("fs.bucket_name") shouldBe "test-bucket"
     options("fs.root_path") shouldBe "data/milvus"

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -110,14 +110,14 @@ class BackfillModeTest
   private def buildOriginal(
       rows: Seq[(Int, java.lang.Integer, java.lang.String, Long, Long)]
   ): DataFrame = {
-    // columns: pk, f1 (nullable Int), f2 (nullable String), segment_id, row_offset
+    // columns: pk, f1 (nullable Int), f2 (nullable String), $segment_id, $row_offset
     val schema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
         StructField("f1", IntegerType, nullable = true),
         StructField("f2", StringType, nullable = true),
-        StructField("segment_id", LongType, nullable = false),
-        StructField("row_offset", LongType, nullable = false)
+        StructField("$segment_id", LongType, nullable = false),
+        StructField("$row_offset", LongType, nullable = false)
       )
     )
     val javaRows = rows.map { case (pk, f1, f2, seg, off) =>
@@ -144,8 +144,8 @@ class BackfillModeTest
     val originalSchema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
-        StructField("segment_id", LongType, nullable = false),
-        StructField("row_offset", LongType, nullable = false)
+        StructField("$segment_id", LongType, nullable = false),
+        StructField("$row_offset", LongType, nullable = false)
       )
     )
     val originalRows = Seq(Row(1, 10L, 0L), Row(2, 10L, 1L), Row(3, 10L, 2L))
@@ -226,8 +226,8 @@ class BackfillModeTest
       "pk",
       "f1",
       "f2",
-      "segment_id",
-      "row_offset",
+      "$segment_id",
+      "$row_offset",
       MilvusBackfill.MatchFlagCol,
       MilvusBackfill.usedSrcCol("f1"),
       MilvusBackfill.usedBfCol("f1"),
@@ -450,8 +450,8 @@ class BackfillModeTest
       "pk",
       "f1",
       "f2",
-      "segment_id",
-      "row_offset",
+      "$segment_id",
+      "$row_offset",
       MilvusBackfill.MatchFlagCol,
       MilvusBackfill.usedSrcCol("f1"),
       MilvusBackfill.usedBfCol("f1"),

--- a/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
@@ -1,0 +1,46 @@
+package com.zilliz.spark.connector.read
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
+
+class MilvusLoonPartitionReaderTest extends AnyFunSuite {
+  test("buildFieldNameToId exposes non-conflicting system aliases") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+
+    val mapping = MilvusLoonPartitionReader.buildFieldNameToId(schema)
+
+    assert(mapping("RowID") == 0L)
+    assert(mapping("row_id") == 0L)
+    assert(mapping("rowid") == 0L)
+    assert(mapping("Timestamp") == 1L)
+    assert(mapping("timestamp") == 1L)
+    assert(mapping("pk") == 100L)
+  }
+
+  test("buildFieldNameToId preserves user fields that use system alias names") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "Timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        ),
+        FieldSchema(name = "rowid", fieldID = 102, dataType = DataType.Int64)
+      )
+    )
+
+    val mapping = MilvusLoonPartitionReader.buildFieldNameToId(schema)
+
+    assert(mapping("RowID") == 100L)
+    assert(mapping("Timestamp") == 101L)
+    assert(mapping("rowid") == 102L)
+    assert(mapping("row_id") == 0L)
+    assert(mapping("timestamp") == 1L)
+  }
+}

--- a/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
@@ -30,6 +30,59 @@ class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
     assert(mappings.fieldNameToArrowColumn("Timestamp") == "Timestamp")
   }
 
+  test("system aliases are omitted when user fields use canonical names") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "Timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        ),
+        FieldSchema(name = "rowid", fieldID = 102, dataType = DataType.Int64)
+      )
+    )
+
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+
+    assert(mappings.fieldNameToId("RowID") == 100L)
+    assert(mappings.fieldNameToId("Timestamp") == 101L)
+    assert(mappings.fieldNameToId("rowid") == 102L)
+    assert(mappings.fieldNameToId("row_id") == 0L)
+    assert(mappings.fieldNameToId("timestamp") == 1L)
+    assert(!mappings.fieldNameToArrowColumn.contains("RowID"))
+    assert(!mappings.fieldNameToArrowColumn.contains("Timestamp"))
+    assert(!mappings.fieldNameToArrowColumn.contains("rowid"))
+    assert(mappings.fieldNameToArrowColumn("row_id") == "RowID")
+    assert(mappings.fieldNameToArrowColumn("timestamp") == "Timestamp")
+  }
+
+  test("resolveNeededColumns uses exact user names before system aliases") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(Seq(StructField("RowID", LongType)))
+    val columnGroups = Seq(
+      V2ColumnGroup(
+        fieldIds = Seq(100L),
+        filePaths = Seq("s3a://bucket/files/insert_log/1/2/3/100/1"),
+        fileRowCounts = Seq(1L)
+      )
+    )
+
+    val columns = MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups,
+      mappings,
+      neededColumnFieldIds = Seq.empty
+    )
+
+    assert(columns.toSeq == Seq("RowID"))
+  }
+
   test(
     "resolveNeededColumns fails when requested field is absent from V2 column groups"
   ) {

--- a/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.read
 
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
@@ -27,5 +28,41 @@ class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
     assert(!mappings.fieldNameToArrowColumn.contains("timestamp"))
     assert(mappings.fieldNameToArrowColumn("RowID") == "RowID")
     assert(mappings.fieldNameToArrowColumn("Timestamp") == "Timestamp")
+  }
+
+  test(
+    "resolveNeededColumns fails when requested field is absent from V2 column groups"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(name = "value", fieldID = 101, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(
+      Seq(
+        StructField("pk", LongType),
+        StructField("value", LongType)
+      )
+    )
+    val columnGroups = Seq(
+      V2ColumnGroup(
+        fieldIds = Seq(100L),
+        filePaths = Seq("s3a://bucket/files/insert_log/1/2/3/100/1"),
+        fileRowCounts = Seq(1L)
+      )
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      MilvusPackedV2PartitionReader.resolveNeededColumns(
+        sourceSchema,
+        columnGroups,
+        mappings,
+        neededColumnFieldIds = Seq(100L, 101L)
+      )
+    }
+
+    assert(err.getMessage.contains("do not contain requested columns: value"))
   }
 }

--- a/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
@@ -1,0 +1,31 @@
+package com.zilliz.spark.connector.read
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
+
+class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
+  test(
+    "lowercase system aliases are omitted when user fields use those names"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "row_id", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        )
+      )
+    )
+
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+
+    assert(mappings.fieldNameToId("row_id") == 100L)
+    assert(mappings.fieldNameToId("timestamp") == 101L)
+    assert(!mappings.fieldNameToArrowColumn.contains("row_id"))
+    assert(!mappings.fieldNameToArrowColumn.contains("timestamp"))
+    assert(mappings.fieldNameToArrowColumn("RowID") == "RowID")
+    assert(mappings.fieldNameToArrowColumn("Timestamp") == "Timestamp")
+  }
+}

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -2,6 +2,8 @@ package com.zilliz.spark.connector.read
 
 import java.io.ByteArrayInputStream
 
+import com.fasterxml.jackson.databind.node.IntNode
+import org.apache.spark.sql.types.DataTypes
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -19,6 +21,42 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     }
 
     err.getMessage should include("exceeds maximum supported size")
+  }
+
+  test("toSparkSchema maps vector enum values using Milvus proto codes") {
+    val schema = CollectionSchema(
+      name = "c",
+      fields = Seq(
+        Field(name = "binary", rawDataType = Some(IntNode.valueOf(100))),
+        Field(name = "float", rawDataType = Some(IntNode.valueOf(101))),
+        Field(name = "float16", rawDataType = Some(IntNode.valueOf(102))),
+        Field(name = "bfloat16", rawDataType = Some(IntNode.valueOf(103))),
+        Field(name = "sparse", rawDataType = Some(IntNode.valueOf(104))),
+        Field(name = "int8", rawDataType = Some(IntNode.valueOf(105)))
+      )
+    )
+
+    val sparkSchema = MilvusSnapshotReader.toSparkSchema(schema)
+
+    sparkSchema("binary").dataType shouldBe DataTypes.createArrayType(
+      DataTypes.BinaryType
+    )
+    sparkSchema("float").dataType shouldBe DataTypes.createArrayType(
+      DataTypes.FloatType
+    )
+    sparkSchema("float16").dataType shouldBe DataTypes.createArrayType(
+      DataTypes.FloatType
+    )
+    sparkSchema("bfloat16").dataType shouldBe DataTypes.createArrayType(
+      DataTypes.FloatType
+    )
+    sparkSchema("sparse").dataType shouldBe DataTypes.createMapType(
+      DataTypes.LongType,
+      DataTypes.FloatType
+    )
+    sparkSchema("int8").dataType shouldBe DataTypes.createArrayType(
+      DataTypes.ShortType
+    )
   }
 
   test("Parse complete snapshot metadata successfully") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -39,7 +39,7 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     val sparkSchema = MilvusSnapshotReader.toSparkSchema(schema)
 
     sparkSchema("binary").dataType shouldBe DataTypes.createArrayType(
-      DataTypes.BinaryType
+      DataTypes.ByteType
     )
     sparkSchema("float").dataType shouldBe DataTypes.createArrayType(
       DataTypes.FloatType

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -1,5 +1,7 @@
 package com.zilliz.spark.connector.read
 
+import java.io.ByteArrayInputStream
+
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -8,6 +10,16 @@ import org.scalatest.matchers.should.Matchers
 class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
 
   private val snapshotFilePath = "src/test/data/sample_snapshot.json"
+
+  test("readUtf8WithLimit rejects oversized snapshot metadata") {
+    val in = new ByteArrayInputStream("abcdef".getBytes("UTF-8"))
+
+    val err = intercept[IllegalArgumentException] {
+      MilvusSnapshotReader.readUtf8WithLimit(in, "snapshot.json", maxBytes = 5)
+    }
+
+    err.getMessage should include("exceeds maximum supported size")
+  }
 
   test("Parse complete snapshot metadata successfully") {
     val result =
@@ -300,12 +312,14 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
       includeSystemFields = true
     )
 
-    // Should have 7 fields (including RowID and Timestamp)
+    // Should have 7 fields (including row_id and timestamp)
     sparkSchema.fields should have size 7
 
     // Verify field names
     val fieldNames = sparkSchema.fields.map(_.name)
-    fieldNames should contain allOf ("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
+    fieldNames should contain allOf ("row_id", "timestamp", "id", "int64", "float", "varchar", "vector")
+    fieldNames should not contain "RowID"
+    fieldNames should not contain "Timestamp"
   }
 
   test("Get field ID to name mapping") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -312,14 +312,12 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
       includeSystemFields = true
     )
 
-    // Should have 7 fields (including row_id and timestamp)
+    // Should have 7 fields (including RowID and Timestamp)
     sparkSchema.fields should have size 7
 
     // Verify field names
     val fieldNames = sparkSchema.fields.map(_.name)
-    fieldNames should contain allOf ("row_id", "timestamp", "id", "int64", "float", "varchar", "vector")
-    fieldNames should not contain "RowID"
-    fieldNames should not contain "Timestamp"
+    fieldNames should contain allOf ("id", "int64", "float", "varchar", "vector", "RowID", "Timestamp")
   }
 
   test("Get field ID to name mapping") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -38,9 +38,7 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
 
     val sparkSchema = MilvusSnapshotReader.toSparkSchema(schema)
 
-    sparkSchema("binary").dataType shouldBe DataTypes.createArrayType(
-      DataTypes.ByteType
-    )
+    sparkSchema("binary").dataType shouldBe DataTypes.BinaryType
     sparkSchema("float").dataType shouldBe DataTypes.createArrayType(
       DataTypes.FloatType
     )

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -46,4 +46,38 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
       allocator.close()
     }
   }
+
+  test("arrowToInternalRow rejects non UTF-8 VarBinary as Spark StringType") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val arrowField = new Field(
+      "103",
+      FieldType.nullable(new ArrowType.Binary()),
+      null
+    )
+    val root =
+      VectorSchemaRoot.create(new Schema(Seq(arrowField).asJava), allocator)
+
+    try {
+      val vector = root.getVector("103").asInstanceOf[VarBinaryVector]
+      vector.allocateNew()
+      vector.setSafe(0, Array[Byte](0xc3.toByte, 0x28.toByte))
+      vector.setValueCount(1)
+      root.setRowCount(1)
+
+      val sparkSchema = StructType(Seq(StructField("$meta", StringType, true)))
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          sparkSchema,
+          Map("$meta" -> "103")
+        )
+      }
+
+      err.getMessage should include("not valid UTF-8")
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
 }

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -1,15 +1,18 @@
 package com.zilliz.spark.connector.serde
 
+import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
 
 import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.{FixedSizeBinaryVector, VarBinaryVector}
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
-import org.apache.arrow.vector.VarBinaryVector
 import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import com.zilliz.spark.connector.FloatConverter
 
 class ArrowConverterTest extends AnyFunSuite with Matchers {
   test("arrowToInternalRow reads Spark StringType from Arrow VarBinaryVector") {
@@ -75,6 +78,123 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
       }
 
       err.getMessage should include("not valid UTF-8")
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  test("arrowToInternalRow reads BinaryVector from FixedSizeBinary as bytes") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val arrowField = new Field(
+      "100",
+      FieldType.nullable(new ArrowType.FixedSizeBinary(2)),
+      null
+    )
+    val root =
+      VectorSchemaRoot.create(new Schema(Seq(arrowField).asJava), allocator)
+
+    try {
+      val vector = root.getVector("100").asInstanceOf[FixedSizeBinaryVector]
+      vector.allocateNew()
+      vector.set(0, Array[Byte](0x01.toByte, 0x02.toByte))
+      vector.setValueCount(1)
+      root.setRowCount(1)
+
+      val sparkSchema =
+        StructType(Seq(StructField("binary", ArrayType(ByteType))))
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        sparkSchema,
+        Map("binary" -> "100")
+      )
+
+      row.getArray(0).toByteArray().toSeq shouldBe Seq(1.toByte, 2.toByte)
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  test("arrowToInternalRow decodes Float16Vector from FixedSizeBinary") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val arrowField = new Field(
+      "102",
+      new FieldType(
+        true,
+        new ArrowType.FixedSizeBinary(4),
+        null,
+        Map("milvus_data_type" -> "102").asJava
+      ),
+      null
+    )
+    val root =
+      VectorSchemaRoot.create(new Schema(Seq(arrowField).asJava), allocator)
+
+    try {
+      val vector = root.getVector("102").asInstanceOf[FixedSizeBinaryVector]
+      vector.allocateNew()
+      vector.set(
+        0,
+        (FloatConverter.toFloat16Bytes(1.5f) ++ FloatConverter
+          .toFloat16Bytes(-2.0f)).toArray
+      )
+      vector.setValueCount(1)
+      root.setRowCount(1)
+
+      val sparkSchema =
+        StructType(Seq(StructField("float16", ArrayType(FloatType))))
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        sparkSchema,
+        Map("float16" -> "102")
+      )
+
+      row.getArray(0).toFloatArray.toSeq shouldBe Seq(1.5f, -2.0f)
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+
+  test("arrowToInternalRow decodes BFloat16Vector from FixedSizeBinary") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val arrowField = new Field(
+      "103",
+      new FieldType(
+        true,
+        new ArrowType.FixedSizeBinary(4),
+        null,
+        Map("milvus_data_type" -> "103").asJava
+      ),
+      null
+    )
+    val root =
+      VectorSchemaRoot.create(new Schema(Seq(arrowField).asJava), allocator)
+
+    try {
+      val vector = root.getVector("103").asInstanceOf[FixedSizeBinaryVector]
+      vector.allocateNew()
+      vector.set(
+        0,
+        (FloatConverter.toBFloat16Bytes(1.5f) ++ FloatConverter
+          .toBFloat16Bytes(-2.0f)).toArray
+      )
+      vector.setValueCount(1)
+      root.setRowCount(1)
+
+      val sparkSchema =
+        StructType(Seq(StructField("bfloat16", ArrayType(FloatType))))
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        sparkSchema,
+        Map("bfloat16" -> "103")
+      )
+
+      row.getArray(0).toFloatArray.toSeq shouldBe Seq(1.5f, -2.0f)
     } finally {
       root.close()
       allocator.close()

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -1,0 +1,49 @@
+package com.zilliz.spark.connector.serde
+
+import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.arrow.vector.VarBinaryVector
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ArrowConverterTest extends AnyFunSuite with Matchers {
+  test("arrowToInternalRow reads Spark StringType from Arrow VarBinaryVector") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    val arrowField = new Field(
+      "103",
+      FieldType.nullable(new ArrowType.Binary()),
+      null
+    )
+    val root =
+      VectorSchemaRoot.create(new Schema(Seq(arrowField).asJava), allocator)
+
+    try {
+      val vector = root.getVector("103").asInstanceOf[VarBinaryVector]
+      vector.allocateNew()
+      vector.setSafe(
+        0,
+        "{\"source\":\"json\"}".getBytes(StandardCharsets.UTF_8)
+      )
+      vector.setValueCount(1)
+      root.setRowCount(1)
+
+      val sparkSchema = StructType(Seq(StructField("$meta", StringType, true)))
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        sparkSchema,
+        Map("$meta" -> "103")
+      )
+
+      row.getUTF8String(0).toString shouldBe "{\"source\":\"json\"}"
+    } finally {
+      root.close()
+      allocator.close()
+    }
+  }
+}

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -97,12 +97,12 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
     try {
       val vector = root.getVector("100").asInstanceOf[FixedSizeBinaryVector]
       vector.allocateNew()
-      vector.set(0, Array[Byte](0x01.toByte, 0x02.toByte))
+      vector.set(0, Array[Byte](0x01.toByte, 0xff.toByte))
       vector.setValueCount(1)
       root.setRowCount(1)
 
       val sparkSchema =
-        StructType(Seq(StructField("binary", ArrayType(ByteType))))
+        StructType(Seq(StructField("binary", BinaryType)))
       val row = ArrowConverter.arrowToInternalRow(
         root,
         0,
@@ -110,7 +110,7 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
         Map("binary" -> "100")
       )
 
-      row.getArray(0).toByteArray().toSeq shouldBe Seq(1.toByte, 2.toByte)
+      row.getBinary(0).toSeq shouldBe Seq(1.toByte, 0xff.toByte)
     } finally {
       root.close()
       allocator.close()

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -200,10 +200,10 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     result shouldBe DataTypes.createArrayType(DataTypes.FloatType)
   }
 
-  test("toDataType converts BinaryVector to Spark Array[Byte]") {
+  test("toDataType converts BinaryVector to Spark BinaryType") {
     val fieldSchema = FieldSchema(dataType = MilvusDataType.BinaryVector)
     val result = DataTypeUtil.toDataType(fieldSchema)
-    result shouldBe DataTypes.createArrayType(DataTypes.ByteType)
+    result shouldBe DataTypes.BinaryType
   }
 
   test("toDataType converts Int8Vector to Spark Array[Short]") {

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -200,6 +200,12 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     result shouldBe DataTypes.createArrayType(DataTypes.FloatType)
   }
 
+  test("toDataType converts BinaryVector to Spark Array[Byte]") {
+    val fieldSchema = FieldSchema(dataType = MilvusDataType.BinaryVector)
+    val result = DataTypeUtil.toDataType(fieldSchema)
+    result shouldBe DataTypes.createArrayType(DataTypes.ByteType)
+  }
+
   test("toDataType converts Int8Vector to Spark Array[Short]") {
     val fieldSchema = FieldSchema(dataType = MilvusDataType.Int8Vector)
     val result = DataTypeUtil.toDataType(fieldSchema)

--- a/src/test/scala/serde/SchemaUtilTest.scala
+++ b/src/test/scala/serde/SchemaUtilTest.scala
@@ -2,9 +2,16 @@ package serde
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import io.milvus.grpc.schema.{
+  CollectionSchema => MilvusCollectionSchema,
+  DataType => MilvusDataType,
+  FieldSchema => MilvusFieldSchema
+}
 
 /** Test suite for MilvusSchemaUtil
   */
@@ -331,7 +338,49 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
     // PARQUET:field_id metadata is always stamped, regardless of rename.
     byIdx(0).getMetadata.get("PARQUET:field_id") shouldBe "100"
     byIdx(1).getMetadata.get("PARQUET:field_id") shouldBe "101"
-    byIdx(2).getMetadata.get("PARQUET:field_id") shouldBe "3" // idx+1 fallback
+    byIdx(2).getMetadata.get("PARQUET:field_id") shouldBe "102"
+  }
+
+  test("field ID fallback avoids Milvus system field IDs") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import org.apache.spark.sql.types._
+
+    val schema = StructType(
+      Seq(
+        StructField("first", LongType),
+        StructField("second", StringType)
+      )
+    )
+
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
+    val metadata = arrowSchema.getFields.asScala.map(_.getMetadata)
+
+    metadata.head.get("PARQUET:field_id") shouldBe "100"
+    metadata(1).get("PARQUET:field_id") shouldBe "101"
+  }
+
+  test("system fields are not appended over case-insensitive name conflicts") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+
+    val schema = MilvusCollectionSchema(
+      fields = Seq(
+        MilvusFieldSchema(
+          name = "row_id",
+          fieldID = 100,
+          dataType = MilvusDataType.Int64
+        ),
+        MilvusFieldSchema(
+          name = "timestamp",
+          fieldID = 101,
+          dataType = MilvusDataType.Int64
+        )
+      )
+    )
+
+    val arrowSchema = MilvusSchemaUtil.convertToArrowSchema(schema)
+    val names = arrowSchema.getFields.asScala.map(_.getName)
+
+    names shouldBe Seq("row_id", "timestamp")
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -228,7 +228,7 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
-  test("snapshot planner tags V3 partitions from manifest base path") {
+  test("snapshot planner tags V3 partitions with partition ID string") {
     val manifestJson = MilvusSnapshotReader.serializeManifestList(
       Seq(
         StorageV2ManifestItem(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -50,6 +50,30 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
+  test("client snapshot fast path is disabled when partition or segment selectors are set") {
+    val base = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusCollectionName -> "c"
+    )
+
+    assert(MilvusScan.canUseClientSnapshotFastPath(MilvusOption(base)))
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusPartitionID -> "10"))
+      )
+    )
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusSegmentID -> "20"))
+      )
+    )
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusPartitionName -> "p1"))
+      )
+    )
+  }
+
   test(
     "buildClientSnapshotOptions preserves read options and adds snapshot options"
   ) {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1,11 +1,35 @@
 package com.zilliz.spark.connector.sources
 
+import java.util.HashMap
+
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 
 import com.zilliz.spark.connector.read.{StorageV2ManifestItem, V2SegmentInfo}
 import com.zilliz.spark.connector.MilvusOption
 
 class MilvusScanClientSnapshotTest extends AnyFunSuite {
+  test("snapshot table schema appends requested extra metadata columns") {
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, "[]")
+    rawOptions.put(MilvusOption.MilvusCollectionName, "c")
+    rawOptions.put(
+      MilvusOption.MilvusExtraColumns,
+      "$segment_id,$row_offset"
+    )
+    val options = new CaseInsensitiveStringMap(rawOptions)
+    val table = MilvusTable(
+      MilvusOption(options),
+      Some(StructType(Seq(StructField("id", LongType, nullable = false))))
+    )
+
+    assert(
+      table.schema().fieldNames.toSeq == Seq("id", "$segment_id", "$row_offset")
+    )
+  }
+
   test(
     "resolveClientSnapshotLocation prefixes bucket-relative snapshot locations"
   ) {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1,0 +1,66 @@
+package com.zilliz.spark.connector.sources
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.zilliz.spark.connector.read.{StorageV2ManifestItem, V2SegmentInfo}
+import com.zilliz.spark.connector.MilvusOption
+
+class MilvusScanClientSnapshotTest extends AnyFunSuite {
+  test(
+    "resolveClientSnapshotLocation prefixes bucket-relative snapshot locations"
+  ) {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "files/snapshots/1/metadata/2.json",
+        "a-bucket"
+      ) == "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+    )
+  }
+
+  test("resolveClientSnapshotLocation normalizes s3 scheme to s3a") {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "s3://a-bucket/files/snapshots/1/metadata/2.json",
+        "ignored"
+      ) == "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+    )
+  }
+
+  test(
+    "buildClientSnapshotOptions preserves read options and adds snapshot options"
+  ) {
+    val base = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusCollectionName -> "c",
+      MilvusOption.MilvusExtraColumns -> "$segment_id,$row_offset",
+      MilvusOption.ReaderDebug -> "true",
+      MilvusOption.SnapshotCollectionId -> "old"
+    )
+
+    val out = MilvusScan.buildClientSnapshotOptions(
+      base,
+      collectionName = "c",
+      collectionId = 10L,
+      partitionIds = Seq(20L),
+      snapshotJson = "{\"snapshot_info\":{},\"collection\":{}}",
+      schemaBytesBase64 = "abc",
+      manifestList = Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":1,\"base_path\":\"files/insert_log/10/20/30\"}"
+        )
+      ),
+      v2Segments = Seq.empty[V2SegmentInfo]
+    )
+
+    assert(out(MilvusOption.SnapshotMode) == "true")
+    assert(out(MilvusOption.MilvusCollectionName) == "c")
+    assert(out(MilvusOption.SnapshotCollectionId) == "10")
+    assert(out(MilvusOption.SnapshotPartitionIds) == "20")
+    assert(out(MilvusOption.SnapshotSchemaJson).nonEmpty)
+    assert(out(MilvusOption.SnapshotSchemaBytes) == "abc")
+    assert(out.contains(MilvusOption.SnapshotManifests))
+    assert(out(MilvusOption.MilvusExtraColumns) == "$segment_id,$row_offset")
+    assert(out(MilvusOption.ReaderDebug) == "true")
+  }
+}

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1,15 +1,34 @@
 package com.zilliz.spark.connector.sources
 
-import java.util.HashMap
+import java.util.{Base64, HashMap}
 
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 
-import com.zilliz.spark.connector.read.{StorageV2ManifestItem, V2SegmentInfo}
+import com.zilliz.spark.connector.read.{
+  MilvusPackedV2InputPartition,
+  MilvusSnapshotReader,
+  MilvusStorageV3InputPartition,
+  StorageV2ManifestItem,
+  V2ColumnGroup,
+  V2SegmentInfo
+}
 import com.zilliz.spark.connector.MilvusOption
 
 class MilvusScanClientSnapshotTest extends AnyFunSuite {
+  private val emptySchemaBytes =
+    Base64.getEncoder.encodeToString(Array.emptyByteArray)
+
+  private def scanWithOptions(
+      rawOptions: HashMap[String, String]
+  ): MilvusScan = {
+    new MilvusScan(
+      StructType(Seq(StructField("id", LongType, nullable = false))),
+      new CaseInsensitiveStringMap(rawOptions)
+    )
+  }
+
   test("snapshot table schema appends requested extra metadata columns") {
     val rawOptions = new HashMap[String, String]()
     rawOptions.put(MilvusOption.SnapshotMode, "true")
@@ -17,7 +36,7 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     rawOptions.put(MilvusOption.MilvusCollectionName, "c")
     rawOptions.put(
       MilvusOption.MilvusExtraColumns,
-      "$segment_id,$row_offset"
+      "partition,$segment_id,$row_offset"
     )
     val options = new CaseInsensitiveStringMap(rawOptions)
     val table = MilvusTable(
@@ -26,7 +45,12 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
 
     assert(
-      table.schema().fieldNames.toSeq == Seq("id", "$segment_id", "$row_offset")
+      table.schema().fieldNames.toSeq == Seq(
+        "id",
+        "partition",
+        "$segment_id",
+        "$row_offset"
+      )
     )
   }
 
@@ -127,5 +151,119 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(out.contains(MilvusOption.SnapshotManifests))
     assert(out(MilvusOption.MilvusExtraColumns) == "$segment_id,$row_offset")
     assert(out(MilvusOption.ReaderDebug) == "true")
+  }
+
+  test(
+    "parseInsertLogPathIds extracts partition and segment from manifest base path"
+  ) {
+    assert(
+      MilvusScan
+        .parseInsertLogPathIds(
+          "a-bucket/files/insert_log/10/20/30"
+        )
+        .contains("20" -> 30L)
+    )
+    assert(
+      MilvusScan
+        .parseInsertLogPathIds(
+          "s3a://a-bucket/files/insert_log/10/21/31"
+        )
+        .contains("21" -> 31L)
+    )
+    assert(MilvusScan.parseInsertLogPathIds("a-bucket/files/30").isEmpty)
+  }
+
+  test(
+    "snapshot planner fails loudly when all snapshot segment lists are empty"
+  ) {
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, "[]")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+
+    val err = intercept[IllegalArgumentException] {
+      scanWithOptions(rawOptions).planInputPartitions()
+    }
+
+    assert(
+      err.getMessage.contains("no StorageV3 manifests or StorageV2 segments")
+    )
+  }
+
+  test("snapshot planner tags V3 partitions from manifest base path") {
+    val manifestJson = MilvusSnapshotReader.serializeManifestList(
+      Seq(
+        StorageV2ManifestItem(
+          0L,
+          "{\"ver\":7,\"base_path\":\"a-bucket/files/insert_log/10/20/30\"}"
+        )
+      )
+    )
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, manifestJson)
+    rawOptions.put(MilvusOption.SnapshotPartitionIds, "20,21")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+
+    assert(partitions.length == 1)
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.partitionName == "20")
+    assert(partition.segmentID == 30L)
+    assert(partition.readVersion == 7L)
+  }
+
+  test("snapshot planner rejects mismatched V3 segment id metadata") {
+    val manifestJson = MilvusSnapshotReader.serializeManifestList(
+      Seq(
+        StorageV2ManifestItem(
+          31L,
+          "{\"ver\":7,\"base_path\":\"a-bucket/files/insert_log/10/20/30\"}"
+        )
+      )
+    )
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, manifestJson)
+    rawOptions.put(MilvusOption.SnapshotPartitionIds, "20")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+
+    val err = intercept[IllegalArgumentException] {
+      scanWithOptions(rawOptions).planInputPartitions()
+    }
+
+    assert(err.getMessage.contains("does not match base_path segment"))
+  }
+
+  test("snapshot planner accepts V2-only snapshot segments") {
+    val v2Json = MilvusSnapshotReader.serializeV2Segments(
+      Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 2L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(0L, 1L),
+              filePaths = Seq("a-bucket/files/insert_log/10/20/30/0/1"),
+              fileRowCounts = Seq(2L)
+            )
+          )
+        )
+      )
+    )
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotV2Segments, v2Json)
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+
+    assert(partitions.length == 1)
+    val partition = partitions.head.asInstanceOf[MilvusPackedV2InputPartition]
+    assert(partition.segmentID == 30L)
+    assert(partition.partitionID == 20L)
   }
 }

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -211,21 +211,28 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(err.getMessage.contains("does not contain insert_log"))
   }
 
-  test(
-    "snapshot planner fails loudly when all snapshot segment lists are empty"
-  ) {
+  test("snapshot planner returns no partitions for empty snapshots") {
     val rawOptions = new HashMap[String, String]()
     rawOptions.put(MilvusOption.SnapshotMode, "true")
     rawOptions.put(MilvusOption.SnapshotManifests, "[]")
     rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
 
-    val err = intercept[IllegalArgumentException] {
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+
+    assert(partitions.isEmpty)
+  }
+
+  test("snapshot planner fails loudly on malformed manifest JSON") {
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, "not-json")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+
+    val err = intercept[Exception] {
       scanWithOptions(rawOptions).planInputPartitions()
     }
 
-    assert(
-      err.getMessage.contains("no StorageV3 manifests or StorageV2 segments")
-    )
+    assert(err.getMessage.contains("Failed to parse snapshot manifests"))
   }
 
   test("snapshot planner tags V3 partitions with partition ID string") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -2,6 +2,7 @@ package com.zilliz.spark.connector.sources
 
 import java.util.{Base64, HashMap}
 
+import org.apache.spark.sql.sources.{EqualTo, Filter}
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
@@ -131,6 +132,20 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     builder.pruneColumns(StructType(Seq.empty))
 
     assert(builder.build().readSchema().fieldNames.toSeq == Seq("RowID"))
+  }
+
+  test("pushFilters returns all filters for client snapshot fast path") {
+    val rawOptions = new HashMap[String, String]()
+    rawOptions.put(MilvusOption.MilvusUri, "http://localhost:19530")
+    rawOptions.put(MilvusOption.MilvusCollectionName, "c")
+    val builder = new MilvusScanBuilder(
+      StructType(Seq(StructField("id", LongType, nullable = false))),
+      new CaseInsensitiveStringMap(rawOptions)
+    )
+    val filters: Array[Filter] = Array(EqualTo("id", 10L))
+
+    assert(builder.pushFilters(filters).sameElements(filters))
+    assert(builder.pushedFilters().isEmpty)
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -50,6 +50,21 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
+  test("snapshotBucketsToConfigure includes cross-bucket snapshot locations") {
+    assert(
+      MilvusScan.snapshotBucketsToConfigure(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/2.json",
+        "connector-bucket"
+      ) == Seq("connector-bucket", "snapshot-bucket")
+    )
+    assert(
+      MilvusScan.snapshotBucketsToConfigure(
+        "s3a://connector-bucket/files/snapshots/1/metadata/2.json",
+        "connector-bucket"
+      ) == Seq("connector-bucket")
+    )
+  }
+
   test(
     "client snapshot fast path is disabled when partition or segment selectors are set"
   ) {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -115,6 +115,24 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
+  test("pruneColumns uses first available field for empty required schema") {
+    val rawOptions = new HashMap[String, String]()
+    val schema = StructType(
+      Seq(
+        StructField("RowID", LongType, nullable = false),
+        StructField("Timestamp", LongType, nullable = false)
+      )
+    )
+    val builder = new MilvusScanBuilder(
+      schema,
+      new CaseInsensitiveStringMap(rawOptions)
+    )
+
+    builder.pruneColumns(StructType(Seq.empty))
+
+    assert(builder.build().readSchema().fieldNames.toSeq == Seq("RowID"))
+  }
+
   test(
     "buildClientSnapshotOptions preserves read options and adds snapshot options"
   ) {
@@ -123,6 +141,7 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
       MilvusOption.MilvusCollectionName -> "c",
       MilvusOption.MilvusExtraColumns -> "$segment_id,$row_offset",
       MilvusOption.ReaderDebug -> "true",
+      MilvusOption.SnapshotMode -> "false",
       MilvusOption.SnapshotCollectionId -> "old"
     )
 
@@ -160,17 +179,18 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
       MilvusScan
         .parseInsertLogPathIds(
           "a-bucket/files/insert_log/10/20/30"
-        )
-        .contains("20" -> 30L)
+        ) == ("20" -> 30L)
     )
     assert(
       MilvusScan
         .parseInsertLogPathIds(
           "s3a://a-bucket/files/insert_log/10/21/31"
-        )
-        .contains("21" -> 31L)
+        ) == ("21" -> 31L)
     )
-    assert(MilvusScan.parseInsertLogPathIds("a-bucket/files/30").isEmpty)
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.parseInsertLogPathIds("a-bucket/files/30")
+    }
+    assert(err.getMessage.contains("does not contain insert_log"))
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -144,8 +144,11 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
     val filters: Array[Filter] = Array(EqualTo("id", 10L))
 
-    assert(builder.pushFilters(filters).sameElements(filters))
+    val unhandledFilters = builder.pushFilters(filters)
+    assert(unhandledFilters.sameElements(filters))
     assert(builder.pushedFilters().isEmpty)
+    val scan = builder.build().asInstanceOf[MilvusScan]
+    assert(scan.readerFiltersForPlanning.sameElements(filters))
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -50,7 +50,9 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
-  test("client snapshot fast path is disabled when partition or segment selectors are set") {
+  test(
+    "client snapshot fast path is disabled when partition or segment selectors are set"
+  ) {
     val base = Map(
       MilvusOption.MilvusUri -> "http://localhost:19530",
       MilvusOption.MilvusCollectionName -> "c"

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -1,0 +1,362 @@
+package com.zilliz.spark.connector.tools
+
+import java.util.Base64
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+import com.zilliz.spark.connector.loon.Properties
+import com.zilliz.spark.connector.read.MilvusSnapshotReader
+import com.zilliz.spark.connector.MilvusOption
+
+class MilvusReadAppTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll {
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("MilvusReadAppTest")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  test("parseArgs parses client mode arguments") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "client",
+        "--milvus-uri",
+        "http://127.0.0.1:19530",
+        "--milvus-token",
+        "root:Milvus",
+        "--database",
+        "default",
+        "--collection",
+        "book",
+        "--s3-endpoint",
+        "127.0.0.1:9000",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-root-path",
+        "files",
+        "--s3-access-key",
+        "ak",
+        "--s3-secret-key",
+        "sk",
+        "--s3-region",
+        "us-east-1",
+        "--show",
+        "10",
+        "--count",
+        "--print-schema",
+        "--debug-read"
+      )
+    )
+
+    args.mode shouldBe "client"
+    args.milvusUri shouldBe "http://127.0.0.1:19530"
+    args.collection shouldBe "book"
+    args.s3Bucket shouldBe "a-bucket"
+    args.show shouldBe Some(10)
+    args.count shouldBe true
+    args.printSchema shouldBe true
+    args.debugRead shouldBe true
+  }
+
+  test("parseArgs parses snapshot mode arguments") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "s3://a-bucket/files/snapshots/metadata.json",
+        "--s3-endpoint",
+        "127.0.0.1:9000",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-root-path",
+        "files",
+        "--use-iam",
+        "--field-ids",
+        "100,101",
+        "--extra-columns",
+        "$segment_id,$row_offset",
+        "--output-parquet",
+        "/tmp/milvus-read-output"
+      )
+    )
+
+    args.mode shouldBe "snapshot"
+    args.snapshot shouldBe Some("s3://a-bucket/files/snapshots/metadata.json")
+    args.useIam shouldBe true
+    args.fieldIds shouldBe Some("100,101")
+    args.extraColumns shouldBe Some("$segment_id,$row_offset")
+    args.outputParquet shouldBe Some("/tmp/milvus-read-output")
+  }
+
+  test("parseArgs rejects unknown flags") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(Array("--mode", "client", "--bad-flag", "x"))
+    }
+  }
+
+  test("parseArgs rejects missing value for key flag") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(Array("--mode"))
+    }
+  }
+
+  test("parseArgs rejects unsupported mode") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(Array("--mode", "offline"))
+    }
+  }
+
+  test("buildClientOptions maps client and storage arguments") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "client",
+        "--milvus-uri",
+        "http://127.0.0.1:19530",
+        "--milvus-token",
+        "root:Milvus",
+        "--database",
+        "default",
+        "--collection",
+        "book",
+        "--partition-name",
+        "p1",
+        "--s3-endpoint",
+        "127.0.0.1:9000",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-root-path",
+        "files",
+        "--s3-access-key",
+        "ak",
+        "--s3-secret-key",
+        "sk",
+        "--s3-region",
+        "us-east-1",
+        "--s3-use-ssl",
+        "--field-ids",
+        "100,101",
+        "--extra-columns",
+        "$segment_id,$row_offset",
+        "--debug-read"
+      )
+    )
+
+    val opts = MilvusReadApp.buildClientOptions(args)
+    opts(MilvusOption.MilvusUri) shouldBe "http://127.0.0.1:19530"
+    opts(MilvusOption.MilvusToken) shouldBe "root:Milvus"
+    opts(MilvusOption.MilvusDatabaseName) shouldBe "default"
+    opts(MilvusOption.MilvusCollectionName) shouldBe "book"
+    opts(MilvusOption.MilvusPartitionName) shouldBe "p1"
+    opts(MilvusOption.ReaderFieldIDs) shouldBe "100,101"
+    opts(MilvusOption.MilvusExtraColumns) shouldBe "$segment_id,$row_offset"
+    opts(MilvusOption.ReaderDebug) shouldBe "true"
+    opts(Properties.FsConfig.FsAddress) shouldBe "127.0.0.1:9000"
+    opts(Properties.FsConfig.FsBucketName) shouldBe "a-bucket"
+    opts(Properties.FsConfig.FsRootPath) shouldBe "files"
+    opts(Properties.FsConfig.FsAccessKeyId) shouldBe "ak"
+    opts(Properties.FsConfig.FsAccessKeyValue) shouldBe "sk"
+    opts(Properties.FsConfig.FsRegion) shouldBe "us-east-1"
+    opts(Properties.FsConfig.FsUseSSL) shouldBe "true"
+  }
+
+  test("buildClientOptions rejects missing required client arguments") {
+    val args = MilvusReadApp.parseArgs(Array("--mode", "client"))
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.buildClientOptions(args)
+    }
+  }
+
+  test("buildStorageOptions omits AK/SK in IAM mode") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "src/test/data/sample_snapshot.json",
+        "--s3-bucket",
+        "a-bucket",
+        "--use-iam"
+      )
+    )
+
+    val opts = MilvusReadApp.buildStorageOptions(args)
+    opts(Properties.FsConfig.FsUseIam) shouldBe "true"
+    opts.get(Properties.FsConfig.FsAccessKeyId) shouldBe None
+    opts.get(Properties.FsConfig.FsAccessKeyValue) shouldBe None
+  }
+
+  test(
+    "buildSnapshotOptionsFromMetadata includes schema bytes and manifest options"
+  ) {
+    val source = scala.io.Source.fromFile("src/test/data/sample_snapshot.json")
+    val json =
+      try source.mkString
+      finally source.close()
+    val metadata = MilvusSnapshotReader
+      .parseSnapshotMetadata(json)
+      .toOption
+      .get
+
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "src/test/data/sample_snapshot.json",
+        "--s3-endpoint",
+        "127.0.0.1:9000",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-root-path",
+        "files",
+        "--s3-access-key",
+        "ak",
+        "--s3-secret-key",
+        "sk",
+        "--field-ids",
+        "100",
+        "--extra-columns",
+        "$segment_id,$row_offset"
+      )
+    )
+
+    val opts = MilvusReadApp.buildSnapshotOptionsFromMetadata(
+      args,
+      metadata,
+      json,
+      v2Segments = Seq.empty
+    )
+
+    opts(MilvusOption.SnapshotMode) shouldBe "true"
+    opts(MilvusOption.MilvusUri) shouldBe "dummy://snapshot-mode"
+    opts(
+      MilvusOption.MilvusCollectionName
+    ) shouldBe metadata.collection.schema.name
+    opts(
+      MilvusOption.SnapshotCollectionId
+    ) shouldBe metadata.snapshotInfo.collectionId.toString
+    opts(
+      MilvusOption.SnapshotPartitionIds
+    ) shouldBe metadata.snapshotInfo.partitionIds.mkString(",")
+    opts(MilvusOption.SnapshotSchemaJson) shouldBe json
+    opts(MilvusOption.ReaderFieldIDs) shouldBe "100"
+    opts(MilvusOption.MilvusExtraColumns) shouldBe "$segment_id,$row_offset"
+    opts should contain key MilvusOption.SnapshotSchemaBytes
+    Base64.getDecoder
+      .decode(opts(MilvusOption.SnapshotSchemaBytes))
+      .length should be > 0
+    opts should contain key MilvusOption.SnapshotManifests
+    opts should not contain key(MilvusOption.SnapshotV2Segments)
+  }
+
+  test("normalizeSnapshotPath converts s3 scheme to s3a") {
+    MilvusReadApp.normalizeSnapshotPath(
+      "s3://bucket/path/to/file.json"
+    ) shouldBe
+      "s3a://bucket/path/to/file.json"
+    MilvusReadApp.normalizeSnapshotPath(
+      "s3a://bucket/path/to/file.json"
+    ) shouldBe
+      "s3a://bucket/path/to/file.json"
+    MilvusReadApp.normalizeSnapshotPath(
+      "src/test/data/sample_snapshot.json"
+    ) shouldBe
+      "src/test/data/sample_snapshot.json"
+  }
+
+  test("readLocalSnapshotJson reads local snapshot file") {
+    val json =
+      MilvusReadApp.readLocalSnapshotJson("src/test/data/sample_snapshot.json")
+    json should include("snapshot-info")
+    json should include("collection")
+  }
+
+  test("configureHadoopS3A configures static credentials") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "s3://a-bucket/files/snapshots/metadata.json",
+        "--s3-endpoint",
+        "127.0.0.1:9000",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-access-key",
+        "ak",
+        "--s3-secret-key",
+        "sk",
+        "--s3-region",
+        "us-east-1"
+      )
+    )
+    val conf = new Configuration()
+
+    MilvusReadApp.configureHadoopS3A(conf, args)
+
+    conf.get("fs.s3a.bucket.a-bucket.endpoint") shouldBe "127.0.0.1:9000"
+    conf.get("fs.s3a.bucket.a-bucket.access.key") shouldBe "ak"
+    conf.get("fs.s3a.bucket.a-bucket.secret.key") shouldBe "sk"
+    conf.get("fs.s3a.bucket.a-bucket.endpoint.region") shouldBe "us-east-1"
+  }
+
+  test("configureHadoopS3A configures IAM credentials chain") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "s3://a-bucket/files/snapshots/metadata.json",
+        "--s3-bucket",
+        "a-bucket",
+        "--use-iam"
+      )
+    )
+    val conf = new Configuration()
+
+    MilvusReadApp.configureHadoopS3A(conf, args)
+
+    conf.get("fs.s3a.bucket.a-bucket.aws.credentials.provider") should include(
+      "WebIdentityTokenCredentialsProvider"
+    )
+  }
+
+  test("applyTransformations applies select and where") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val df = Seq((1L, "a"), (2L, "b"), (3L, "c")).toDF("id", "tag")
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "client",
+        "--select",
+        "id",
+        "--where",
+        "id >= 2"
+      )
+    )
+
+    val result = MilvusReadApp.applyTransformations(df, args)
+    result.columns.toSeq shouldBe Seq("id")
+    result.collect().map(_.getLong(0)).toSeq shouldBe Seq(2L, 3L)
+  }
+}

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -269,6 +269,43 @@ class MilvusReadAppTest
     }
   }
 
+  test("credentialWarning warns when command-line S3 credentials are present") {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "src/test/data/sample_snapshot.json",
+        "--s3-bucket",
+        "a-bucket",
+        "--s3-access-key",
+        "ak"
+      )
+    )
+
+    MilvusReadApp.credentialWarning(args).get should include(
+      "S3 credentials passed on the command line"
+    )
+  }
+
+  test(
+    "credentialWarning is empty when command-line S3 credentials are omitted"
+  ) {
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "src/test/data/sample_snapshot.json",
+        "--s3-bucket",
+        "a-bucket",
+        "--use-iam"
+      )
+    )
+
+    MilvusReadApp.credentialWarning(args) shouldBe None
+  }
+
   test("buildStorageOptions omits AK/SK in IAM mode") {
     val args = MilvusReadApp.parseArgs(
       Array(

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -359,4 +359,24 @@ class MilvusReadAppTest
     result.columns.toSeq shouldBe Seq("id")
     result.collect().map(_.getLong(0)).toSeq shouldBe Seq(2L, 3L)
   }
+
+  test("applyTransformations filters before selecting columns") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val df = Seq((1L, "a"), (2L, "b"), (3L, "c")).toDF("id", "tag")
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "client",
+        "--select",
+        "id",
+        "--where",
+        "tag = 'b'"
+      )
+    )
+
+    val result = MilvusReadApp.applyTransformations(df, args)
+    result.columns.toSeq shouldBe Seq("id")
+    result.collect().map(_.getLong(0)).toSeq shouldBe Seq(2L)
+  }
 }

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -204,6 +204,38 @@ class MilvusReadAppTest
     opts.get(Properties.FsConfig.FsAccessKeyValue) shouldBe None
   }
 
+  test("buildSnapshotOptionsFromMetadata emits empty manifest option") {
+    val source = scala.io.Source.fromFile("src/test/data/sample_snapshot.json")
+    val json =
+      try source.mkString
+      finally source.close()
+    val metadata = MilvusSnapshotReader
+      .parseSnapshotMetadata(json)
+      .toOption
+      .get
+      .copy(manifestList = Seq.empty, storageV2ManifestList = Some(Seq.empty))
+    val args = MilvusReadApp.parseArgs(
+      Array(
+        "--mode",
+        "snapshot",
+        "--snapshot",
+        "src/test/data/sample_snapshot.json",
+        "--s3-bucket",
+        "a-bucket"
+      )
+    )
+
+    val opts = MilvusReadApp.buildSnapshotOptionsFromMetadata(
+      args,
+      metadata,
+      json,
+      v2Segments = Seq.empty
+    )
+
+    opts(MilvusOption.SnapshotManifests) shouldBe "[]"
+    opts should not contain key(MilvusOption.SnapshotV2Segments)
+  }
+
   test(
     "buildSnapshotOptionsFromMetadata includes schema bytes and manifest options"
   ) {

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -61,7 +61,17 @@ class MilvusReadAppTest
         "10",
         "--count",
         "--print-schema",
-        "--debug-read"
+        "--debug-read",
+        "--client-snapshot-name",
+        "spark-read-test",
+        "--client-snapshot-description",
+        "test snapshot",
+        "--client-snapshot-compaction-protection-seconds",
+        "60",
+        "--snapshot-max-json-bytes",
+        "1024",
+        "--spark-log-level",
+        "WARN"
       )
     )
 
@@ -73,6 +83,11 @@ class MilvusReadAppTest
     args.count shouldBe true
     args.printSchema shouldBe true
     args.debugRead shouldBe true
+    args.clientSnapshotName shouldBe Some("spark-read-test")
+    args.clientSnapshotDescription shouldBe Some("test snapshot")
+    args.clientSnapshotCompactionProtectionSeconds shouldBe Some(60L)
+    args.snapshotMaxJsonBytes shouldBe Some(1024L)
+    args.sparkLogLevel shouldBe Some("WARN")
   }
 
   test("parseArgs parses snapshot mode arguments") {
@@ -142,6 +157,8 @@ class MilvusReadAppTest
           "src/test/data/sample_snapshot.json",
           "--collection",
           "book",
+          "--client-snapshot-name",
+          "spark-read-test",
           "--s3-bucket",
           "a-bucket"
         )
@@ -159,6 +176,19 @@ class MilvusReadAppTest
           "client",
           "--snapshot",
           "src/test/data/sample_snapshot.json"
+        )
+      )
+    }
+  }
+
+  test("parseArgs rejects non-positive client snapshot protection seconds") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(
+        Array(
+          "--mode",
+          "client",
+          "--client-snapshot-compaction-protection-seconds",
+          "0"
         )
       )
     }
@@ -196,7 +226,15 @@ class MilvusReadAppTest
         "100,101",
         "--extra-columns",
         "$segment_id,$row_offset",
-        "--debug-read"
+        "--debug-read",
+        "--client-snapshot-name",
+        "spark-read-test",
+        "--client-snapshot-description",
+        "test snapshot",
+        "--client-snapshot-compaction-protection-seconds",
+        "60",
+        "--snapshot-max-json-bytes",
+        "1024"
       )
     )
 
@@ -209,6 +247,12 @@ class MilvusReadAppTest
     opts(MilvusOption.ReaderFieldIDs) shouldBe "100,101"
     opts(MilvusOption.MilvusExtraColumns) shouldBe "$segment_id,$row_offset"
     opts(MilvusOption.ReaderDebug) shouldBe "true"
+    opts(MilvusOption.ClientSnapshotName) shouldBe "spark-read-test"
+    opts(MilvusOption.ClientSnapshotDescription) shouldBe "test snapshot"
+    opts(
+      MilvusOption.ClientSnapshotCompactionProtectionSeconds
+    ) shouldBe "60"
+    opts(MilvusOption.SnapshotMaxJsonBytes) shouldBe "1024"
     opts(Properties.FsConfig.FsAddress) shouldBe "127.0.0.1:9000"
     opts(Properties.FsConfig.FsBucketName) shouldBe "a-bucket"
     opts(Properties.FsConfig.FsRootPath) shouldBe "files"
@@ -307,7 +351,9 @@ class MilvusReadAppTest
         "--field-ids",
         "100",
         "--extra-columns",
-        "$segment_id,$row_offset"
+        "$segment_id,$row_offset",
+        "--snapshot-max-json-bytes",
+        "1024"
       )
     )
 
@@ -332,6 +378,7 @@ class MilvusReadAppTest
     opts(MilvusOption.SnapshotSchemaJson) shouldBe json
     opts(MilvusOption.ReaderFieldIDs) shouldBe "100"
     opts(MilvusOption.MilvusExtraColumns) shouldBe "$segment_id,$row_offset"
+    opts(MilvusOption.SnapshotMaxJsonBytes) shouldBe "1024"
     opts should contain key MilvusOption.SnapshotSchemaBytes
     Base64.getDecoder
       .decode(opts(MilvusOption.SnapshotSchemaBytes))
@@ -360,6 +407,15 @@ class MilvusReadAppTest
       MilvusReadApp.readLocalSnapshotJson("src/test/data/sample_snapshot.json")
     json should include("snapshot-info")
     json should include("collection")
+  }
+
+  test("readLocalSnapshotJson applies explicit max JSON byte limit") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.readLocalSnapshotJson(
+        "src/test/data/sample_snapshot.json",
+        maxBytes = 1L
+      )
+    }
   }
 
   test("configureHadoopS3A configures static credentials") {

--- a/src/test/scala/tools/MilvusReadAppTest.scala
+++ b/src/test/scala/tools/MilvusReadAppTest.scala
@@ -124,6 +124,46 @@ class MilvusReadAppTest
     }
   }
 
+  test("parseArgs rejects snapshot mode without snapshot path") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(
+        Array("--mode", "snapshot", "--s3-bucket", "a-bucket")
+      )
+    }
+  }
+
+  test("parseArgs rejects client-only options in snapshot mode") {
+    val err = intercept[IllegalArgumentException] {
+      MilvusReadApp.parseArgs(
+        Array(
+          "--mode",
+          "snapshot",
+          "--snapshot",
+          "src/test/data/sample_snapshot.json",
+          "--collection",
+          "book",
+          "--s3-bucket",
+          "a-bucket"
+        )
+      )
+    }
+
+    err.getMessage should include("Snapshot mode does not accept")
+  }
+
+  test("parseArgs rejects snapshot option in client mode") {
+    an[IllegalArgumentException] should be thrownBy {
+      MilvusReadApp.parseArgs(
+        Array(
+          "--mode",
+          "client",
+          "--snapshot",
+          "src/test/data/sample_snapshot.json"
+        )
+      )
+    }
+  }
+
   test("buildClientOptions maps client and storage arguments") {
     val args = MilvusReadApp.parseArgs(
       Array(
@@ -279,7 +319,7 @@ class MilvusReadAppTest
     )
 
     opts(MilvusOption.SnapshotMode) shouldBe "true"
-    opts(MilvusOption.MilvusUri) shouldBe "dummy://snapshot-mode"
+    opts should not contain key(MilvusOption.MilvusUri)
     opts(
       MilvusOption.MilvusCollectionName
     ) shouldBe metadata.collection.schema.name
@@ -370,6 +410,26 @@ class MilvusReadAppTest
     conf.get("fs.s3a.bucket.a-bucket.aws.credentials.provider") should include(
       "WebIdentityTokenCredentialsProvider"
     )
+  }
+
+  test("runActions caches a DataFrame before multiple data actions") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val acc = sparkSession.sparkContext.longAccumulator("run-actions-cache")
+    val df = sparkSession
+      .range(0, 3)
+      .map { value =>
+        acc.add(1L)
+        value
+      }
+      .toDF("id")
+    val args = MilvusReadApp.parseArgs(
+      Array("--mode", "client", "--show", "2", "--count")
+    )
+
+    MilvusReadApp.runActions(df, args)
+
+    acc.value shouldBe 3L
   }
 
   test("applyTransformations applies select and where") {


### PR DESCRIPTION
Add MilvusReadApp and a spark-submit wrapper for client and snapshot reads, and prefer client-created snapshots with fallback only when snapshot RPCs are unavailable.

Reuse snapshot planning for V2/V3 segments, expose real row_id/timestamp plus $segment_id/$row_offset metadata, and make Arrow string conversion handle JSON stored as binary.

Update Milvus proto for snapshot RPCs and add focused tests for the read app, snapshot planner helpers, and Arrow VarBinary StringType conversion.

Also: reader/backfill metadata columns are now named $segment_id and $row_offset instead of segment_id and row_offset.