### PR TITLE
enhance: [reader] add client snapshot planning lifecycle

### DIFF
--- a/src/main/scala/MilvusClient.scala
+++ b/src/main/scala/MilvusClient.scala
@@ -977,6 +977,23 @@ object MilvusClient {
     ServiceUnavailableMarkers.exists(normalized.contains)
   }
 
+  private def hasGrpcCode(
+      t: Throwable,
+      codes: Set[GrpcStatus.Code]
+  ): Boolean = {
+    val visited = java.util.Collections.newSetFromMap(
+      new java.util.IdentityHashMap[Throwable, java.lang.Boolean]()
+    )
+    var current = t
+    while (current != null && visited.add(current)) {
+      grpcStatus(current).foreach { status =>
+        if (codes.contains(status.getCode)) return true
+      }
+      current = current.getCause
+    }
+    false
+  }
+
   def isServiceNotImplemented(t: Throwable): Boolean = {
     val visited = java.util.Collections.newSetFromMap(
       new java.util.IdentityHashMap[Throwable, java.lang.Boolean]()
@@ -994,6 +1011,19 @@ object MilvusClient {
     }
     false
   }
+
+  def isSnapshotAlreadyDropped(t: Throwable): Boolean =
+    hasGrpcCode(t, Set(GrpcStatus.Code.NOT_FOUND))
+
+  def isTerminalSnapshotDropError(t: Throwable): Boolean =
+    hasGrpcCode(
+      t,
+      Set(
+        GrpcStatus.Code.NOT_FOUND,
+        GrpcStatus.Code.PERMISSION_DENIED,
+        GrpcStatus.Code.INVALID_ARGUMENT
+      )
+    )
 
   val mapper: ObjectMapper with ScalaObjectMapper = {
     val m = new ObjectMapper() with ScalaObjectMapper

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -159,6 +159,12 @@ object MilvusOption {
   val ClientSnapshotCompactionProtectionSeconds =
     "milvus.client.snapshot.compaction.protection.seconds"
 
+  private def nonEmptyOption(
+      getOption: String => Option[String],
+      key: String
+  ): Boolean =
+    getOption(key).exists(_.trim.nonEmpty)
+
   private def isSnapshotModeFrom(
       getOption: String => Option[String]
   ): Boolean = {
@@ -172,6 +178,20 @@ object MilvusOption {
       }
   }
 
+  private def validateSnapshotModeOptionsFrom(
+      getOption: String => Option[String]
+  ): Unit = {
+    val explicitSnapshotMode = getOption(SnapshotMode)
+      .exists(_.trim.equalsIgnoreCase("true"))
+    val hasSnapshotData = nonEmptyOption(getOption, SnapshotManifests) ||
+      nonEmptyOption(getOption, SnapshotV2Segments)
+    if (explicitSnapshotMode && !hasSnapshotData) {
+      throw new IllegalArgumentException(
+        s"$SnapshotMode=true requires $SnapshotManifests or $SnapshotV2Segments"
+      )
+    }
+  }
+
   def isSnapshotMode(options: Map[String, String]): Boolean = {
     isSnapshotModeFrom { key =>
       options.collectFirst {
@@ -183,6 +203,19 @@ object MilvusOption {
 
   def isSnapshotMode(options: CaseInsensitiveStringMap): Boolean = {
     isSnapshotModeFrom(key => Option(options.get(key)))
+  }
+
+  def validateSnapshotModeOptions(options: Map[String, String]): Unit = {
+    validateSnapshotModeOptionsFrom { key =>
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) =>
+          value
+      }
+    }
+  }
+
+  def validateSnapshotModeOptions(options: CaseInsensitiveStringMap): Unit = {
+    validateSnapshotModeOptionsFrom(key => Option(options.get(key)))
   }
 
   // Create MilvusOption from a map

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -162,9 +162,14 @@ object MilvusOption {
   private def isSnapshotModeFrom(
       getOption: String => Option[String]
   ): Boolean = {
-    getOption(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||
-    getOption(SnapshotManifests).isDefined ||
-    getOption(SnapshotV2Segments).isDefined
+    getOption(SnapshotMode)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(_.equalsIgnoreCase("true"))
+      .getOrElse {
+        getOption(SnapshotManifests).isDefined ||
+        getOption(SnapshotV2Segments).isDefined
+      }
   }
 
   def isSnapshotMode(options: Map[String, String]): Boolean = {

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -153,6 +153,23 @@ object MilvusOption {
     "milvus.snapshot.schema.json" // Optional: raw schema JSON for building MilvusCollectionInfo
   val SnapshotSchemaBytes =
     "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
+  val SnapshotMaxJsonBytes = "milvus.snapshot.maxJsonBytes"
+  val ClientSnapshotName = "milvus.client.snapshot.name"
+  val ClientSnapshotDescription = "milvus.client.snapshot.description"
+  val ClientSnapshotCompactionProtectionSeconds =
+    "milvus.client.snapshot.compactionProtectionSeconds"
+
+  def isSnapshotMode(options: Map[String, String]): Boolean = {
+    options.get(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||
+    options.contains(SnapshotManifests) ||
+    options.contains(SnapshotV2Segments)
+  }
+
+  def isSnapshotMode(options: CaseInsensitiveStringMap): Boolean = {
+    Option(options.get(SnapshotMode)).exists(_.equalsIgnoreCase("true")) ||
+    Option(options.get(SnapshotManifests)).isDefined ||
+    Option(options.get(SnapshotV2Segments)).isDefined
+  }
 
   // Create MilvusOption from a map
   def apply(options: CaseInsensitiveStringMap): MilvusOption = {

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -159,16 +159,25 @@ object MilvusOption {
   val ClientSnapshotCompactionProtectionSeconds =
     "milvus.client.snapshot.compaction.protection.seconds"
 
+  private def isSnapshotModeFrom(
+      getOption: String => Option[String]
+  ): Boolean = {
+    getOption(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||
+    getOption(SnapshotManifests).isDefined ||
+    getOption(SnapshotV2Segments).isDefined
+  }
+
   def isSnapshotMode(options: Map[String, String]): Boolean = {
-    options.get(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||
-    options.contains(SnapshotManifests) ||
-    options.contains(SnapshotV2Segments)
+    isSnapshotModeFrom { key =>
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) =>
+          value
+      }
+    }
   }
 
   def isSnapshotMode(options: CaseInsensitiveStringMap): Boolean = {
-    Option(options.get(SnapshotMode)).exists(_.equalsIgnoreCase("true")) ||
-    Option(options.get(SnapshotManifests)).isDefined ||
-    Option(options.get(SnapshotV2Segments)).isDefined
+    isSnapshotModeFrom(key => Option(options.get(key)))
   }
 
   // Create MilvusOption from a map

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -153,11 +153,11 @@ object MilvusOption {
     "milvus.snapshot.schema.json" // Optional: raw schema JSON for building MilvusCollectionInfo
   val SnapshotSchemaBytes =
     "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
-  val SnapshotMaxJsonBytes = "milvus.snapshot.maxJsonBytes"
+  val SnapshotMaxJsonBytes = "milvus.snapshot.max.json.bytes"
   val ClientSnapshotName = "milvus.client.snapshot.name"
   val ClientSnapshotDescription = "milvus.client.snapshot.description"
   val ClientSnapshotCompactionProtectionSeconds =
-    "milvus.client.snapshot.compactionProtectionSeconds"
+    "milvus.client.snapshot.compaction.protection.seconds"
 
   def isSnapshotMode(options: Map[String, String]): Boolean = {
     options.get(SnapshotMode).exists(_.equalsIgnoreCase("true")) ||

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -2,6 +2,7 @@ package com.zilliz.spark.connector.read
 
 import java.net.URI
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -152,7 +153,7 @@ object MilvusParquetFooterReader extends Logging {
       }
       Right(read(inputFile))
     } catch {
-      case e: Throwable => Left(e)
+      case NonFatal(e) => Left(e)
     } finally {
       Option(uri).flatMap(uri => Option(uri.getScheme)).foreach { scheme =>
         if (

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -1,11 +1,13 @@
 package com.zilliz.spark.connector.read
 
+import java.net.URI
 import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.parquet.hadoop.util.HadoopStreams
 import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.io.InputFile
 import org.apache.parquet.schema.Type
 import org.apache.spark.internal.Logging
 
@@ -70,24 +72,17 @@ object MilvusParquetFooterReader extends Logging {
       path: String,
       hadoopConf: Configuration
   ): Either[Throwable, ParquetFooterMetadata] = {
-    try {
-      val inputFile =
-        HadoopInputFile.fromPath(new Path(path), hadoopConf)
+    readWithFileSystem(path, hadoopConf) { inputFile =>
       val parquet = ParquetFileReader.open(inputFile)
       try {
         val kv = parquet.getFooter.getFileMetaData.getKeyValueMetaData
-        Right(
-          ParquetFooterMetadata(
-            storageVersion = Option(kv.get(StorageVersionKey)),
-            groupFieldIdList =
-              parseGroupFieldIdList(kv.get(GroupFieldIdListKey))
-          )
+        ParquetFooterMetadata(
+          storageVersion = Option(kv.get(StorageVersionKey)),
+          groupFieldIdList = parseGroupFieldIdList(kv.get(GroupFieldIdListKey))
         )
       } finally {
         parquet.close()
       }
-    } catch {
-      case e: Throwable => Left(e)
     }
   }
 
@@ -117,14 +112,12 @@ object MilvusParquetFooterReader extends Logging {
       path: String,
       hadoopConf: Configuration
   ): Either[Throwable, Seq[Long]] = {
-    try {
-      val inputFile =
-        HadoopInputFile.fromPath(new Path(path), hadoopConf)
+    readWithFileSystem(path, hadoopConf) { inputFile =>
       val parquet = ParquetFileReader.open(inputFile)
       try {
         val schema = parquet.getFooter.getFileMetaData.getSchema
         val fields = schema.getFields.asScala
-        val ids = fields.map { t: Type =>
+        fields.map { t: Type =>
           val id = t.getId
           if (id == null) {
             throw new IllegalStateException(
@@ -134,12 +127,38 @@ object MilvusParquetFooterReader extends Logging {
           }
           id.intValue().toLong
         }.toSeq
-        Right(ids)
       } finally {
         parquet.close()
       }
+    }
+  }
+
+  private def readWithFileSystem[T](
+      path: String,
+      hadoopConf: Configuration
+  )(read: InputFile => T): Either[Throwable, T] = {
+    val uri = new URI(path)
+    var fs: FileSystem = null
+    try {
+      val hadoopPath = new Path(uri)
+      fs = hadoopPath.getFileSystem(hadoopConf)
+      val fileStatus = fs.getFileStatus(hadoopPath)
+      val inputFile = new InputFile {
+        override def getLength: Long = fileStatus.getLen
+
+        override def newStream(): org.apache.parquet.io.SeekableInputStream =
+          HadoopStreams.wrap(fs.open(hadoopPath))
+      }
+      Right(read(inputFile))
     } catch {
       case e: Throwable => Left(e)
+    } finally {
+      if (
+        fs != null &&
+        hadoopConf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)
+      ) {
+        fs.close()
+      }
     }
   }
 

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -137,9 +137,10 @@ object MilvusParquetFooterReader extends Logging {
       path: String,
       hadoopConf: Configuration
   )(read: InputFile => T): Either[Throwable, T] = {
-    val uri = new URI(path)
+    var uri: URI = null
     var fs: FileSystem = null
     try {
+      uri = new URI(path)
       val hadoopPath = new Path(uri)
       fs = hadoopPath.getFileSystem(hadoopConf)
       val fileStatus = fs.getFileStatus(hadoopPath)
@@ -153,11 +154,13 @@ object MilvusParquetFooterReader extends Logging {
     } catch {
       case e: Throwable => Left(e)
     } finally {
-      if (
-        fs != null &&
-        hadoopConf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)
-      ) {
-        fs.close()
+      Option(uri).flatMap(uri => Option(uri.getScheme)).foreach { scheme =>
+        if (
+          fs != null && hadoopConf
+            .getBoolean(s"fs.$scheme.impl.disable.cache", false)
+        ) {
+          fs.close()
+        }
       }
     }
   }

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -383,6 +383,30 @@ case class SnapshotMetadata(
   */
 object MilvusSnapshotReader {
 
+  val MaxSnapshotJsonBytes: Long = 64L * 1024L * 1024L
+
+  def readUtf8WithLimit(
+      in: java.io.InputStream,
+      path: String,
+      maxBytes: Long = MaxSnapshotJsonBytes
+  ): String = {
+    val out = new java.io.ByteArrayOutputStream()
+    val buf = new Array[Byte](8192)
+    var total = 0L
+    var n = in.read(buf)
+    while (n >= 0) {
+      total += n
+      if (total > maxBytes) {
+        throw new IllegalArgumentException(
+          s"Snapshot metadata $path exceeds max size $maxBytes bytes"
+        )
+      }
+      out.write(buf, 0, n)
+      n = in.read(buf)
+    }
+    out.toString(java.nio.charset.StandardCharsets.UTF_8.name())
+  }
+
   private val mapper: ObjectMapper with ScalaObjectMapper = {
     val m = new ObjectMapper() with ScalaObjectMapper
     m.registerModule(DefaultScalaModule)
@@ -428,12 +452,11 @@ object MilvusSnapshotReader {
       path: String
   ): Either[Throwable, SnapshotMetadata] = {
     try {
-      val source = scala.io.Source.fromFile(path)
+      val in = new java.io.FileInputStream(path)
       try {
-        val json = source.mkString
-        parseSnapshotMetadata(json)
+        parseSnapshotMetadata(readUtf8WithLimit(in, path))
       } finally {
-        source.close()
+        in.close()
       }
     } catch {
       case e: Exception => Left(e)

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -390,6 +390,11 @@ object MilvusSnapshotReader {
       path: String,
       maxBytes: Long = MaxSnapshotJsonBytes
   ): String = {
+    if (maxBytes <= 0) {
+      throw new IllegalArgumentException(
+        s"Snapshot metadata max size must be positive, got $maxBytes"
+      )
+    }
     val out = new java.io.ByteArrayOutputStream()
     val buf = new Array[Byte](8192)
     var total = 0L

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.module.scala.{
 }
 import org.apache.spark.sql.types._
 
+import com.zilliz.spark.connector.serde.ArrowConverter
+
 /** Helper object for converting JSON values that may be either numeric or
   * string to Long/Int Milvus snapshot JSON format may serialize numbers as
   * strings in some versions
@@ -687,7 +689,10 @@ object MilvusSnapshotReader {
         StructField(
           field.name,
           dataTypeToSparkType(field.dataType, field.elementType),
-          nullable = field.nullable.getOrElse(true)
+          nullable = field.nullable.getOrElse(true),
+          metadata = new MetadataBuilder()
+            .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType)
+            .build()
         )
       }
     StructType(userFields)

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -81,6 +81,23 @@ private[read] object JsonTypeConverter {
       }
     case _ => 0
   }
+
+  def toFieldStateCode(value: Any): Int = value match {
+    case i: Int    => i
+    case l: Long   => l.toInt
+    case n: Number => n.intValue()
+    case s: String =>
+      try s.toInt
+      catch { case _: NumberFormatException => Field.fieldStateNameToCode(s) }
+    case node: JsonNode if node.isNumber => node.asInt()
+    case node: JsonNode if node.isTextual =>
+      val text = node.asText()
+      try text.toInt
+      catch {
+        case _: NumberFormatException => Field.fieldStateNameToCode(text)
+      }
+    case _ => 0
+  }
 }
 
 /** Type parameter for Milvus field
@@ -101,7 +118,18 @@ case class Field(
       None, // Can be Int or String (e.g., 5 or "Int64")
     @JsonProperty("is_primary_key") isPrimaryKey: Option[Boolean] = None,
     @JsonProperty("is_clustering_key") isClusteringKey: Option[Boolean] = None,
-    @JsonProperty("type_params") typeParams: Option[Seq[TypeParam]] = None
+    @JsonProperty("type_params") typeParams: Option[Seq[TypeParam]] = None,
+    @JsonProperty("autoID") @JsonAlias(Array("auto_id")) autoID: Option[
+      Boolean
+    ] = None,
+    @JsonProperty("state") rawState: Option[JsonNode] = None,
+    @JsonProperty("element_type") rawElementType: Option[JsonNode] = None,
+    @JsonProperty("is_dynamic") isDynamic: Option[Boolean] = None,
+    @JsonProperty("is_partition_key") isPartitionKey: Option[Boolean] = None,
+    @JsonProperty("nullable") nullable: Option[Boolean] = None,
+    @JsonProperty("is_function_output") isFunctionOutput: Option[Boolean] =
+      None,
+    @JsonProperty("default_value") defaultValue: Option[JsonNode] = None
 ) {
 
   /** Get the data type as Int, handling both numeric and string formats String
@@ -121,7 +149,15 @@ case class Field(
       case _          => 0L
     }
   }
+
+  def state: Int = rawState.map(JsonTypeConverter.toFieldStateCode).getOrElse(0)
+
+  def elementType: Int =
+    rawElementType.map(JsonTypeConverter.toDataTypeCode).getOrElse(0)
 }
+
+case class UnsupportedSnapshotSchemaField(message: String)
+    extends IllegalArgumentException(message)
 
 object Field {
 
@@ -139,27 +175,36 @@ object Field {
     "Double" -> 11,
     "String" -> 20,
     "VarChar" -> 21,
-    "JSON" -> 22,
-    "Array" -> 23,
-    // Array element types (23-30 based on element type)
-    "ArrayBool" -> 23,
-    "ArrayInt8" -> 24,
-    "ArrayInt16" -> 25,
-    "ArrayInt32" -> 26,
-    "ArrayInt64" -> 27,
-    "ArrayFloat" -> 28,
-    "ArrayDouble" -> 29,
-    "ArrayVarChar" -> 30,
+    "Array" -> 22,
+    "JSON" -> 23,
+    "Geometry" -> 24,
+    "Text" -> 25,
+    "Timestamptz" -> 26,
     // Vector types
     "BinaryVector" -> 100,
     "FloatVector" -> 101,
     "Float16Vector" -> 102,
     "BFloat16Vector" -> 103,
-    "SparseFloatVector" -> 104
+    "SparseFloatVector" -> 104,
+    "Int8Vector" -> 105,
+    "ArrayOfVector" -> 106,
+    "ArrayOfStruct" -> 200,
+    "Struct" -> 201
+  )
+
+  private val fieldStateNameToCodeMap: Map[String, Int] = Map(
+    "FieldCreated" -> 0,
+    "FieldCreating" -> 1,
+    "FieldDropping" -> 2,
+    "FieldDropped" -> 3
   )
 
   def dataTypeNameToCode(name: String): Int = {
     dataTypeNameToCodeMap.getOrElse(name, 0)
+  }
+
+  def fieldStateNameToCode(name: String): Int = {
+    fieldStateNameToCodeMap.getOrElse(name, 0)
   }
 }
 
@@ -176,7 +221,12 @@ case class CollectionSchema(
     @JsonProperty("name") name: String,
     @JsonProperty("description") description: Option[String] = None,
     @JsonProperty("fields") fields: Seq[Field],
-    @JsonProperty("properties") properties: Option[Seq[Property]] = None
+    @JsonProperty("properties") properties: Option[Seq[Property]] = None,
+    @JsonProperty("autoID") @JsonAlias(Array("auto_id")) autoID: Option[
+      Boolean
+    ] = None,
+    @JsonProperty("enable_dynamic_field") enableDynamicField: Option[Boolean] =
+      None
 ) {
   def getFieldByName(name: String): Option[Field] = {
     fields.find(_.name == name)
@@ -429,6 +479,69 @@ object MilvusSnapshotReader {
     m
   }
 
+  private def protobufDefaultValue(
+      node: JsonNode,
+      fieldName: String
+  ): io.milvus.grpc.schema.ValueField = {
+    import io.milvus.grpc.schema.ValueField
+
+    val value = Option(node).filterNot(_.isNull).getOrElse {
+      throw UnsupportedSnapshotSchemaField(
+        s"default_value for field $fieldName is null"
+      )
+    }
+
+    def child(names: String*): Option[JsonNode] =
+      names.iterator.map(value.get).find(v => v != null && !v.isNull)
+
+    child("bool_data", "boolData")
+      .map(v => ValueField().withBoolData(v.asBoolean()))
+      .orElse(
+        child("int_data", "intData").map(v =>
+          ValueField().withIntData(v.asInt())
+        )
+      )
+      .orElse(
+        child("long_data", "longData").map(v =>
+          ValueField().withLongData(v.asLong())
+        )
+      )
+      .orElse(
+        child("float_data", "floatData").map(v =>
+          ValueField().withFloatData(v.floatValue())
+        )
+      )
+      .orElse(
+        child("double_data", "doubleData").map(v =>
+          ValueField().withDoubleData(v.asDouble())
+        )
+      )
+      .orElse(
+        child("string_data", "stringData").map(v =>
+          ValueField().withStringData(v.asText())
+        )
+      )
+      .orElse(
+        child("bytes_data", "bytesData").map { v =>
+          ValueField().withBytesData(
+            com.google.protobuf.ByteString.copyFrom(
+              java.util.Base64.getDecoder.decode(v.asText())
+            )
+          )
+        }
+      )
+      .orElse(
+        child("timestamptz_data", "timestamptzData").map(v =>
+          ValueField().withTimestamptzData(v.asLong())
+        )
+      )
+      .getOrElse {
+        throw UnsupportedSnapshotSchemaField(
+          s"default_value for field $fieldName uses an unsupported shape: $value"
+        )
+      }
+  }
+
   /** Parse snapshot metadata from JSON string
     *
     * @param json
@@ -573,8 +686,8 @@ object MilvusSnapshotReader {
       .map { field =>
         StructField(
           field.name,
-          dataTypeToSparkType(field.dataType, field.typeParams),
-          nullable = true
+          dataTypeToSparkType(field.dataType, field.elementType),
+          nullable = field.nullable.getOrElse(true)
         )
       }
     StructType(userFields)
@@ -588,7 +701,7 @@ object MilvusSnapshotReader {
     *   Corresponding Spark DataType
     */
   def fieldToSparkType(field: Field): DataType = {
-    dataTypeToSparkType(field.dataType, field.typeParams)
+    dataTypeToSparkType(field.dataType, field.elementType)
   }
 
   /** Convert Milvus data type to Spark DataType
@@ -602,7 +715,7 @@ object MilvusSnapshotReader {
     */
   private def dataTypeToSparkType(
       dataType: Int,
-      typeParams: Option[Seq[TypeParam]]
+      elementType: Int
   ): DataType = {
     dataType match {
       case 1   => BooleanType // Bool
@@ -614,20 +727,17 @@ object MilvusSnapshotReader {
       case 11  => DoubleType // Double
       case 20  => StringType // String
       case 21  => StringType // VarChar
-      case 22  => StringType // JSON (as string)
-      case 23  => ArrayType(BooleanType) // Array[Bool]
-      case 24  => ArrayType(ByteType) // Array[Int8]
-      case 25  => ArrayType(ShortType) // Array[Int16]
-      case 26  => ArrayType(IntegerType) // Array[Int32]
-      case 27  => ArrayType(LongType) // Array[Int64]
-      case 28  => ArrayType(FloatType) // Array[Float]
-      case 29  => ArrayType(DoubleType) // Array[Double]
-      case 30  => ArrayType(StringType) // Array[VarChar]
+      case 22  => ArrayType(dataTypeToSparkType(elementType, 0)) // Array
+      case 23  => StringType // JSON (as string)
+      case 24  => StringType // Geometry
+      case 25  => StringType // Text
+      case 26  => LongType // Timestamptz
+      case 100 => ArrayType(ByteType) // BinaryVector
       case 101 => ArrayType(FloatType) // FloatVector
-      case 102 => ArrayType(ByteType) // BinaryVector
-      case 103 => ArrayType(ShortType) // Float16Vector
-      case 104 => ArrayType(ShortType) // BFloat16Vector
-      case 105 => MapType(LongType, FloatType) // SparseFloatVector
+      case 102 => ArrayType(FloatType) // Float16Vector
+      case 103 => ArrayType(FloatType) // BFloat16Vector
+      case 104 => MapType(LongType, FloatType) // SparseFloatVector
+      case 105 => ArrayType(ByteType) // Int8Vector
       case _   => BinaryType // Unknown types as binary
     }
   }
@@ -665,8 +775,9 @@ object MilvusSnapshotReader {
   def toProtobufSchemaBytes(schema: CollectionSchema): Array[Byte] = {
     import io.milvus.grpc.schema.{
       CollectionSchema => ProtoCollectionSchema,
+      DataType,
       FieldSchema,
-      DataType
+      FieldState
     }
     import io.milvus.grpc.common.KeyValuePair
 
@@ -684,14 +795,28 @@ object MilvusSnapshotReader {
         isClusteringKey = field.isClusteringKey.getOrElse(false),
         typeParams = field.typeParams.getOrElse(Seq.empty).map { tp =>
           KeyValuePair(key = tp.key, value = tp.value)
-        }
+        },
+        autoID = field.autoID.getOrElse(false),
+        state = FieldState.fromValue(field.state),
+        elementType = DataType.fromValue(field.elementType),
+        isDynamic = field.isDynamic.getOrElse(false),
+        isPartitionKey = field.isPartitionKey.getOrElse(false),
+        nullable = field.nullable.getOrElse(false),
+        isFunctionOutput = field.isFunctionOutput.getOrElse(false),
+        defaultValue =
+          field.defaultValue.map(protobufDefaultValue(_, field.name))
       )
     }
 
     val protoSchema = ProtoCollectionSchema(
       name = schema.name,
       description = schema.description.getOrElse(""),
-      fields = protoFields
+      autoID = schema.autoID.getOrElse(false),
+      fields = protoFields,
+      enableDynamicField = schema.enableDynamicField.getOrElse(false),
+      properties = schema.properties.getOrElse(Seq.empty).map { prop =>
+        KeyValuePair(key = prop.key, value = prop.value)
+      }
     )
 
     protoSchema.toByteArray

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -188,9 +188,11 @@ object V2SegmentLoader extends Logging {
       conf: Configuration,
       fullyQualifiedPath: String
   ): Array[Byte] = {
-    val uri = new URI(fullyQualifiedPath)
-    val fs = FileSystem.get(uri, conf)
+    var uri: URI = null
+    var fs: FileSystem = null
     try {
+      uri = new URI(fullyQualifiedPath)
+      fs = FileSystem.get(uri, conf)
       val in = fs.open(new Path(uri))
       try {
         val out = new ByteArrayOutputStream()
@@ -204,9 +206,19 @@ object V2SegmentLoader extends Logging {
       } finally {
         in.close()
       }
+    } catch {
+      case e: Throwable =>
+        throw new RuntimeException(
+          s"failed to read bytes from $fullyQualifiedPath: ${e.getMessage}",
+          e
+        )
     } finally {
-      if (conf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)) {
-        fs.close()
+      Option(uri).flatMap(uri => Option(uri.getScheme)).foreach { scheme =>
+        if (
+          fs != null && conf.getBoolean(s"fs.$scheme.impl.disable.cache", false)
+        ) {
+          fs.close()
+        }
       }
     }
   }

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -184,24 +184,30 @@ object V2SegmentLoader extends Logging {
     else path
   }
 
-  private def readAllBytes(
+  private[read] def readAllBytes(
       conf: Configuration,
       fullyQualifiedPath: String
   ): Array[Byte] = {
     val uri = new URI(fullyQualifiedPath)
     val fs = FileSystem.get(uri, conf)
-    val in = fs.open(new Path(uri))
     try {
-      val out = new ByteArrayOutputStream()
-      val buf = new Array[Byte](8192)
-      var n = in.read(buf)
-      while (n >= 0) {
-        out.write(buf, 0, n)
-        n = in.read(buf)
+      val in = fs.open(new Path(uri))
+      try {
+        val out = new ByteArrayOutputStream()
+        val buf = new Array[Byte](8192)
+        var n = in.read(buf)
+        while (n >= 0) {
+          out.write(buf, 0, n)
+          n = in.read(buf)
+        }
+        out.toByteArray
+      } finally {
+        in.close()
       }
-      out.toByteArray
     } finally {
-      in.close()
+      if (conf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)) {
+        fs.close()
+      }
     }
   }
 }

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -2,6 +2,7 @@ package com.zilliz.spark.connector.read
 
 import java.io.ByteArrayOutputStream
 import java.net.URI
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -72,7 +73,7 @@ object V2SegmentLoader extends Logging {
       }
       Right(out.toSeq)
     } catch {
-      case e: Throwable => Left(e)
+      case NonFatal(e) => Left(e)
     }
   }
 
@@ -169,7 +170,7 @@ object V2SegmentLoader extends Logging {
             )
         }
       } catch {
-        case e: Throwable => Left(e)
+        case NonFatal(e) => Left(e)
       }
     }
   }
@@ -207,7 +208,7 @@ object V2SegmentLoader extends Logging {
         in.close()
       }
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         throw new RuntimeException(
           s"failed to read bytes from $fullyQualifiedPath: ${e.getMessage}",
           e

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -78,14 +78,21 @@ object ArrowConverter extends Logging {
       rowIndex: Int,
       sparkType: DataType
   ): Any = {
-    arrowValueToSparkValue(vector, rowIndex, sparkType, None)
+    arrowValueToSparkValue(
+      vector,
+      rowIndex,
+      sparkType,
+      None,
+      allowLegacyFloatVector = true
+    )
   }
 
   private def arrowValueToSparkValue(
       vector: FieldVector,
       rowIndex: Int,
       sparkType: DataType,
-      milvusType: Option[MilvusDataType]
+      milvusType: Option[MilvusDataType],
+      allowLegacyFloatVector: Boolean = false
   ): Any = {
     sparkType match {
       case LongType =>
@@ -123,7 +130,13 @@ object ArrowConverter extends Logging {
       case ArrayType(FloatType, _)
           if vector.isInstanceOf[FixedSizeBinaryVector] =>
         val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
-        ArrayData.toArrayData(decodeFixedSizeBinaryFloats(bytes, milvusType))
+        ArrayData.toArrayData(
+          decodeFixedSizeBinaryFloats(
+            bytes,
+            milvusType,
+            allowLegacyFloatVector
+          )
+        )
 
       case ArrayType(FloatType, _) =>
         val listVector = vector.asInstanceOf[ListVector]
@@ -204,7 +217,8 @@ object ArrowConverter extends Logging {
 
   private def decodeFixedSizeBinaryFloats(
       bytes: Array[Byte],
-      milvusType: Option[MilvusDataType]
+      milvusType: Option[MilvusDataType],
+      allowLegacyFloatVector: Boolean
   ): Array[Float] = {
     milvusType match {
       case Some(MilvusDataType.Float16Vector) =>
@@ -217,10 +231,24 @@ object ArrowConverter extends Logging {
           .grouped(2)
           .map(b => FloatConverter.fromBFloat16Bytes(b.toSeq))
           .toArray
-      case _ =>
-        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+      case Some(MilvusDataType.FloatVector) =>
+        decodeFloatVectorBytes(bytes)
+      case None if allowLegacyFloatVector =>
+        decodeFloatVectorBytes(bytes)
+      case None =>
+        throw new IllegalArgumentException(
+          s"FixedSizeBinary float vectors require ${MilvusDataTypeMetadataKey} metadata"
+        )
+      case Some(other) =>
+        throw new IllegalArgumentException(
+          s"Cannot decode FixedSizeBinary as Array[Float] for Milvus type $other"
+        )
     }
+  }
+
+  private def decodeFloatVectorBytes(bytes: Array[Byte]): Array[Float] = {
+    val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
   }
 
   val MilvusDataTypeMetadataKey = "milvus.data_type"

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -11,6 +11,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
+import com.zilliz.spark.connector.FloatConverter
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
+
 /** Utilities for converting between Spark InternalRow and Arrow vectors
   */
 object ArrowConverter extends Logging {
@@ -47,7 +50,12 @@ object ArrowConverter extends Logging {
       } else if (vector.isNull(rowIndex)) {
         values(index) = null
       } else {
-        values(index) = arrowValueToSparkValue(vector, rowIndex, field.dataType)
+        values(index) = arrowValueToSparkValue(
+          vector,
+          rowIndex,
+          field.dataType,
+          milvusDataType(field)
+        )
       }
     }
 
@@ -69,6 +77,15 @@ object ArrowConverter extends Logging {
       vector: FieldVector,
       rowIndex: Int,
       sparkType: DataType
+  ): Any = {
+    arrowValueToSparkValue(vector, rowIndex, sparkType, None)
+  }
+
+  private def arrowValueToSparkValue(
+      vector: FieldVector,
+      rowIndex: Int,
+      sparkType: DataType,
+      milvusType: Option[MilvusDataType]
   ): Any = {
     sparkType match {
       case LongType =>
@@ -93,13 +110,33 @@ object ArrowConverter extends Logging {
         val bytes = vector.asInstanceOf[VarCharVector].get(rowIndex)
         UTF8String.fromBytes(bytes)
 
-      case ArrayType(FloatType, _) =>
-        // FloatVector stored as FixedSizeBinaryVector
+      case ArrayType(ByteType, _)
+          if vector.isInstanceOf[FixedSizeBinaryVector] =>
         val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
-        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        val floats =
-          (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
-        ArrayData.toArrayData(floats)
+        ArrayData.toArrayData(bytes)
+
+      case ArrayType(ShortType, _)
+          if vector.isInstanceOf[FixedSizeBinaryVector] =>
+        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
+        ArrayData.toArrayData(bytes.map(_.toShort))
+
+      case ArrayType(FloatType, _)
+          if vector.isInstanceOf[FixedSizeBinaryVector] =>
+        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
+        ArrayData.toArrayData(decodeFixedSizeBinaryFloats(bytes, milvusType))
+
+      case ArrayType(FloatType, _) =>
+        val listVector = vector.asInstanceOf[ListVector]
+        val dataVector = listVector.getDataVector
+        val startIndex = listVector.getElementStartIndex(rowIndex)
+        val endIndex = listVector.getElementEndIndex(rowIndex)
+        val length = endIndex - startIndex
+        val arrayElements = (0 until length).map { i =>
+          val elemIndex = startIndex + i
+          if (dataVector.isNull(elemIndex)) null
+          else arrowValueToSparkValue(dataVector, elemIndex, FloatType, None)
+        }.toArray
+        ArrayData.toArrayData(arrayElements)
 
       case ArrayType(elementType, _) =>
         // Generic array handling
@@ -114,7 +151,7 @@ object ArrowConverter extends Logging {
           if (dataVector.isNull(elemIndex)) {
             null
           } else {
-            arrowValueToSparkValue(dataVector, elemIndex, elementType)
+            arrowValueToSparkValue(dataVector, elemIndex, elementType, None)
           }
         }.toArray
 
@@ -139,12 +176,14 @@ object ArrowConverter extends Logging {
           keys(i) = arrowValueToSparkValue(
             dataVector.getChild("key"),
             elemIndex,
-            keyType
+            keyType,
+            None
           )
           values(i) = arrowValueToSparkValue(
             dataVector.getChild("value"),
             elemIndex,
-            valueType
+            valueType,
+            None
           )
         }
 
@@ -155,6 +194,36 @@ object ArrowConverter extends Logging {
         null
     }
   }
+
+  private def milvusDataType(field: StructField): Option[MilvusDataType] = {
+    Option(field.metadata)
+      .filter(_.contains(MilvusDataTypeMetadataKey))
+      .map(_.getLong(MilvusDataTypeMetadataKey).toInt)
+      .map(MilvusDataType.fromValue)
+  }
+
+  private def decodeFixedSizeBinaryFloats(
+      bytes: Array[Byte],
+      milvusType: Option[MilvusDataType]
+  ): Array[Float] = {
+    milvusType match {
+      case Some(MilvusDataType.Float16Vector) =>
+        bytes
+          .grouped(2)
+          .map(b => FloatConverter.fromFloat16Bytes(b.toSeq))
+          .toArray
+      case Some(MilvusDataType.BFloat16Vector) =>
+        bytes
+          .grouped(2)
+          .map(b => FloatConverter.fromBFloat16Bytes(b.toSeq))
+          .toArray
+      case _ =>
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+    }
+  }
+
+  val MilvusDataTypeMetadataKey = "milvus.data_type"
 
   /** Set a value in an Arrow vector from a Spark InternalRow
     *

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -3,8 +3,9 @@ package com.zilliz.spark.connector
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.spark.sql.types.{DataType => SparkDataType}
-import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.{DataTypes, MetadataBuilder}
 
+import com.zilliz.spark.connector.serde.ArrowConverter
 import com.zilliz.spark.connector.DataParseException
 import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
@@ -45,6 +46,15 @@ object DataTypeUtil {
           s"Unsupported Milvus data type for Arrow conversion: $dataType"
         )
     }
+  }
+
+  def metadata(fieldSchema: FieldSchema) = {
+    new MetadataBuilder()
+      .putLong(
+        ArrowConverter.MilvusDataTypeMetadataKey,
+        fieldSchema.dataType.value
+      )
+      .build()
   }
 
   def toDataType(fieldSchema: FieldSchema): SparkDataType = {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -745,18 +745,45 @@ object MilvusScan extends Logging {
     )).distinct
   }
 
+  private[sources] def optionValue(
+      options: scala.collection.Map[String, String],
+      key: String
+  ): Option[String] = {
+    options.collectFirst {
+      case (optionKey, value) if optionKey.equalsIgnoreCase(key) => value
+    }
+  }
+
+  private[sources] def connectorS3BucketOption(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    optionValue(options, Properties.FsConfig.FsBucketName)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+  }
+
   private[sources] def resolveConnectorS3Bucket(
       options: scala.collection.Map[String, String]
   ): String = {
-    options
-      .get(Properties.FsConfig.FsBucketName)
-      .map(_.trim)
-      .filter(_.nonEmpty)
-      .getOrElse {
-        throw new IllegalArgumentException(
-          s"${Properties.FsConfig.FsBucketName} is required for client snapshot reads"
-        )
-      }
+    connectorS3BucketOption(options).getOrElse {
+      throw new IllegalArgumentException(
+        s"${Properties.FsConfig.FsBucketName} is required for client snapshot reads"
+      )
+    }
+  }
+
+  private[sources] def snapshotS3BucketForRelativePaths(
+      snapshotPath: String,
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    connectorS3BucketOption(options).orElse(snapshotBucket(snapshotPath))
+  }
+
+  private[sources] def isBucketRelativeSnapshotLocation(
+      location: String
+  ): Boolean = {
+    val trimmed = Option(location).map(_.trim).getOrElse("")
+    trimmed.nonEmpty && Option(new URI(trimmed).getScheme).isEmpty
   }
 
   private[sources] def canUseClientSnapshotFastPath(
@@ -1096,7 +1123,6 @@ class MilvusScan(
   private def planInputPartitionsFromClientSnapshot(
       client: MilvusClient
   ): Option[Array[InputPartition]] = {
-    val s3Bucket = MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     val snapshotName = Option(options.get(MilvusOption.ClientSnapshotName))
       .filter(_.trim.nonEmpty)
       .getOrElse(
@@ -1128,7 +1154,34 @@ class MilvusScan(
       protectionSeconds
     ) match {
       case scala.util.Success(snapshot) =>
+        val connectorBucket = MilvusScan.connectorS3BucketOption(
+          milvusOption.options
+        )
         if (
+          connectorBucket.isEmpty && MilvusScan
+            .isBucketRelativeSnapshotLocation(snapshot.s3Location)
+        ) {
+          logWarning(
+            s"Skipping client snapshot fast path because ${Properties.FsConfig.FsBucketName} is missing " +
+              "and the snapshot location is bucket-relative; falling back to legacy GetPersistentSegmentInfo read path"
+          )
+          MilvusScan
+            .dropClientReadSnapshot(
+              client,
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name,
+              s"missing ${Properties.FsConfig.FsBucketName} for bucket-relative snapshot location"
+            )
+            .failed
+            .foreach { e =>
+              logError(
+                s"Failed to drop client read snapshot ${snapshot.name} after missing bucket fallback",
+                e
+              )
+            }
+          None
+        } else if (
           MilvusScan.registerClientSnapshotCleanup(
             cleanupRegistration.get,
             options.asScala.toMap,
@@ -1143,7 +1196,7 @@ class MilvusScan(
           )
           val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
             snapshot.s3Location,
-            s3Bucket
+            connectorBucket.getOrElse("")
           )
           Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
         } else {
@@ -1198,12 +1251,15 @@ class MilvusScan(
         snapshotPath
       )
 
-    val s3Bucket = MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
+    val snapshotBucket = MilvusScan.snapshotS3BucketForRelativePaths(
+      snapshotPath,
+      milvusOption.options
+    )
     val v2Segments =
       if (metadata.manifestList.nonEmpty) {
         V2SegmentLoader.loadV2Segments(
           metadata.manifestList,
-          s3Bucket,
+          snapshotBucket.getOrElse(""),
           hadoopConf
         ) match {
           case Right(segs) => segs
@@ -1334,43 +1390,72 @@ class MilvusScan(
       .orElse(SparkSession.getDefaultSession)
       .map(_.sessionState.newHadoopConf())
       .getOrElse(new Configuration())
-    val endpoint = milvusOption.options.get(Properties.FsConfig.FsAddress)
-    val accessKey = milvusOption.options.get(Properties.FsConfig.FsAccessKeyId)
+    val rawOptions = milvusOption.options
+    val endpoint =
+      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAddress)
+    val accessKey =
+      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyId)
     val secretKey =
-      milvusOption.options.get(Properties.FsConfig.FsAccessKeyValue)
-    val useSsl = milvusOption.options.get(Properties.FsConfig.FsUseSSL)
-    val pathStyle = milvusOption.options.get("fs.s3a.path.style.access")
+      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyValue)
+    val useSsl =
+      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsUseSSL)
+    val region =
+      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsRegion)
+    val useIam = MilvusScan
+      .optionValue(rawOptions, Properties.FsConfig.FsUseIam)
+      .exists(_.trim.equalsIgnoreCase("true"))
+    val useVirtualHost = MilvusScan
+      .optionValue(rawOptions, Properties.FsConfig.FsUseVirtualHost)
+      .filter(_.trim.nonEmpty)
+    val pathStyle = MilvusScan
+      .optionValue(rawOptions, "fs.s3a.path.style.access")
+      .orElse(
+        useVirtualHost.map(v => (!v.trim.equalsIgnoreCase("true")).toString)
+      )
 
     def setIfDefined(key: String, value: Option[String]): Unit = {
-      value.filter(_.nonEmpty).foreach(conf.set(key, _))
+      value.map(_.trim).filter(_.nonEmpty).foreach(conf.set(key, _))
+    }
+
+    def configureS3A(prefix: String): Unit = {
+      setIfDefined(s"$prefix.endpoint", endpoint)
+      setIfDefined(s"$prefix.connection.ssl.enabled", useSsl)
+      setIfDefined(s"$prefix.path.style.access", pathStyle)
+      setIfDefined(s"$prefix.endpoint.region", region)
+      setIfDefined(s"$prefix.region", region)
+      if (useIam) {
+        conf.unset(s"$prefix.access.key")
+        conf.unset(s"$prefix.secret.key")
+        conf.set(
+          s"$prefix.aws.credentials.provider",
+          "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
+        )
+      } else {
+        setIfDefined(s"$prefix.access.key", accessKey)
+        setIfDefined(s"$prefix.secret.key", secretKey)
+      }
     }
 
     if (conf.get("fs.s3a.impl") == null) {
       conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
     }
     conf.set("fs.s3a.impl.disable.cache", "true")
-    if (accessKey.forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty)) {
+    if (
+      !useIam && (accessKey
+        .forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty))
+    ) {
       logWarning(
         "Snapshot S3 credentials were not provided; Hadoop S3A will use the default AWS credential provider chain."
       )
     }
-    setIfDefined("fs.s3a.endpoint", endpoint)
-    setIfDefined("fs.s3a.connection.ssl.enabled", useSsl)
-    setIfDefined("fs.s3a.path.style.access", pathStyle)
-    setIfDefined("fs.s3a.access.key", accessKey)
-    setIfDefined("fs.s3a.secret.key", secretKey)
+    configureS3A("fs.s3a")
 
-    val connectorBucket =
-      MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     MilvusScan
-      .snapshotBucketsToConfigure(snapshotPath, connectorBucket)
-      .foreach { bucket =>
-        setIfDefined(s"fs.s3a.bucket.$bucket.endpoint", endpoint)
-        setIfDefined(s"fs.s3a.bucket.$bucket.connection.ssl.enabled", useSsl)
-        setIfDefined(s"fs.s3a.bucket.$bucket.path.style.access", pathStyle)
-        setIfDefined(s"fs.s3a.bucket.$bucket.access.key", accessKey)
-        setIfDefined(s"fs.s3a.bucket.$bucket.secret.key", secretKey)
-      }
+      .snapshotBucketsToConfigure(
+        snapshotPath,
+        MilvusScan.connectorS3BucketOption(rawOptions).getOrElse("")
+      )
+      .foreach(bucket => configureS3A(s"fs.s3a.bucket.$bucket"))
     conf
   }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -743,6 +743,20 @@ object MilvusScan extends Logging {
     )).distinct
   }
 
+  private[sources] def resolveConnectorS3Bucket(
+      options: scala.collection.Map[String, String]
+  ): String = {
+    options
+      .get(Properties.FsConfig.FsBucketName)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          s"${Properties.FsConfig.FsBucketName} is required for client snapshot reads"
+        )
+      }
+  }
+
   private[sources] def canUseClientSnapshotFastPath(
       milvusOption: MilvusOption
   ): Boolean = {
@@ -1031,10 +1045,7 @@ class MilvusScan(
   private def planInputPartitionsFromClientSnapshot(
       client: MilvusClient
   ): Option[Array[InputPartition]] = {
-    val s3Bucket = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsBucketName,
-      "a-bucket"
-    )
+    val s3Bucket = MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     val snapshotName = Option(options.get(MilvusOption.ClientSnapshotName))
       .filter(_.trim.nonEmpty)
       .getOrElse(
@@ -1152,10 +1163,7 @@ class MilvusScan(
           )
       }
 
-    val s3Bucket = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsBucketName,
-      "a-bucket"
-    )
+    val s3Bucket = MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     val v2Segments =
       if (metadata.manifestList.nonEmpty) {
         V2SegmentLoader.loadV2Segments(
@@ -1296,17 +1304,22 @@ class MilvusScan(
       value.filter(_.nonEmpty).foreach(conf.set(key, _))
     }
 
-    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    if (conf.get("fs.s3a.impl") == null) {
+      conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    }
+    if (accessKey.forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty)) {
+      logWarning(
+        "Snapshot S3 credentials were not provided; Hadoop S3A will use the default AWS credential provider chain."
+      )
+    }
     setIfDefined("fs.s3a.endpoint", endpoint)
     setIfDefined("fs.s3a.connection.ssl.enabled", useSsl)
     setIfDefined("fs.s3a.path.style.access", pathStyle)
     setIfDefined("fs.s3a.access.key", accessKey)
     setIfDefined("fs.s3a.secret.key", secretKey)
 
-    val connectorBucket = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsBucketName,
-      "a-bucket"
-    )
+    val connectorBucket =
+      MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     MilvusScan
       .snapshotBucketsToConfigure(snapshotPath, connectorBucket)
       .foreach { bucket =>

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.connector.read.{
 }
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+// Spark does not expose a public SQL-execution-end hook; validate when upgrading Spark.
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
@@ -244,33 +245,12 @@ case class MilvusTable(
   private def createMinimalCollectionSchema(
       snapshotSchema: Option[com.zilliz.spark.connector.read.CollectionSchema]
   ): CollectionSchema = {
-    import io.milvus.grpc.schema.{
-      CollectionSchema => ProtoCollectionSchema,
-      FieldSchema
-    }
-    import io.milvus.grpc.common.KeyValuePair
+    import io.milvus.grpc.schema.{CollectionSchema => ProtoCollectionSchema}
 
     snapshotSchema match {
       case Some(schema) =>
-        // Convert snapshot schema fields to protobuf FieldSchema
-        val protoFields = schema.fields.map { field =>
-          FieldSchema(
-            fieldID = field.getFieldIDAsLong,
-            name = field.name,
-            description = field.description.getOrElse(""),
-            dataType = io.milvus.grpc.schema.DataType.fromValue(field.dataType),
-            isPrimaryKey = field.isPrimaryKey.getOrElse(false),
-            isClusteringKey = field.isClusteringKey.getOrElse(false),
-            typeParams = field.typeParams.getOrElse(Seq.empty).map { tp =>
-              KeyValuePair(key = tp.key, value = tp.value)
-            }
-          )
-        }
-
-        ProtoCollectionSchema(
-          name = schema.name,
-          description = schema.description.getOrElse(""),
-          fields = protoFields
+        ProtoCollectionSchema.parseFrom(
+          MilvusSnapshotReader.toProtobufSchemaBytes(schema)
         )
 
       case None =>
@@ -644,6 +624,9 @@ object MilvusScan extends Logging {
   private val SnapshotCleanupDrainTimeout = 2.seconds
   private val InitialDropRetryDelayMillis = 200L
   private val DropRetryMaxAttempts = 7
+  private val DefaultClientSnapshotCompactionProtectionSeconds = 86400L
+  private val MaxClientSnapshotCompactionProtectionSeconds =
+    7L * 24L * 60L * 60L
   private val MaxGeneratedSnapshotNameLength = 255
   private val DefaultAwsCredentialsProvider =
     "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
@@ -669,27 +652,44 @@ object MilvusScan extends Logging {
 
   private val PendingCleanupFutures =
     ConcurrentHashMap.newKeySet[Future[Unit]]()
+  private val CleanupDraining = new AtomicBoolean(false)
+  private val CleanupSubmissionLock = new Object
+
+  private[sources] def drainPendingCleanupFutures(
+      timeout: FiniteDuration = SnapshotCleanupDrainTimeout
+  ): Unit = {
+    CleanupSubmissionLock.synchronized {
+      CleanupDraining.set(true)
+    }
+    val deadline = timeout.fromNow
+    var keepDraining = true
+    while (keepDraining && deadline.timeLeft.length > 0) {
+      val snapshot = PendingCleanupFutures.asScala.toSeq
+      if (snapshot.isEmpty) {
+        keepDraining = false
+      } else {
+        snapshot.foreach { future =>
+          val remaining = deadline.timeLeft
+          if (remaining.length > 0) {
+            try Await.ready(future, remaining)
+            catch {
+              case NonFatal(e) =>
+                logWarning(
+                  "Timed out waiting for client snapshot cleanup",
+                  e
+                )
+            }
+          }
+        }
+      }
+    }
+  }
 
   Try(
     Runtime.getRuntime.addShutdownHook(
       new Thread(
         new Runnable {
-          override def run(): Unit = {
-            val deadline = SnapshotCleanupDrainTimeout.fromNow
-            PendingCleanupFutures.asScala.foreach { future =>
-              val remaining = deadline.timeLeft
-              if (remaining.length > 0) {
-                try Await.ready(future, remaining)
-                catch {
-                  case NonFatal(e) =>
-                    logWarning(
-                      "Timed out waiting for client snapshot cleanup",
-                      e
-                    )
-                }
-              }
-            }
-          }
+          override def run(): Unit = drainPendingCleanupFutures()
         },
         "milvus-snapshot-cleanup-shutdown-drain"
       )
@@ -801,6 +801,56 @@ object MilvusScan extends Logging {
     snapshotBucket(snapshotPath).orElse(connectorS3BucketOption(options))
   }
 
+  private[sources] def storageV2ManifestBasePath(
+      item: StorageV2ManifestItem
+  ): String = {
+    MilvusSnapshotReader.parseManifestContent(item.manifest) match {
+      case Right(content) => content.basePath
+      case Left(_)        => item.manifest
+    }
+  }
+
+  private[sources] def validateSnapshotBucketForRelativeDataPaths(
+      snapshotPath: String,
+      connectorBucket: Option[String],
+      storageV2ManifestList: Seq[StorageV2ManifestItem],
+      v2Segments: Seq[V2SegmentInfo]
+  ): Unit = {
+    (snapshotBucket(snapshotPath), connectorBucket) match {
+      case (Some(snapshot), Some(connector)) if snapshot != connector =>
+        val relativeStorageV3Paths = storageV2ManifestList
+          .map(storageV2ManifestBasePath)
+          .filter(isBucketRelativeSnapshotLocation)
+        val relativeStorageV2Paths = v2Segments
+          .flatMap(_.columnGroups.flatMap(_.filePaths))
+          .filter(isBucketRelativeSnapshotLocation)
+        val relativePaths = relativeStorageV3Paths ++ relativeStorageV2Paths
+        if (relativePaths.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"Client-created snapshot metadata is in bucket '$snapshot' but " +
+              s"${Properties.FsConfig.FsBucketName} is '$connector' and snapshot data paths are bucket-relative. " +
+              "Refusing to guess which bucket native executors should use; set the connector bucket to the data bucket or use fully-qualified data paths. " +
+              s"Example relative path: ${relativePaths.head}"
+          )
+        }
+      case _ =>
+    }
+  }
+
+  private[sources] def ensureClientSnapshotHasPackedSegments(
+      storageV2ManifestList: Seq[StorageV2ManifestItem],
+      v2Segments: Seq[V2SegmentInfo],
+      collectionName: String
+  ): Unit = {
+    if (storageV2ManifestList.isEmpty && v2Segments.isEmpty) {
+      throw new IllegalArgumentException(
+        s"No packed-parquet segments (StorageV2/V3) found in client-created snapshot for collection " +
+          s"$collectionName. This connector requires Milvus 2.6+ with Storage V2 or V3. " +
+          "Please ensure the collection has been flushed and contains data."
+      )
+    }
+  }
+
   private[sources] def isBucketRelativeSnapshotLocation(
       location: String
   ): Boolean = {
@@ -854,6 +904,29 @@ object MilvusScan extends Logging {
     if (value <= 0) {
       throw new IllegalArgumentException(
         s"Option '$key' must be positive, got $value"
+      )
+    }
+    value
+  }
+
+  private[sources] def parseClientSnapshotCompactionProtectionSeconds(
+      options: CaseInsensitiveStringMap
+  ): Long = {
+    val value = parsePositiveLongOption(
+      options,
+      MilvusOption.ClientSnapshotCompactionProtectionSeconds,
+      DefaultClientSnapshotCompactionProtectionSeconds
+    )
+    if (value > MaxClientSnapshotCompactionProtectionSeconds) {
+      throw new IllegalArgumentException(
+        s"Option '${MilvusOption.ClientSnapshotCompactionProtectionSeconds}' must be <= " +
+          s"$MaxClientSnapshotCompactionProtectionSeconds seconds, got $value"
+      )
+    }
+    if (value > DefaultClientSnapshotCompactionProtectionSeconds) {
+      logWarning(
+        s"Client snapshot compaction protection is set to $value seconds; " +
+          "long protection windows can delay Milvus compaction."
       )
     }
     value
@@ -917,6 +990,17 @@ object MilvusScan extends Logging {
     )
   }
 
+  private[sources] def preserveResultWhenCloseFails(
+      result: Try[Unit],
+      close: => Unit,
+      closeDescription: String
+  ): Try[Unit] = {
+    Try(close).failed.foreach { e =>
+      logWarning(s"Failed to close $closeDescription", e)
+    }
+    result
+  }
+
   private def dropClientReadSnapshotWithNewClient(
       baseOptions: Map[String, String],
       databaseName: String,
@@ -925,17 +1009,18 @@ object MilvusScan extends Logging {
       reason: String
   ): Try[Unit] = {
     Try(MilvusClient(MilvusOption(baseOptions))).flatMap { client =>
-      try {
-        dropClientReadSnapshot(
-          client,
-          databaseName,
-          collectionName,
-          snapshotName,
-          reason
-        )
-      } finally {
-        client.close()
-      }
+      val dropResult = dropClientReadSnapshot(
+        client,
+        databaseName,
+        collectionName,
+        snapshotName,
+        reason
+      )
+      preserveResultWhenCloseFails(
+        dropResult,
+        client.close(),
+        s"Milvus client after dropping client read snapshot $snapshotName"
+      )
     }
   }
 
@@ -946,24 +1031,32 @@ object MilvusScan extends Logging {
       snapshotName: String,
       reason: String
   ): Unit = {
-    val cleanupFuture = Future {
-      dropClientReadSnapshotWithNewClient(
-        baseOptions,
-        databaseName,
-        collectionName,
-        snapshotName,
-        reason
-      ) match {
-        case Success(_) =>
-        case Failure(e) =>
-          logError(
-            s"Failed to drop client read snapshot $snapshotName after $reason",
-            e
-          )
+    CleanupSubmissionLock.synchronized {
+      if (CleanupDraining.get()) {
+        logWarning(
+          s"Skipping client read snapshot cleanup submission for $snapshotName after $reason because shutdown drain has started"
+        )
+        return
       }
+      val cleanupFuture = Future {
+        dropClientReadSnapshotWithNewClient(
+          baseOptions,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        ) match {
+          case Success(_) =>
+          case Failure(e) =>
+            logError(
+              s"Failed to drop client read snapshot $snapshotName after $reason",
+              e
+            )
+        }
+      }
+      PendingCleanupFutures.add(cleanupFuture)
+      cleanupFuture.onComplete(_ => PendingCleanupFutures.remove(cleanupFuture))
     }
-    PendingCleanupFutures.add(cleanupFuture)
-    cleanupFuture.onComplete(_ => PendingCleanupFutures.remove(cleanupFuture))
   }
 
   private[sources] def registerClientSnapshotCleanup(
@@ -1172,11 +1265,8 @@ class MilvusScan(
     val description = Option(
       options.get(MilvusOption.ClientSnapshotDescription)
     ).filter(_.trim.nonEmpty).getOrElse("spark connector client read snapshot")
-    val protectionSeconds = MilvusScan.parsePositiveLongOption(
-      options,
-      MilvusOption.ClientSnapshotCompactionProtectionSeconds,
-      86400L
-    )
+    val protectionSeconds =
+      MilvusScan.parseClientSnapshotCompactionProtectionSeconds(options)
 
     val cleanupRegistration = MilvusScan.activeCleanupRegistration()
     if (cleanupRegistration.isEmpty) {
@@ -1295,6 +1385,19 @@ class MilvusScan(
             )
         }
       } else Seq.empty
+    val storageV2ManifestList =
+      metadata.storageV2ManifestList.getOrElse(Seq.empty)
+    MilvusScan.ensureClientSnapshotHasPackedSegments(
+      storageV2ManifestList,
+      v2Segments,
+      metadata.collection.schema.name
+    )
+    MilvusScan.validateSnapshotBucketForRelativeDataPaths(
+      snapshotPath,
+      MilvusScan.connectorS3BucketOption(milvusOption.options),
+      storageV2ManifestList,
+      v2Segments
+    )
 
     val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
       metadata.collection.schema
@@ -1305,7 +1408,7 @@ class MilvusScan(
       collectionId = metadata.snapshotInfo.collectionId,
       partitionIds = metadata.snapshotInfo.partitionIds,
       schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
-      manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
+      manifestList = storageV2ManifestList,
       v2Segments = v2Segments,
       snapshotBucketForRelativePaths = snapshotBucket
     )
@@ -1497,19 +1600,11 @@ class MilvusScan(
       conf: Configuration,
       path: String
   ): String = {
-    val maxBytes = milvusOption.options
-      .get(MilvusOption.SnapshotMaxJsonBytes)
-      .filter(_.trim.nonEmpty)
-      .map { raw =>
-        val parsed = raw.toLong
-        if (parsed <= 0) {
-          throw new IllegalArgumentException(
-            s"${MilvusOption.SnapshotMaxJsonBytes} must be positive, got $raw"
-          )
-        }
-        parsed
-      }
-      .getOrElse(MilvusSnapshotReader.MaxSnapshotJsonBytes)
+    val maxBytes = MilvusScan.parsePositiveLongOption(
+      options,
+      MilvusOption.SnapshotMaxJsonBytes,
+      MilvusSnapshotReader.MaxSnapshotJsonBytes
+    )
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)
     try {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -77,6 +77,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
   ): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val milvusOption = MilvusOption(options)
+    MilvusOption.validateSnapshotModeOptions(options)
     val isSnapshotMode = MilvusOption.isSnapshotMode(options)
     if (milvusOption.uri.isEmpty && !isSnapshotMode) {
       throw new IllegalArgumentException(
@@ -93,6 +94,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
     val milvusOption = MilvusOption(options)
 
     // Check for snapshot mode - use snapshot schema if provided
+    MilvusOption.validateSnapshotModeOptions(options)
     val isSnapshotMode = MilvusOption.isSnapshotMode(options)
 
     if (isSnapshotMode) {
@@ -653,7 +655,8 @@ object MilvusScan extends Logging {
       }
     }
 
-  private val CleanupRpcExecutor = Executors.newCachedThreadPool(
+  private val CleanupRpcExecutor = Executors.newFixedThreadPool(
+    2,
     daemonThreadFactory("milvus-snapshot-cleanup-rpc")
   )
 
@@ -726,12 +729,20 @@ object MilvusScan extends Logging {
     if (trimmed.isEmpty) {
       None
     } else {
-      val uri = new URI(resolveClientSnapshotLocation(trimmed, ""))
-      Option(uri.getHost).orElse {
-        Option(uri.getAuthority)
-          .map(_.takeWhile(_ != '@'))
-          .map(_.split(":").head)
-          .filter(_.nonEmpty)
+      val uri = new URI(trimmed)
+      Option(uri.getScheme).map(_.toLowerCase) match {
+        case Some("s3a") | Some("s3") =>
+          Option(uri.getHost).orElse {
+            Option(uri.getAuthority)
+              .map(_.takeWhile(_ != '@'))
+              .map(_.split(":").head)
+              .filter(_.nonEmpty)
+          }
+        case Some(other) =>
+          throw new IllegalArgumentException(
+            s"Unsupported snapshot s3_location scheme '$other': $trimmed"
+          )
+        case None => None
       }
     }
   }
@@ -776,7 +787,7 @@ object MilvusScan extends Logging {
       snapshotPath: String,
       options: scala.collection.Map[String, String]
   ): Option[String] = {
-    connectorS3BucketOption(options).orElse(snapshotBucket(snapshotPath))
+    snapshotBucket(snapshotPath).orElse(connectorS3BucketOption(options))
   }
 
   private[sources] def isBucketRelativeSnapshotLocation(
@@ -803,7 +814,11 @@ object MilvusScan extends Logging {
     val prefix = "spark_read_"
     val maxCollectionNameLength =
       MaxGeneratedSnapshotNameLength - prefix.length - suffix.length
-    val safeCollectionName = collectionName.take(maxCollectionNameLength.max(0))
+    val sanitizedCollectionName =
+      collectionName.replaceAll("[^A-Za-z0-9_]", "_")
+    val safeCollectionName = sanitizedCollectionName.take(
+      maxCollectionNameLength.max(0)
+    )
     s"$prefix$safeCollectionName$suffix"
   }
 
@@ -913,6 +928,33 @@ object MilvusScan extends Logging {
     }
   }
 
+  private def submitClientSnapshotCleanup(
+      baseOptions: Map[String, String],
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String,
+      reason: String
+  ): Unit = {
+    val cleanupFuture = Future {
+      dropClientReadSnapshotWithNewClient(
+        baseOptions,
+        databaseName,
+        collectionName,
+        snapshotName,
+        reason
+      ) match {
+        case Success(_) =>
+        case Failure(e) =>
+          logError(
+            s"Failed to drop client read snapshot $snapshotName after $reason",
+            e
+          )
+      }
+    }
+    PendingCleanupFutures.add(cleanupFuture)
+    cleanupFuture.onComplete(_ => PendingCleanupFutures.remove(cleanupFuture))
+  }
+
   private[sources] def registerClientSnapshotCleanup(
       registration: SnapshotCleanupRegistration,
       baseOptions: Map[String, String],
@@ -925,24 +967,13 @@ object MilvusScan extends Logging {
     val executionId = registration.executionId
 
     def submitCleanup(reason: String): Unit = {
-      val cleanupFuture = Future {
-        dropClientReadSnapshotWithNewClient(
-          baseOptions,
-          databaseName,
-          collectionName,
-          snapshotName,
-          reason
-        ) match {
-          case Success(_) =>
-          case Failure(e) =>
-            logError(
-              s"Failed to drop client read snapshot $snapshotName after $reason",
-              e
-            )
-        }
-      }
-      PendingCleanupFutures.add(cleanupFuture)
-      cleanupFuture.onComplete(_ => PendingCleanupFutures.remove(cleanupFuture))
+      submitClientSnapshotCleanup(
+        baseOptions,
+        databaseName,
+        collectionName,
+        snapshotName,
+        reason
+      )
     }
 
     val listener = new SparkListener {
@@ -976,7 +1007,8 @@ object MilvusScan extends Logging {
       partitionIds: Seq[Long],
       schemaBytesBase64: String,
       manifestList: Seq[StorageV2ManifestItem],
-      v2Segments: Seq[V2SegmentInfo]
+      v2Segments: Seq[V2SegmentInfo],
+      snapshotBucketForRelativePaths: Option[String] = None
   ): Map[String, String] = {
     var out = baseOptions.filterNot { case (key, _) =>
       SnapshotOptionKeys.exists(_.equalsIgnoreCase(key))
@@ -993,6 +1025,12 @@ object MilvusScan extends Logging {
     if (v2Segments.nonEmpty) {
       out += MilvusOption.SnapshotV2Segments ->
         MilvusSnapshotReader.serializeV2Segments(v2Segments)
+    }
+    snapshotBucketForRelativePaths.foreach { bucket =>
+      out = out.filterNot { case (key, _) =>
+        key.equalsIgnoreCase(Properties.FsConfig.FsBucketName)
+      }
+      out += Properties.FsConfig.FsBucketName -> bucket
     }
     out
   }
@@ -1065,24 +1103,10 @@ class MilvusScan(
 
   private def computeInputPartitions(): Array[InputPartition] = {
     if (MilvusOption.isSnapshotMode(options)) {
+      MilvusOption.validateSnapshotModeOptions(options)
       val snapshotManifests = Option(
         options.get(MilvusOption.SnapshotManifests)
       )
-      val snapshotV2Segments = Option(
-        options.get(MilvusOption.SnapshotV2Segments)
-      )
-      val explicitSnapshotMode = Option(options.get(MilvusOption.SnapshotMode))
-        .exists(_.equalsIgnoreCase("true"))
-      if (
-        explicitSnapshotMode && snapshotManifests.forall(
-          _.trim.isEmpty
-        ) && snapshotV2Segments
-          .forall(_.trim.isEmpty)
-      ) {
-        throw new IllegalArgumentException(
-          s"${MilvusOption.SnapshotMode}=true requires ${MilvusOption.SnapshotManifests} or ${MilvusOption.SnapshotV2Segments}"
-        )
-      }
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
     }
 
@@ -1165,21 +1189,13 @@ class MilvusScan(
             s"Skipping client snapshot fast path because ${Properties.FsConfig.FsBucketName} is missing " +
               "and the snapshot location is bucket-relative; falling back to legacy GetPersistentSegmentInfo read path"
           )
-          MilvusScan
-            .dropClientReadSnapshot(
-              client,
-              milvusOption.databaseName,
-              milvusOption.collectionName,
-              snapshot.name,
-              s"missing ${Properties.FsConfig.FsBucketName} for bucket-relative snapshot location"
-            )
-            .failed
-            .foreach { e =>
-              logError(
-                s"Failed to drop client read snapshot ${snapshot.name} after missing bucket fallback",
-                e
-              )
-            }
+          MilvusScan.submitClientSnapshotCleanup(
+            options.asScala.toMap,
+            milvusOption.databaseName,
+            milvusOption.collectionName,
+            snapshot.name,
+            s"missing ${Properties.FsConfig.FsBucketName} for bucket-relative snapshot location"
+          )
           None
         } else if (
           MilvusScan.registerClientSnapshotCleanup(
@@ -1200,21 +1216,13 @@ class MilvusScan(
           )
           Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
         } else {
-          MilvusScan
-            .dropClientReadSnapshot(
-              client,
-              milvusOption.databaseName,
-              milvusOption.collectionName,
-              snapshot.name,
-              "cleanup registration failure"
-            )
-            .failed
-            .foreach { e =>
-              logError(
-                s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure; falling back to legacy read path",
-                e
-              )
-            }
+          MilvusScan.submitClientSnapshotCleanup(
+            options.asScala.toMap,
+            milvusOption.databaseName,
+            milvusOption.collectionName,
+            snapshot.name,
+            "cleanup registration failure"
+          )
           None
         }
 
@@ -1281,7 +1289,8 @@ class MilvusScan(
       partitionIds = metadata.snapshotInfo.partitionIds,
       schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
       manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
-      v2Segments = v2Segments
+      v2Segments = v2Segments,
+      snapshotBucketForRelativePaths = snapshotBucket
     )
     require(
       MilvusOption.isSnapshotMode(snapshotOptions),
@@ -1483,8 +1492,10 @@ class MilvusScan(
       try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
       finally in.close()
     } finally {
-      if (conf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)) {
-        fs.close()
+      Option(uri.getScheme).foreach { scheme =>
+        if (conf.getBoolean(s"fs.$scheme.impl.disable.cache", false)) {
+          fs.close()
+        }
       }
     }
   }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -937,17 +937,6 @@ class MilvusScan(
 
     val client = MilvusClient(milvusOption)
     try {
-      val collectionInfo = client
-        .getCollectionInfo(
-          milvusOption.databaseName,
-          milvusOption.collectionName
-        )
-        .getOrElse(
-          throw new Exception(
-            s"Collection ${milvusOption.collectionName} not found"
-          )
-        )
-
       val clientSnapshotPartitions =
         if (MilvusScan.canUseClientSnapshotFastPath(milvusOption)) {
           planInputPartitionsFromClientSnapshot(client)
@@ -959,6 +948,16 @@ class MilvusScan(
         }
 
       clientSnapshotPartitions.getOrElse {
+        val collectionInfo = client
+          .getCollectionInfo(
+            milvusOption.databaseName,
+            milvusOption.collectionName
+          )
+          .getOrElse(
+            throw new Exception(
+              s"Collection ${milvusOption.collectionName} not found"
+            )
+          )
         planInputPartitionsFromLegacyClient(client, collectionInfo)
       }
     } finally {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -60,6 +60,7 @@ import com.zilliz.spark.connector.read.{
   MilvusPartitionReaderFactory,
   MilvusSnapshotReader,
   MilvusStorageV3InputPartition,
+  SnapshotMetadata,
   StorageV2ManifestItem,
   V2SegmentInfo,
   V2SegmentLoader
@@ -641,6 +642,7 @@ object MilvusScan extends Logging {
   private val SnapshotCleanupDrainTimeout = 2.seconds
   private val InitialDropRetryDelayMillis = 200L
   private val DropRetryMaxAttempts = 7
+  private val MaxGeneratedSnapshotNameLength = 255
 
   private def daemonThreadFactory(namePrefix: String): ThreadFactory =
     new ThreadFactory {
@@ -765,6 +767,19 @@ object MilvusScan extends Logging {
     milvusOption.segmentID.isEmpty
   }
 
+  private[sources] def generatedClientSnapshotName(
+      collectionName: String,
+      currentTimeMillis: Long = System.currentTimeMillis(),
+      uuid: String = UUID.randomUUID().toString.replace("-", "")
+  ): String = {
+    val suffix = s"_${currentTimeMillis}_$uuid"
+    val prefix = "spark_read_"
+    val maxCollectionNameLength =
+      MaxGeneratedSnapshotNameLength - prefix.length - suffix.length
+    val safeCollectionName = collectionName.take(maxCollectionNameLength.max(0))
+    s"$prefix$safeCollectionName$suffix"
+  }
+
   private[sources] def parsePositiveLongOption(
       options: CaseInsensitiveStringMap,
       key: String,
@@ -878,43 +893,25 @@ object MilvusScan extends Logging {
       collectionName: String,
       snapshotName: String
   ): Boolean = {
-    val cleanupComplete = new AtomicBoolean(false)
-    val cleanupInFlight = new AtomicBoolean(false)
+    val cleanupTriggered = new AtomicBoolean(false)
     val session = registration.session
     val executionId = registration.executionId
 
-    def removeListener(listener: SparkListener): Unit = {
-      session.sparkContext.removeSparkListener(listener)
-    }
-
-    def submitCleanup(reason: String, listener: SparkListener): Unit = {
-      if (
-        cleanupComplete.get() || !cleanupInFlight.compareAndSet(false, true)
-      ) {
-        return
-      }
+    def submitCleanup(reason: String): Unit = {
       val cleanupFuture = Future {
-        try {
-          val dropResult = dropClientReadSnapshotWithNewClient(
-            baseOptions,
-            databaseName,
-            collectionName,
-            snapshotName,
-            reason
-          )
-          dropResult match {
-            case Success(_) => cleanupComplete.set(true)
-            case Failure(e) =>
-              logError(
-                s"Failed to drop client read snapshot $snapshotName after $reason",
-                e
-              )
-          }
-        } finally {
-          cleanupInFlight.set(false)
-          if (cleanupComplete.get()) {
-            removeListener(listener)
-          }
+        dropClientReadSnapshotWithNewClient(
+          baseOptions,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        ) match {
+          case Success(_) =>
+          case Failure(e) =>
+            logError(
+              s"Failed to drop client read snapshot $snapshotName after $reason",
+              e
+            )
         }
       }
       PendingCleanupFutures.add(cleanupFuture)
@@ -925,8 +922,10 @@ object MilvusScan extends Logging {
       override def onOtherEvent(event: SparkListenerEvent): Unit = {
         event match {
           case e: SparkListenerSQLExecutionEnd
-              if e.executionId == executionId =>
-            submitCleanup(s"Spark SQL execution $executionId ended", this)
+              if e.executionId == executionId && cleanupTriggered
+                .compareAndSet(false, true) =>
+            try submitCleanup(s"Spark SQL execution $executionId ended")
+            finally session.sparkContext.removeSparkListener(this)
           case _ =>
         }
       }
@@ -952,7 +951,9 @@ object MilvusScan extends Logging {
       manifestList: Seq[StorageV2ManifestItem],
       v2Segments: Seq[V2SegmentInfo]
   ): Map[String, String] = {
-    var out = baseOptions -- SnapshotOptionKeys
+    var out = baseOptions.filterNot { case (key, _) =>
+      SnapshotOptionKeys.exists(_.equalsIgnoreCase(key))
+    }
     out = out ++ Map(
       MilvusOption.SnapshotMode -> "true",
       MilvusOption.MilvusCollectionName -> collectionName,
@@ -967,6 +968,33 @@ object MilvusScan extends Logging {
         MilvusSnapshotReader.serializeV2Segments(v2Segments)
     }
     out
+  }
+
+  private[sources] def validateClientSnapshotMetadata(
+      metadata: SnapshotMetadata,
+      snapshotPath: String
+  ): SnapshotMetadata = {
+    if (metadata == null) {
+      throw new IllegalArgumentException(
+        s"Client-created snapshot metadata at $snapshotPath is missing metadata"
+      )
+    }
+    if (metadata.snapshotInfo == null) {
+      throw new IllegalArgumentException(
+        s"Client-created snapshot metadata at $snapshotPath is missing snapshot_info"
+      )
+    }
+    if (metadata.collection == null) {
+      throw new IllegalArgumentException(
+        s"Client-created snapshot metadata at $snapshotPath is missing collection"
+      )
+    }
+    if (metadata.collection.schema == null) {
+      throw new IllegalArgumentException(
+        s"Client-created snapshot metadata at $snapshotPath is missing collection.schema"
+      )
+    }
+    metadata
   }
 }
 
@@ -1005,6 +1033,21 @@ class MilvusScan(
       val snapshotManifests = Option(
         options.get(MilvusOption.SnapshotManifests)
       )
+      val snapshotV2Segments = Option(
+        options.get(MilvusOption.SnapshotV2Segments)
+      )
+      val explicitSnapshotMode = Option(options.get(MilvusOption.SnapshotMode))
+        .exists(_.equalsIgnoreCase("true"))
+      if (
+        explicitSnapshotMode && snapshotManifests.forall(
+          _.trim.isEmpty
+        ) && snapshotV2Segments
+          .forall(_.trim.isEmpty)
+      ) {
+        throw new IllegalArgumentException(
+          s"${MilvusOption.SnapshotMode}=true requires ${MilvusOption.SnapshotManifests} or ${MilvusOption.SnapshotV2Segments}"
+        )
+      }
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
     }
 
@@ -1049,8 +1092,7 @@ class MilvusScan(
     val snapshotName = Option(options.get(MilvusOption.ClientSnapshotName))
       .filter(_.trim.nonEmpty)
       .getOrElse(
-        s"spark_read_${milvusOption.collectionName}_${System
-            .currentTimeMillis()}_${UUID.randomUUID().toString.replace("-", "")}"
+        MilvusScan.generatedClientSnapshotName(milvusOption.collectionName)
       )
     val description = Option(
       options.get(MilvusOption.ClientSnapshotDescription)
@@ -1078,59 +1120,41 @@ class MilvusScan(
       protectionSeconds
     ) match {
       case scala.util.Success(snapshot) =>
-        try {
+        if (
+          MilvusScan.registerClientSnapshotCleanup(
+            cleanupRegistration.get,
+            options.asScala.toMap,
+            milvusOption.databaseName,
+            milvusOption.collectionName,
+            snapshot.name
+          )
+        ) {
+          logWarning(
+            s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
+              "an unclean driver exit can leave it behind and require manual cleanup."
+          )
           val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
             snapshot.s3Location,
             s3Bucket
           )
-          val partitions = planInputPartitionsFromClientSnapshotPath(
-            snapshotPath
-          )
-          if (
-            MilvusScan.registerClientSnapshotCleanup(
-              cleanupRegistration.get,
-              options.asScala.toMap,
+          Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+        } else {
+          MilvusScan
+            .dropClientReadSnapshot(
+              client,
               milvusOption.databaseName,
               milvusOption.collectionName,
-              snapshot.name
+              snapshot.name,
+              "cleanup registration failure"
             )
-          ) {
-            logWarning(
-              s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
-                "an unclean driver exit can leave it behind and require manual cleanup."
-            )
-            Some(partitions)
-          } else {
-            MilvusScan
-              .dropClientReadSnapshot(
-                client,
-                milvusOption.databaseName,
-                milvusOption.collectionName,
-                snapshot.name,
-                "cleanup registration failure"
+            .failed
+            .foreach { e =>
+              logError(
+                s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure; falling back to legacy read path",
+                e
               )
-              .failed
-              .foreach { e =>
-                logError(
-                  s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure; falling back to legacy read path",
-                  e
-                )
-              }
-            None
-          }
-        } catch {
-          case NonFatal(e) =>
-            MilvusScan
-              .dropClientReadSnapshot(
-                client,
-                milvusOption.databaseName,
-                milvusOption.collectionName,
-                snapshot.name,
-                "planning failure"
-              )
-              .failed
-              .foreach(e.addSuppressed)
-            throw e
+            }
+          None
         }
 
       case scala.util.Failure(e) if MilvusClient.isServiceNotImplemented(e) =>
@@ -1154,14 +1178,17 @@ class MilvusScan(
     val hadoopConf = buildSnapshotHadoopConf(snapshotPath)
     val snapshotJson = readAllBytes(hadoopConf, snapshotPath)
     val metadata =
-      MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
-        case Right(value) => value
-        case Left(err) =>
-          throw new IllegalArgumentException(
-            s"Failed to parse client-created snapshot metadata: ${err.getMessage}",
-            err
-          )
-      }
+      MilvusScan.validateClientSnapshotMetadata(
+        MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
+          case Right(value) => value
+          case Left(err) =>
+            throw new IllegalArgumentException(
+              s"Failed to parse client-created snapshot metadata: ${err.getMessage}",
+              err
+            )
+        },
+        snapshotPath
+      )
 
     val s3Bucket = MilvusScan.resolveConnectorS3Bucket(milvusOption.options)
     val v2Segments =
@@ -1191,6 +1218,10 @@ class MilvusScan(
       schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
       manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
       v2Segments = v2Segments
+    )
+    require(
+      MilvusOption.isSnapshotMode(snapshotOptions),
+      "Client-created snapshot options must enable snapshot mode"
     )
 
     new MilvusScan(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -3,15 +3,11 @@ package com.zilliz.spark.connector.sources
 import java.{util => ju}
 import java.net.URI
 import java.util.{Base64, HashMap, Map => JMap, UUID}
-import java.util.concurrent.{
-  Executors,
-  ScheduledFuture,
-  ThreadFactory,
-  TimeUnit
-}
+import java.util.concurrent.{ConcurrentHashMap, Executors, ThreadFactory}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
@@ -637,27 +633,54 @@ class MilvusScanBuilder(
 }
 
 object MilvusScan extends Logging {
-  case class SnapshotCleanupRegistration(
+  private[sources] case class SnapshotCleanupRegistration(
       session: SparkSession,
-      executionId: String
+      executionId: Long
   )
 
-  private val SnapshotCleanupTtlMillis = TimeUnit.MINUTES.toMillis(30)
+  private val SnapshotCleanupDrainTimeout = 2.seconds
+  private val InitialDropRetryDelayMillis = 200L
+  private val DropRetryMaxAttempts = 7
 
-  private val CleanupThreadFactory = new ThreadFactory {
-    override def newThread(r: Runnable): Thread = {
-      val thread = new Thread(r, "milvus-snapshot-cleanup")
-      thread.setDaemon(true)
-      thread
+  private def daemonThreadFactory(namePrefix: String): ThreadFactory =
+    new ThreadFactory {
+      override def newThread(r: Runnable): Thread = {
+        val thread = new Thread(r, namePrefix)
+        thread.setDaemon(true)
+        thread
+      }
     }
-  }
 
-  private val CleanupExecutor = Executors.newSingleThreadScheduledExecutor(
-    CleanupThreadFactory
+  private val CleanupRpcExecutor = Executors.newCachedThreadPool(
+    daemonThreadFactory("milvus-snapshot-cleanup-rpc")
   )
 
   private implicit val CleanupExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(CleanupExecutor)
+    ExecutionContext.fromExecutor(CleanupRpcExecutor)
+
+  private val PendingCleanupFutures =
+    ConcurrentHashMap.newKeySet[Future[Unit]]()
+
+  Runtime.getRuntime.addShutdownHook(
+    new Thread(
+      new Runnable {
+        override def run(): Unit = {
+          val deadline = SnapshotCleanupDrainTimeout.fromNow
+          PendingCleanupFutures.asScala.foreach { future =>
+            val remaining = deadline.timeLeft
+            if (remaining.length > 0) {
+              try Await.ready(future, remaining)
+              catch {
+                case NonFatal(e) =>
+                  logWarning("Timed out waiting for client snapshot cleanup", e)
+              }
+            }
+          }
+        }
+      },
+      "milvus-snapshot-cleanup-shutdown-drain"
+    )
+  )
 
   private val SnapshotOptionKeys = Seq(
     MilvusOption.SnapshotMode,
@@ -665,37 +688,53 @@ object MilvusScan extends Logging {
     MilvusOption.SnapshotV2Segments,
     MilvusOption.SnapshotCollectionId,
     MilvusOption.SnapshotPartitionIds,
+    MilvusOption.SnapshotSchemaJson,
     MilvusOption.SnapshotSchemaBytes
   )
 
-  def resolveClientSnapshotLocation(
+  private[sources] def resolveClientSnapshotLocation(
       location: String,
       bucket: String
   ): String = {
     val trimmed = Option(location).map(_.trim).getOrElse("")
     if (trimmed.isEmpty) {
       throw new IllegalArgumentException("snapshot s3_location is empty")
-    } else if (trimmed.startsWith("s3a://")) {
-      trimmed
-    } else if (trimmed.startsWith("s3://")) {
-      "s3a://" + trimmed.stripPrefix("s3://")
-    } else if (bucket.trim.nonEmpty) {
-      s"s3a://${bucket.trim}/${trimmed.stripPrefix("/")}"
-    } else {
-      trimmed
+    }
+
+    val scheme = Option(new URI(trimmed).getScheme).map(_.toLowerCase)
+    scheme match {
+      case Some("s3a") => trimmed
+      case Some("s3") =>
+        s"s3a://${trimmed.substring(trimmed.indexOf("://") + 3)}"
+      case Some(other) =>
+        throw new IllegalArgumentException(
+          s"Unsupported snapshot s3_location scheme '$other': $trimmed"
+        )
+      case None if bucket.trim.nonEmpty =>
+        s"s3a://${bucket.trim}/${trimmed.stripPrefix("/")}"
+      case None =>
+        throw new IllegalArgumentException(
+          "bucket-relative snapshot s3_location requires connector S3 bucket"
+        )
     }
   }
 
-  def snapshotBucket(location: String): Option[String] = {
+  private[sources] def snapshotBucket(location: String): Option[String] = {
     val trimmed = Option(location).map(_.trim).getOrElse("")
     if (trimmed.isEmpty) {
       None
     } else {
-      Option(new URI(resolveClientSnapshotLocation(trimmed, "")).getHost)
+      val uri = new URI(resolveClientSnapshotLocation(trimmed, ""))
+      Option(uri.getHost).orElse {
+        Option(uri.getAuthority)
+          .map(_.takeWhile(_ != '@'))
+          .map(_.split(":").head)
+          .filter(_.nonEmpty)
+      }
     }
   }
 
-  def snapshotBucketsToConfigure(
+  private[sources] def snapshotBucketsToConfigure(
       snapshotPath: String,
       connectorBucket: String
   ): Seq[String] = {
@@ -704,31 +743,69 @@ object MilvusScan extends Logging {
     )).distinct
   }
 
-  def canUseClientSnapshotFastPath(milvusOption: MilvusOption): Boolean = {
+  private[sources] def canUseClientSnapshotFastPath(
+      milvusOption: MilvusOption
+  ): Boolean = {
     milvusOption.partitionName.isEmpty &&
     milvusOption.partitionID.isEmpty &&
     milvusOption.segmentID.isEmpty
   }
 
-  def activeCleanupRegistration(): Option[SnapshotCleanupRegistration] = {
+  private[sources] def parsePositiveLongOption(
+      options: CaseInsensitiveStringMap,
+      key: String,
+      defaultValue: Long
+  ): Long = {
+    val value = Option(options.get(key))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map { raw =>
+        try raw.toLong
+        catch {
+          case _: NumberFormatException =>
+            throw new IllegalArgumentException(
+              s"Option '$key' must be a positive long, got '$raw'"
+            )
+        }
+      }
+      .getOrElse(defaultValue)
+    if (value <= 0) {
+      throw new IllegalArgumentException(
+        s"Option '$key' must be positive, got $value"
+      )
+    }
+    value
+  }
+
+  private[sources] def activeCleanupRegistration()
+      : Option[SnapshotCleanupRegistration] = {
     SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
       case Some(session) =>
         Option(
           session.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-        )
-          .filter(_.trim.nonEmpty)
-          .map(SnapshotCleanupRegistration(session, _))
+        ).flatMap { raw =>
+          try {
+            val executionId = raw.trim.toLong
+            Some(SnapshotCleanupRegistration(session, executionId))
+          } catch {
+            case _: NumberFormatException =>
+              logWarning(
+                s"Ignoring non-numeric ${SQLExecution.EXECUTION_ID_KEY}: $raw"
+              )
+              None
+          }
+        }
       case None => None
     }
   }
 
-  def dropClientReadSnapshot(
+  private[sources] def dropClientReadSnapshot(
       client: MilvusClient,
       databaseName: String,
       collectionName: String,
       snapshotName: String,
       reason: String,
-      maxAttempts: Int = 3
+      maxAttempts: Int = DropRetryMaxAttempts
   ): Try[Unit] = {
     var lastFailure = Option.empty[Throwable]
     (1 to maxAttempts).foreach { attempt =>
@@ -743,7 +820,10 @@ object MilvusScan extends Logging {
               s"(attempt $attempt/$maxAttempts)",
             e
           )
-          if (attempt < maxAttempts) Thread.sleep(200L * attempt)
+          if (attempt < maxAttempts) {
+            val delayMillis = InitialDropRetryDelayMillis << (attempt - 1)
+            Thread.sleep(delayMillis)
+          }
       }
     }
     Failure(
@@ -777,7 +857,7 @@ object MilvusScan extends Logging {
     }
   }
 
-  def registerClientSnapshotCleanup(
+  private[sources] def registerClientSnapshotCleanup(
       registration: SnapshotCleanupRegistration,
       baseOptions: Map[String, String],
       databaseName: String,
@@ -789,79 +869,57 @@ object MilvusScan extends Logging {
     val session = registration.session
     val executionId = registration.executionId
 
-    var ttlTask: ScheduledFuture[_] = null
-
     def removeListener(listener: SparkListener): Unit = {
       session.sparkContext.removeSparkListener(listener)
-      if (ttlTask != null) ttlTask.cancel(false)
     }
 
-    def submitCleanup(
-        reason: String,
-        listener: SparkListener,
-        finalAttempt: Boolean
-    ): Unit = {
+    def submitCleanup(reason: String, listener: SparkListener): Unit = {
       if (
         cleanupComplete.get() || !cleanupInFlight.compareAndSet(false, true)
       ) {
         return
       }
-      Future {
-        val dropResult = dropClientReadSnapshotWithNewClient(
-          baseOptions,
-          databaseName,
-          collectionName,
-          snapshotName,
-          reason
-        )
-        dropResult match {
-          case Success(_) =>
-            cleanupComplete.set(true)
+      val cleanupFuture = Future {
+        try {
+          val dropResult = dropClientReadSnapshotWithNewClient(
+            baseOptions,
+            databaseName,
+            collectionName,
+            snapshotName,
+            reason
+          )
+          dropResult match {
+            case Success(_) => cleanupComplete.set(true)
+            case Failure(e) =>
+              logError(
+                s"Failed to drop client read snapshot $snapshotName after $reason",
+                e
+              )
+          }
+        } finally {
+          cleanupInFlight.set(false)
+          if (cleanupComplete.get()) {
             removeListener(listener)
-          case Failure(e) =>
-            logError(
-              s"Failed to drop client read snapshot $snapshotName after $reason",
-              e
-            )
-            if (finalAttempt) {
-              removeListener(listener)
-            }
+          }
         }
-        cleanupInFlight.set(false)
       }
+      PendingCleanupFutures.add(cleanupFuture)
+      cleanupFuture.onComplete(_ => PendingCleanupFutures.remove(cleanupFuture))
     }
 
     val listener = new SparkListener {
       override def onOtherEvent(event: SparkListenerEvent): Unit = {
         event match {
           case e: SparkListenerSQLExecutionEnd
-              if e.executionId.toString == executionId =>
-            submitCleanup(
-              s"Spark SQL execution $executionId ended",
-              this,
-              finalAttempt = false
-            )
+              if e.executionId == executionId =>
+            submitCleanup(s"Spark SQL execution $executionId ended", this)
           case _ =>
         }
       }
     }
 
     Try(session.sparkContext.addSparkListener(listener)) match {
-      case Success(_) =>
-        ttlTask = CleanupExecutor.schedule(
-          new Runnable {
-            override def run(): Unit = {
-              submitCleanup(
-                s"cleanup listener TTL ${SnapshotCleanupTtlMillis}ms expired",
-                listener,
-                finalAttempt = true
-              )
-            }
-          },
-          SnapshotCleanupTtlMillis,
-          TimeUnit.MILLISECONDS
-        )
-        true
+      case Success(_) => true
       case Failure(e) =>
         logError(
           s"Failed to register cleanup listener for client read snapshot $snapshotName",
@@ -871,7 +929,7 @@ object MilvusScan extends Logging {
     }
   }
 
-  def buildClientSnapshotOptions(
+  private[sources] def buildClientSnapshotOptions(
       baseOptions: Map[String, String],
       collectionName: String,
       collectionId: Long,
@@ -923,7 +981,12 @@ class MilvusScan(
 
   override def toBatch: Batch = this
 
-  override def planInputPartitions(): Array[InputPartition] = {
+  private lazy val plannedPartitions: Array[InputPartition] =
+    computeInputPartitions()
+
+  override def planInputPartitions(): Array[InputPartition] = plannedPartitions
+
+  private def computeInputPartitions(): Array[InputPartition] = {
     if (MilvusOption.isSnapshotMode(options)) {
       val snapshotManifests = Option(
         options.get(MilvusOption.SnapshotManifests)
@@ -981,9 +1044,11 @@ class MilvusScan(
     val description = Option(
       options.get(MilvusOption.ClientSnapshotDescription)
     ).filter(_.trim.nonEmpty).getOrElse("spark connector client read snapshot")
-    val protectionSeconds = Option(
-      options.get(MilvusOption.ClientSnapshotCompactionProtectionSeconds)
-    ).filter(_.trim.nonEmpty).map(_.toLong).getOrElse(86400L)
+    val protectionSeconds = MilvusScan.parsePositiveLongOption(
+      options,
+      MilvusOption.ClientSnapshotCompactionProtectionSeconds,
+      86400L
+    )
 
     val cleanupRegistration = MilvusScan.activeCleanupRegistration()
     if (cleanupRegistration.isEmpty) {
@@ -1002,11 +1067,11 @@ class MilvusScan(
       protectionSeconds
     ) match {
       case scala.util.Success(snapshot) =>
-        val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
-          snapshot.s3Location,
-          s3Bucket
-        )
         try {
+          val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
+            snapshot.s3Location,
+            s3Bucket
+          )
           val partitions = planInputPartitionsFromClientSnapshotPath(
             snapshotPath
           )

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -994,6 +994,14 @@ object MilvusScan extends Logging {
         s"Client-created snapshot metadata at $snapshotPath is missing collection.schema"
       )
     }
+    if (
+      metadata.manifestList.isEmpty &&
+      metadata.storageV2ManifestList.forall(_.isEmpty)
+    ) {
+      throw new IllegalArgumentException(
+        s"Invalid client-created snapshot metadata at $snapshotPath: client snapshot is empty: no manifests and no V2 segments"
+      )
+    }
     metadata
   }
 }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1327,7 +1327,9 @@ class MilvusScan(
     partitions
   }
 
-  private def buildSnapshotHadoopConf(snapshotPath: String): Configuration = {
+  private[sources] def buildSnapshotHadoopConf(
+      snapshotPath: String
+  ): Configuration = {
     val conf = SparkSession.getActiveSession
       .orElse(SparkSession.getDefaultSession)
       .map(_.sessionState.newHadoopConf())
@@ -1346,6 +1348,7 @@ class MilvusScan(
     if (conf.get("fs.s3a.impl") == null) {
       conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
     }
+    conf.set("fs.s3a.impl.disable.cache", "true")
     if (accessKey.forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty)) {
       logWarning(
         "Snapshot S3 credentials were not provided; Hadoop S3A will use the default AWS credential provider chain."
@@ -1371,7 +1374,10 @@ class MilvusScan(
     conf
   }
 
-  private def readAllBytes(conf: Configuration, path: String): String = {
+  private[sources] def readAllBytes(
+      conf: Configuration,
+      path: String
+  ): String = {
     val maxBytes = milvusOption.options
       .get(MilvusOption.SnapshotMaxJsonBytes)
       .filter(_.trim.nonEmpty)
@@ -1387,9 +1393,15 @@ class MilvusScan(
       .getOrElse(MilvusSnapshotReader.MaxSnapshotJsonBytes)
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)
-    val in = fs.open(new Path(uri))
-    try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
-    finally in.close()
+    try {
+      val in = fs.open(new Path(uri))
+      try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
+      finally in.close()
+    } finally {
+      if (conf.getBoolean(s"fs.${uri.getScheme}.impl.disable.cache", false)) {
+        fs.close()
+      }
+    }
   }
 
   /** Plan input partitions from snapshot manifests (offline mode - no client

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -3,9 +3,18 @@ package com.zilliz.spark.connector.sources
 import java.{util => ju}
 import java.net.URI
 import java.util.{Base64, HashMap, Map => JMap, UUID}
+import java.util.concurrent.{
+  Executors,
+  ScheduledFuture,
+  ThreadFactory,
+  TimeUnit
+}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
+import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -30,6 +39,7 @@ import org.apache.spark.sql.connector.read.{
 }
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
   DataTypes => SparkDataTypes,
@@ -627,7 +637,27 @@ class MilvusScanBuilder(
 }
 
 object MilvusScan extends Logging {
-  private val SparkSqlExecutionIdKey = "spark.sql.execution.id"
+  case class SnapshotCleanupRegistration(
+      session: SparkSession,
+      executionId: String
+  )
+
+  private val SnapshotCleanupTtlMillis = TimeUnit.MINUTES.toMillis(30)
+
+  private val CleanupThreadFactory = new ThreadFactory {
+    override def newThread(r: Runnable): Thread = {
+      val thread = new Thread(r, "milvus-snapshot-cleanup")
+      thread.setDaemon(true)
+      thread
+    }
+  }
+
+  private val CleanupExecutor = Executors.newSingleThreadScheduledExecutor(
+    CleanupThreadFactory
+  )
+
+  private implicit val CleanupExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(CleanupExecutor)
 
   private val SnapshotOptionKeys = Seq(
     MilvusOption.SnapshotMode,
@@ -635,7 +665,6 @@ object MilvusScan extends Logging {
     MilvusOption.SnapshotV2Segments,
     MilvusOption.SnapshotCollectionId,
     MilvusOption.SnapshotPartitionIds,
-    MilvusOption.SnapshotSchemaJson,
     MilvusOption.SnapshotSchemaBytes
   )
 
@@ -681,6 +710,18 @@ object MilvusScan extends Logging {
     milvusOption.segmentID.isEmpty
   }
 
+  def activeCleanupRegistration(): Option[SnapshotCleanupRegistration] = {
+    SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
+      case Some(session) =>
+        Option(
+          session.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+        )
+          .filter(_.trim.nonEmpty)
+          .map(SnapshotCleanupRegistration(session, _))
+      case None => None
+    }
+  }
+
   def dropClientReadSnapshot(
       client: MilvusClient,
       databaseName: String,
@@ -688,14 +729,14 @@ object MilvusScan extends Logging {
       snapshotName: String,
       reason: String,
       maxAttempts: Int = 3
-  ): Boolean = {
+  ): Try[Unit] = {
     var lastFailure = Option.empty[Throwable]
     (1 to maxAttempts).foreach { attempt =>
       client.dropSnapshot(databaseName, collectionName, snapshotName) match {
-        case scala.util.Success(_) =>
+        case Success(_) =>
           logInfo(s"Dropped client read snapshot $snapshotName after $reason")
-          return true
-        case scala.util.Failure(e) =>
+          return Success(())
+        case Failure(e) =>
           lastFailure = Some(e)
           logWarning(
             s"Failed to drop client read snapshot $snapshotName after $reason " +
@@ -705,26 +746,23 @@ object MilvusScan extends Logging {
           if (attempt < maxAttempts) Thread.sleep(200L * attempt)
       }
     }
-    lastFailure.foreach { e =>
-      logWarning(
-        s"Giving up dropping client read snapshot $snapshotName after $maxAttempts attempt(s)",
-        e
+    Failure(
+      lastFailure.getOrElse(
+        new RuntimeException(
+          s"Failed to drop client read snapshot $snapshotName after $reason"
+        )
       )
-    }
-    false
+    )
   }
 
-  def registerClientSnapshotCleanup(
+  private def dropClientReadSnapshotWithNewClient(
       baseOptions: Map[String, String],
       databaseName: String,
       collectionName: String,
-      snapshotName: String
-  ): Boolean = {
-    val dropped = new AtomicBoolean(false)
-
-    def dropSnapshot(reason: String): Unit = {
-      if (!dropped.compareAndSet(false, true)) return
-      val client = MilvusClient(MilvusOption(baseOptions))
+      snapshotName: String,
+      reason: String
+  ): Try[Unit] = {
+    Try(MilvusClient(MilvusOption(baseOptions))).flatMap { client =>
       try {
         dropClientReadSnapshot(
           client,
@@ -737,38 +775,97 @@ object MilvusScan extends Logging {
         client.close()
       }
     }
+  }
 
-    SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
-      case Some(session) =>
-        Option(session.sparkContext.getLocalProperty(SparkSqlExecutionIdKey))
-          .filter(_.trim.nonEmpty) match {
-          case Some(executionId) =>
-            val listener = new SparkListener {
-              private def cleanup(reason: String): Unit = {
-                try dropSnapshot(reason)
-                finally session.sparkContext.removeSparkListener(this)
-              }
+  def registerClientSnapshotCleanup(
+      registration: SnapshotCleanupRegistration,
+      baseOptions: Map[String, String],
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String
+  ): Boolean = {
+    val cleanupComplete = new AtomicBoolean(false)
+    val cleanupInFlight = new AtomicBoolean(false)
+    val session = registration.session
+    val executionId = registration.executionId
 
-              override def onOtherEvent(event: SparkListenerEvent): Unit = {
-                event match {
-                  case e: SparkListenerSQLExecutionEnd
-                      if e.executionId.toString == executionId =>
-                    cleanup(s"Spark SQL execution $executionId ended")
-                  case _ =>
-                }
-              }
-            }
-            session.sparkContext.addSparkListener(listener)
-            true
-          case None =>
-            logWarning(
-              s"No active Spark SQL execution id; client read snapshot $snapshotName cannot be safely auto-dropped"
+    var ttlTask: ScheduledFuture[_] = null
+
+    def removeListener(listener: SparkListener): Unit = {
+      session.sparkContext.removeSparkListener(listener)
+      if (ttlTask != null) ttlTask.cancel(false)
+    }
+
+    def submitCleanup(
+        reason: String,
+        listener: SparkListener,
+        finalAttempt: Boolean
+    ): Unit = {
+      if (
+        cleanupComplete.get() || !cleanupInFlight.compareAndSet(false, true)
+      ) {
+        return
+      }
+      Future {
+        val dropResult = dropClientReadSnapshotWithNewClient(
+          baseOptions,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        )
+        dropResult match {
+          case Success(_) =>
+            cleanupComplete.set(true)
+            removeListener(listener)
+          case Failure(e) =>
+            logError(
+              s"Failed to drop client read snapshot $snapshotName after $reason",
+              e
             )
-            false
+            if (finalAttempt) {
+              removeListener(listener)
+            }
         }
-      case None =>
-        logWarning(
-          s"No active SparkSession; client read snapshot $snapshotName cannot be auto-dropped"
+        cleanupInFlight.set(false)
+      }
+    }
+
+    val listener = new SparkListener {
+      override def onOtherEvent(event: SparkListenerEvent): Unit = {
+        event match {
+          case e: SparkListenerSQLExecutionEnd
+              if e.executionId.toString == executionId =>
+            submitCleanup(
+              s"Spark SQL execution $executionId ended",
+              this,
+              finalAttempt = false
+            )
+          case _ =>
+        }
+      }
+    }
+
+    Try(session.sparkContext.addSparkListener(listener)) match {
+      case Success(_) =>
+        ttlTask = CleanupExecutor.schedule(
+          new Runnable {
+            override def run(): Unit = {
+              submitCleanup(
+                s"cleanup listener TTL ${SnapshotCleanupTtlMillis}ms expired",
+                listener,
+                finalAttempt = true
+              )
+            }
+          },
+          SnapshotCleanupTtlMillis,
+          TimeUnit.MILLISECONDS
+        )
+        true
+      case Failure(e) =>
+        logError(
+          s"Failed to register cleanup listener for client read snapshot $snapshotName",
+          e
         )
         false
     }
@@ -779,7 +876,6 @@ object MilvusScan extends Logging {
       collectionName: String,
       collectionId: Long,
       partitionIds: Seq[Long],
-      snapshotJson: String,
       schemaBytesBase64: String,
       manifestList: Seq[StorageV2ManifestItem],
       v2Segments: Seq[V2SegmentInfo]
@@ -790,7 +886,6 @@ object MilvusScan extends Logging {
       MilvusOption.MilvusCollectionName -> collectionName,
       MilvusOption.SnapshotCollectionId -> collectionId.toString,
       MilvusOption.SnapshotPartitionIds -> partitionIds.mkString(","),
-      MilvusOption.SnapshotSchemaJson -> snapshotJson,
       MilvusOption.SnapshotSchemaBytes -> schemaBytesBase64,
       MilvusOption.SnapshotManifests ->
         MilvusSnapshotReader.serializeManifestList(manifestList)
@@ -891,6 +986,15 @@ class MilvusScan(
       options.get(MilvusOption.ClientSnapshotCompactionProtectionSeconds)
     ).filter(_.trim.nonEmpty).map(_.toLong).getOrElse(86400L)
 
+    val cleanupRegistration = MilvusScan.activeCleanupRegistration()
+    if (cleanupRegistration.isEmpty) {
+      logWarning(
+        "Skipping client snapshot fast path because Spark SQL execution cleanup cannot be registered; " +
+          "falling back to legacy GetPersistentSegmentInfo read path"
+      )
+      return None
+    }
+
     client.createSnapshotForRead(
       milvusOption.databaseName,
       milvusOption.collectionName,
@@ -907,42 +1011,50 @@ class MilvusScan(
           val partitions = planInputPartitionsFromClientSnapshotPath(
             snapshotPath
           )
-          val cleanupRegistered = MilvusScan.registerClientSnapshotCleanup(
-            options.asScala.toMap,
-            milvusOption.databaseName,
-            milvusOption.collectionName,
-            snapshot.name
-          )
-          if (cleanupRegistered) {
+          if (
+            MilvusScan.registerClientSnapshotCleanup(
+              cleanupRegistration.get,
+              options.asScala.toMap,
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name
+            )
+          ) {
             logWarning(
               s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
                 "an unclean driver exit can leave it behind and require manual cleanup."
             )
             Some(partitions)
           } else {
-            val dropped = MilvusScan.dropClientReadSnapshot(
-              client,
-              milvusOption.databaseName,
-              milvusOption.collectionName,
-              snapshot.name,
-              "cleanup registration failure"
-            )
-            if (!dropped) {
-              throw new IllegalStateException(
-                s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure"
+            MilvusScan
+              .dropClientReadSnapshot(
+                client,
+                milvusOption.databaseName,
+                milvusOption.collectionName,
+                snapshot.name,
+                "cleanup registration failure"
               )
-            }
+              .failed
+              .foreach { e =>
+                logError(
+                  s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure; falling back to legacy read path",
+                  e
+                )
+              }
             None
           }
         } catch {
-          case e: Throwable =>
-            MilvusScan.dropClientReadSnapshot(
-              client,
-              milvusOption.databaseName,
-              milvusOption.collectionName,
-              snapshot.name,
-              "planning failure"
-            )
+          case NonFatal(e) =>
+            MilvusScan
+              .dropClientReadSnapshot(
+                client,
+                milvusOption.databaseName,
+                milvusOption.collectionName,
+                snapshot.name,
+                "planning failure"
+              )
+              .failed
+              .foreach(e.addSuppressed)
             throw e
         }
 
@@ -1004,7 +1116,6 @@ class MilvusScan(
       collectionName = metadata.collection.schema.name,
       collectionId = metadata.snapshotInfo.collectionId,
       partitionIds = metadata.snapshotInfo.partitionIds,
-      snapshotJson = snapshotJson,
       schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
       manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
       v2Segments = v2Segments
@@ -1106,34 +1217,27 @@ class MilvusScan(
   }
 
   private def buildSnapshotHadoopConf(snapshotPath: String): Configuration = {
-    val conf = new Configuration()
-    val endpoint = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsAddress,
-      "localhost:9000"
-    )
-    val accessKey = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsAccessKeyId,
-      ""
-    )
-    val secretKey = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsAccessKeyValue,
-      ""
-    )
-    val useSsl = milvusOption.options.getOrElse(
-      Properties.FsConfig.FsUseSSL,
-      "false"
-    )
-    val pathStyle = milvusOption.options.getOrElse(
-      "fs.s3a.path.style.access",
-      "true"
-    )
+    val conf = SparkSession.getActiveSession
+      .orElse(SparkSession.getDefaultSession)
+      .map(_.sessionState.newHadoopConf())
+      .getOrElse(new Configuration())
+    val endpoint = milvusOption.options.get(Properties.FsConfig.FsAddress)
+    val accessKey = milvusOption.options.get(Properties.FsConfig.FsAccessKeyId)
+    val secretKey =
+      milvusOption.options.get(Properties.FsConfig.FsAccessKeyValue)
+    val useSsl = milvusOption.options.get(Properties.FsConfig.FsUseSSL)
+    val pathStyle = milvusOption.options.get("fs.s3a.path.style.access")
+
+    def setIfDefined(key: String, value: Option[String]): Unit = {
+      value.filter(_.nonEmpty).foreach(conf.set(key, _))
+    }
 
     conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-    conf.set("fs.s3a.endpoint", endpoint)
-    conf.set("fs.s3a.connection.ssl.enabled", useSsl)
-    conf.set("fs.s3a.path.style.access", pathStyle)
-    if (accessKey.nonEmpty) conf.set("fs.s3a.access.key", accessKey)
-    if (secretKey.nonEmpty) conf.set("fs.s3a.secret.key", secretKey)
+    setIfDefined("fs.s3a.endpoint", endpoint)
+    setIfDefined("fs.s3a.connection.ssl.enabled", useSsl)
+    setIfDefined("fs.s3a.path.style.access", pathStyle)
+    setIfDefined("fs.s3a.access.key", accessKey)
+    setIfDefined("fs.s3a.secret.key", secretKey)
 
     val connectorBucket = milvusOption.options.getOrElse(
       Properties.FsConfig.FsBucketName,
@@ -1142,17 +1246,11 @@ class MilvusScan(
     MilvusScan
       .snapshotBucketsToConfigure(snapshotPath, connectorBucket)
       .foreach { bucket =>
-        if (endpoint.nonEmpty) {
-          conf.set(s"fs.s3a.bucket.$bucket.endpoint", endpoint)
-        }
-        conf.set(s"fs.s3a.bucket.$bucket.connection.ssl.enabled", useSsl)
-        conf.set(s"fs.s3a.bucket.$bucket.path.style.access", pathStyle)
-        if (accessKey.nonEmpty) {
-          conf.set(s"fs.s3a.bucket.$bucket.access.key", accessKey)
-        }
-        if (secretKey.nonEmpty) {
-          conf.set(s"fs.s3a.bucket.$bucket.secret.key", secretKey)
-        }
+        setIfDefined(s"fs.s3a.bucket.$bucket.endpoint", endpoint)
+        setIfDefined(s"fs.s3a.bucket.$bucket.connection.ssl.enabled", useSsl)
+        setIfDefined(s"fs.s3a.bucket.$bucket.path.style.access", pathStyle)
+        setIfDefined(s"fs.s3a.bucket.$bucket.access.key", accessKey)
+        setIfDefined(s"fs.s3a.bucket.$bucket.secret.key", secretKey)
       }
     conf
   }
@@ -1161,7 +1259,15 @@ class MilvusScan(
     val maxBytes = milvusOption.options
       .get(MilvusOption.SnapshotMaxJsonBytes)
       .filter(_.trim.nonEmpty)
-      .map(_.toLong)
+      .map { raw =>
+        val parsed = raw.toLong
+        if (parsed <= 0) {
+          throw new IllegalArgumentException(
+            s"${MilvusOption.SnapshotMaxJsonBytes} must be positive, got $raw"
+          )
+        }
+        parsed
+      }
       .getOrElse(MilvusSnapshotReader.MaxSnapshotJsonBytes)
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1,11 +1,16 @@
 package com.zilliz.spark.connector.sources
 
 import java.{util => ju}
-import java.util.{HashMap, Map => JMap}
+import java.net.URI
+import java.util.{Base64, HashMap, Map => JMap, UUID}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.connector.catalog.{
   SupportsRead,
   SupportsWrite,
@@ -24,6 +29,7 @@ import org.apache.spark.sql.connector.read.{
   SupportsPushDownRequiredColumns
 }
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
   DataTypes => SparkDataTypes,
@@ -33,6 +39,7 @@ import org.apache.spark.sql.types.{
   StructType
 }
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.SparkSession
 
 import com.zilliz.spark.connector.{
   DataTypeUtil,
@@ -45,7 +52,11 @@ import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusPackedV2InputPartition,
   MilvusPartitionReaderFactory,
-  MilvusStorageV3InputPartition
+  MilvusSnapshotReader,
+  MilvusStorageV3InputPartition,
+  StorageV2ManifestItem,
+  V2SegmentInfo,
+  V2SegmentLoader
 }
 import com.zilliz.spark.connector.write.{MilvusWrite, MilvusWriteBuilder}
 import io.milvus.grpc.schema.CollectionSchema
@@ -59,9 +70,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
   ): Table = {
     val options = new CaseInsensitiveStringMap(properties)
     val milvusOption = MilvusOption(options)
-    val isSnapshotMode =
-      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode = MilvusOption.isSnapshotMode(options)
     if (milvusOption.uri.isEmpty && !isSnapshotMode) {
       throw new IllegalArgumentException(
         s"Option '${MilvusOption.MilvusUri}' is required for reading milvus data."
@@ -77,9 +86,7 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
     val milvusOption = MilvusOption(options)
 
     // Check for snapshot mode - use snapshot schema if provided
-    val isSnapshotMode =
-      Option(options.get(MilvusOption.SnapshotMode)).contains("true") ||
-        Option(options.get(MilvusOption.SnapshotManifests)).isDefined
+    val isSnapshotMode = MilvusOption.isSnapshotMode(options)
 
     if (isSnapshotMode) {
       // Try to get schema from snapshot JSON
@@ -163,11 +170,8 @@ case class MilvusTable(
     * [[MilvusOption.SnapshotV2Segments]] is sufficient to take the
     * snapshot-only path and skip all Milvus client calls.
     */
-  private def isSnapshotMode: Boolean = {
-    milvusOption.options.get(MilvusOption.SnapshotMode).contains("true") &&
-    (milvusOption.options.contains(MilvusOption.SnapshotManifests) ||
-      milvusOption.options.contains(MilvusOption.SnapshotV2Segments))
-  }
+  private def isSnapshotMode: Boolean =
+    MilvusOption.isSnapshotMode(milvusOption.options)
 
   def initInfo(): Unit = {
     // Check for snapshot mode first - skip client calls if snapshot data is provided
@@ -622,6 +626,183 @@ class MilvusScanBuilder(
   }
 }
 
+object MilvusScan extends Logging {
+  private val SparkSqlExecutionIdKey = "spark.sql.execution.id"
+
+  private val SnapshotOptionKeys = Seq(
+    MilvusOption.SnapshotMode,
+    MilvusOption.SnapshotManifests,
+    MilvusOption.SnapshotV2Segments,
+    MilvusOption.SnapshotCollectionId,
+    MilvusOption.SnapshotPartitionIds,
+    MilvusOption.SnapshotSchemaJson,
+    MilvusOption.SnapshotSchemaBytes
+  )
+
+  def resolveClientSnapshotLocation(
+      location: String,
+      bucket: String
+  ): String = {
+    val trimmed = Option(location).map(_.trim).getOrElse("")
+    if (trimmed.isEmpty) {
+      throw new IllegalArgumentException("snapshot s3_location is empty")
+    } else if (trimmed.startsWith("s3a://")) {
+      trimmed
+    } else if (trimmed.startsWith("s3://")) {
+      "s3a://" + trimmed.stripPrefix("s3://")
+    } else if (bucket.trim.nonEmpty) {
+      s"s3a://${bucket.trim}/${trimmed.stripPrefix("/")}"
+    } else {
+      trimmed
+    }
+  }
+
+  def snapshotBucket(location: String): Option[String] = {
+    val trimmed = Option(location).map(_.trim).getOrElse("")
+    if (trimmed.isEmpty) {
+      None
+    } else {
+      Option(new URI(resolveClientSnapshotLocation(trimmed, "")).getHost)
+    }
+  }
+
+  def snapshotBucketsToConfigure(
+      snapshotPath: String,
+      connectorBucket: String
+  ): Seq[String] = {
+    (Seq(connectorBucket).filter(_.nonEmpty) ++ snapshotBucket(
+      snapshotPath
+    )).distinct
+  }
+
+  def canUseClientSnapshotFastPath(milvusOption: MilvusOption): Boolean = {
+    milvusOption.partitionName.isEmpty &&
+    milvusOption.partitionID.isEmpty &&
+    milvusOption.segmentID.isEmpty
+  }
+
+  def dropClientReadSnapshot(
+      client: MilvusClient,
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String,
+      reason: String,
+      maxAttempts: Int = 3
+  ): Boolean = {
+    var lastFailure = Option.empty[Throwable]
+    (1 to maxAttempts).foreach { attempt =>
+      client.dropSnapshot(databaseName, collectionName, snapshotName) match {
+        case scala.util.Success(_) =>
+          logInfo(s"Dropped client read snapshot $snapshotName after $reason")
+          return true
+        case scala.util.Failure(e) =>
+          lastFailure = Some(e)
+          logWarning(
+            s"Failed to drop client read snapshot $snapshotName after $reason " +
+              s"(attempt $attempt/$maxAttempts)",
+            e
+          )
+          if (attempt < maxAttempts) Thread.sleep(200L * attempt)
+      }
+    }
+    lastFailure.foreach { e =>
+      logWarning(
+        s"Giving up dropping client read snapshot $snapshotName after $maxAttempts attempt(s)",
+        e
+      )
+    }
+    false
+  }
+
+  def registerClientSnapshotCleanup(
+      baseOptions: Map[String, String],
+      databaseName: String,
+      collectionName: String,
+      snapshotName: String
+  ): Boolean = {
+    val dropped = new AtomicBoolean(false)
+
+    def dropSnapshot(reason: String): Unit = {
+      if (!dropped.compareAndSet(false, true)) return
+      val client = MilvusClient(MilvusOption(baseOptions))
+      try {
+        dropClientReadSnapshot(
+          client,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        )
+      } finally {
+        client.close()
+      }
+    }
+
+    SparkSession.getActiveSession.orElse(SparkSession.getDefaultSession) match {
+      case Some(session) =>
+        Option(session.sparkContext.getLocalProperty(SparkSqlExecutionIdKey))
+          .filter(_.trim.nonEmpty) match {
+          case Some(executionId) =>
+            val listener = new SparkListener {
+              private def cleanup(reason: String): Unit = {
+                try dropSnapshot(reason)
+                finally session.sparkContext.removeSparkListener(this)
+              }
+
+              override def onOtherEvent(event: SparkListenerEvent): Unit = {
+                event match {
+                  case e: SparkListenerSQLExecutionEnd
+                      if e.executionId.toString == executionId =>
+                    cleanup(s"Spark SQL execution $executionId ended")
+                  case _ =>
+                }
+              }
+            }
+            session.sparkContext.addSparkListener(listener)
+            true
+          case None =>
+            logWarning(
+              s"No active Spark SQL execution id; client read snapshot $snapshotName cannot be safely auto-dropped"
+            )
+            false
+        }
+      case None =>
+        logWarning(
+          s"No active SparkSession; client read snapshot $snapshotName cannot be auto-dropped"
+        )
+        false
+    }
+  }
+
+  def buildClientSnapshotOptions(
+      baseOptions: Map[String, String],
+      collectionName: String,
+      collectionId: Long,
+      partitionIds: Seq[Long],
+      snapshotJson: String,
+      schemaBytesBase64: String,
+      manifestList: Seq[StorageV2ManifestItem],
+      v2Segments: Seq[V2SegmentInfo]
+  ): Map[String, String] = {
+    var out = baseOptions -- SnapshotOptionKeys
+    out = out ++ Map(
+      MilvusOption.SnapshotMode -> "true",
+      MilvusOption.MilvusCollectionName -> collectionName,
+      MilvusOption.SnapshotCollectionId -> collectionId.toString,
+      MilvusOption.SnapshotPartitionIds -> partitionIds.mkString(","),
+      MilvusOption.SnapshotSchemaJson -> snapshotJson,
+      MilvusOption.SnapshotSchemaBytes -> schemaBytesBase64,
+      MilvusOption.SnapshotManifests ->
+        MilvusSnapshotReader.serializeManifestList(manifestList)
+    )
+    if (v2Segments.nonEmpty) {
+      out += MilvusOption.SnapshotV2Segments ->
+        MilvusSnapshotReader.serializeV2Segments(v2Segments)
+    }
+    out
+  }
+}
+
 class MilvusScan(
     schema: StructType,
     options: CaseInsensitiveStringMap,
@@ -648,51 +829,208 @@ class MilvusScan(
   override def toBatch: Batch = this
 
   override def planInputPartitions(): Array[InputPartition] = {
-    // Check if snapshot data is provided (offline/snapshot mode).
-    // Either legacy manifest-based (V3) or packed-parquet (V2) segments.
-    val snapshotManifests = Option(options.get(MilvusOption.SnapshotManifests))
-    val snapshotV2 = Option(options.get(MilvusOption.SnapshotV2Segments))
-    if (snapshotManifests.isDefined || snapshotV2.isDefined) {
+    if (MilvusOption.isSnapshotMode(options)) {
+      val snapshotManifests = Option(
+        options.get(MilvusOption.SnapshotManifests)
+      )
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
     }
 
-    // Validate required parameters
     if (milvusOption.collectionName.isEmpty) {
       throw new IllegalArgumentException("collectionName cannot be empty")
     }
 
-    val collection = milvusOption.collectionID
-    val partition = milvusOption.partitionID
-    val segment = milvusOption.segmentID
-
     val client = MilvusClient(milvusOption)
-
-    // Get collection schema and S3 config for manifest building
-    val collectionInfo = client
-      .getCollectionInfo(
-        milvusOption.databaseName,
-        milvusOption.collectionName
-      )
-      .getOrElse(
-        throw new Exception(
-          s"Collection ${milvusOption.collectionName} not found"
+    try {
+      val collectionInfo = client
+        .getCollectionInfo(
+          milvusOption.databaseName,
+          milvusOption.collectionName
         )
-      )
+        .getOrElse(
+          throw new Exception(
+            s"Collection ${milvusOption.collectionName} not found"
+          )
+        )
+
+      val clientSnapshotPartitions =
+        if (MilvusScan.canUseClientSnapshotFastPath(milvusOption)) {
+          planInputPartitionsFromClientSnapshot(client)
+        } else {
+          logInfo(
+            "client snapshot fast path disabled because partition/segment selector is set"
+          )
+          None
+        }
+
+      clientSnapshotPartitions.getOrElse {
+        planInputPartitionsFromLegacyClient(client, collectionInfo)
+      }
+    } finally {
+      client.close()
+    }
+  }
+
+  private def planInputPartitionsFromClientSnapshot(
+      client: MilvusClient
+  ): Option[Array[InputPartition]] = {
     val s3Bucket = milvusOption.options.getOrElse(
       Properties.FsConfig.FsBucketName,
       "a-bucket"
     )
+    val snapshotName = Option(options.get(MilvusOption.ClientSnapshotName))
+      .filter(_.trim.nonEmpty)
+      .getOrElse(
+        s"spark_read_${milvusOption.collectionName}_${System
+            .currentTimeMillis()}_${UUID.randomUUID().toString.replace("-", "")}"
+      )
+    val description = Option(
+      options.get(MilvusOption.ClientSnapshotDescription)
+    ).filter(_.trim.nonEmpty).getOrElse("spark connector client read snapshot")
+    val protectionSeconds = Option(
+      options.get(MilvusOption.ClientSnapshotCompactionProtectionSeconds)
+    ).filter(_.trim.nonEmpty).map(_.toLong).getOrElse(86400L)
+
+    client.createSnapshotForRead(
+      milvusOption.databaseName,
+      milvusOption.collectionName,
+      snapshotName,
+      description,
+      protectionSeconds
+    ) match {
+      case scala.util.Success(snapshot) =>
+        val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
+          snapshot.s3Location,
+          s3Bucket
+        )
+        try {
+          val partitions = planInputPartitionsFromClientSnapshotPath(
+            snapshotPath
+          )
+          val cleanupRegistered = MilvusScan.registerClientSnapshotCleanup(
+            options.asScala.toMap,
+            milvusOption.databaseName,
+            milvusOption.collectionName,
+            snapshot.name
+          )
+          if (cleanupRegistered) {
+            logWarning(
+              s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
+                "an unclean driver exit can leave it behind and require manual cleanup."
+            )
+            Some(partitions)
+          } else {
+            val dropped = MilvusScan.dropClientReadSnapshot(
+              client,
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name,
+              "cleanup registration failure"
+            )
+            if (!dropped) {
+              throw new IllegalStateException(
+                s"Failed to drop client read snapshot ${snapshot.name} after cleanup registration failure"
+              )
+            }
+            None
+          }
+        } catch {
+          case e: Throwable =>
+            MilvusScan.dropClientReadSnapshot(
+              client,
+              milvusOption.databaseName,
+              milvusOption.collectionName,
+              snapshot.name,
+              "planning failure"
+            )
+            throw e
+        }
+
+      case scala.util.Failure(e) if MilvusClient.isServiceNotImplemented(e) =>
+        logWarning(
+          "CreateSnapshot/DescribeSnapshot is not implemented by this Milvus service; " +
+            "falling back to legacy GetPersistentSegmentInfo read path"
+        )
+        None
+
+      case scala.util.Failure(e) =>
+        throw new RuntimeException(
+          s"Failed to create client read snapshot for collection ${milvusOption.collectionName}: ${e.getMessage}",
+          e
+        )
+    }
+  }
+
+  private def planInputPartitionsFromClientSnapshotPath(
+      snapshotPath: String
+  ): Array[InputPartition] = {
+    val hadoopConf = buildSnapshotHadoopConf(snapshotPath)
+    val snapshotJson = readAllBytes(hadoopConf, snapshotPath)
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
+        case Right(value) => value
+        case Left(err) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse client-created snapshot metadata: ${err.getMessage}",
+            err
+          )
+      }
+
+    val s3Bucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
+    )
+    val v2Segments =
+      if (metadata.manifestList.nonEmpty) {
+        V2SegmentLoader.loadV2Segments(
+          metadata.manifestList,
+          s3Bucket,
+          hadoopConf
+        ) match {
+          case Right(segs) => segs
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Failed to load StorageV2 segments from client-created snapshot: ${err.getMessage}",
+              err
+            )
+        }
+      } else Seq.empty
+
+    val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
+      metadata.collection.schema
+    )
+    val snapshotOptions = MilvusScan.buildClientSnapshotOptions(
+      options.asScala.toMap,
+      collectionName = metadata.collection.schema.name,
+      collectionId = metadata.snapshotInfo.collectionId,
+      partitionIds = metadata.snapshotInfo.partitionIds,
+      snapshotJson = snapshotJson,
+      schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
+      manifestList = metadata.storageV2ManifestList.getOrElse(Seq.empty),
+      v2Segments = v2Segments
+    )
+
+    new MilvusScan(
+      schema,
+      new CaseInsensitiveStringMap(snapshotOptions.asJava),
+      pushedFilters
+    ).planInputPartitions()
+  }
+
+  private def planInputPartitionsFromLegacyClient(
+      client: MilvusClient,
+      collectionInfo: MilvusCollectionInfo
+  ): Array[InputPartition] = {
+    val collection = milvusOption.collectionID
+    val partition = milvusOption.partitionID
+    val segment = milvusOption.segmentID
     val s3RootPath =
       milvusOption.options.getOrElse(Properties.FsConfig.FsRootPath, "files")
 
-    // Helper function to create InputPartition from segment info
     def createPartition(
         segmentID: String,
         partitionID: String
     ): InputPartition = {
-      // Build segment path where manifest files exist
-      // StorageV3 segments have manifest files at:
-      //   rootPath/insert_log/collectionID/partitionID/segmentID/_metadata/
       val segmentPath =
         s"$s3RootPath/insert_log/$collection/$partitionID/$segmentID"
       logInfo(
@@ -715,10 +1053,6 @@ class MilvusScan(
       )
     }
 
-    // Get all segments with storage_version >= 2 (StorageV2 packed parquet
-    // without manifest, or StorageV3 packed parquet with loon manifest).
-    // NOTE: current planner treats every >= 2 segment as StorageV3; a separate
-    // task is tracking client-mode StorageV2 (non-manifest) dispatch.
     val allPackedSegments = client
       .getSegments(
         milvusOption.databaseName,
@@ -738,9 +1072,8 @@ class MilvusScan(
       )
     }
 
-    val partitions: Array[InputPartition] =
-      if (!partition.isEmpty() && !segment.isEmpty()) {
-        // Case 1: Specific segment specified - validate segment belongs to partition
+    val partitions =
+      if (partition.nonEmpty && segment.nonEmpty) {
         val segmentInfo =
           allPackedSegments.find(_.segmentID.toString == segment)
         segmentInfo match {
@@ -757,27 +1090,84 @@ class MilvusScan(
                 "(StorageV2/V3 packed parquet required)"
             )
         }
-
-      } else if (!partition.isEmpty()) {
-        // Case 2: Partition specified - only process packed segments in this partition
+      } else if (partition.nonEmpty) {
         allPackedSegments
           .filter(_.partitionID.toString == partition)
           .map(seg => createPartition(seg.segmentID.toString, partition))
           .toArray
-
       } else {
-        // Case 3: No partition specified - process all packed segments
         allPackedSegments.map { seg =>
           createPartition(seg.segmentID.toString, seg.partitionID.toString)
         }.toArray
       }
 
-    logInfo(
-      s"Created ${partitions.length} partitions (treating all StorageV2/V3 " +
-        "segments as V3; see V2 dispatch TODO)"
-    )
-    client.close()
+    logInfo(s"Created ${partitions.length} partitions via legacy client path")
     partitions
+  }
+
+  private def buildSnapshotHadoopConf(snapshotPath: String): Configuration = {
+    val conf = new Configuration()
+    val endpoint = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsAddress,
+      "localhost:9000"
+    )
+    val accessKey = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsAccessKeyId,
+      ""
+    )
+    val secretKey = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsAccessKeyValue,
+      ""
+    )
+    val useSsl = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsUseSSL,
+      "false"
+    )
+    val pathStyle = milvusOption.options.getOrElse(
+      "fs.s3a.path.style.access",
+      "true"
+    )
+
+    conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    conf.set("fs.s3a.endpoint", endpoint)
+    conf.set("fs.s3a.connection.ssl.enabled", useSsl)
+    conf.set("fs.s3a.path.style.access", pathStyle)
+    if (accessKey.nonEmpty) conf.set("fs.s3a.access.key", accessKey)
+    if (secretKey.nonEmpty) conf.set("fs.s3a.secret.key", secretKey)
+
+    val connectorBucket = milvusOption.options.getOrElse(
+      Properties.FsConfig.FsBucketName,
+      "a-bucket"
+    )
+    MilvusScan
+      .snapshotBucketsToConfigure(snapshotPath, connectorBucket)
+      .foreach { bucket =>
+        if (endpoint.nonEmpty) {
+          conf.set(s"fs.s3a.bucket.$bucket.endpoint", endpoint)
+        }
+        conf.set(s"fs.s3a.bucket.$bucket.connection.ssl.enabled", useSsl)
+        conf.set(s"fs.s3a.bucket.$bucket.path.style.access", pathStyle)
+        if (accessKey.nonEmpty) {
+          conf.set(s"fs.s3a.bucket.$bucket.access.key", accessKey)
+        }
+        if (secretKey.nonEmpty) {
+          conf.set(s"fs.s3a.bucket.$bucket.secret.key", secretKey)
+        }
+      }
+    conf
+  }
+
+  private def readAllBytes(conf: Configuration, path: String): String = {
+    val maxBytes = milvusOption.options
+      .get(MilvusOption.SnapshotMaxJsonBytes)
+      .filter(_.trim.nonEmpty)
+      .map(_.toLong)
+      .getOrElse(MilvusSnapshotReader.MaxSnapshotJsonBytes)
+    val uri = new URI(path)
+    val fs = FileSystem.get(uri, conf)
+    val in = fs.open(new Path(uri))
+    try MilvusSnapshotReader.readUtf8WithLimit(in, path, maxBytes)
+    finally in.close()
   }
 
   /** Plan input partitions from snapshot manifests (offline mode - no client

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -140,7 +140,8 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
             StructField(
               field.name,
               DataTypeUtil.toDataType(field),
-              field.nullable
+              field.nullable,
+              DataTypeUtil.metadata(field)
             )
           )
         )
@@ -361,7 +362,8 @@ case class MilvusTable(
       StructField(
         field.name,
         DataTypeUtil.toDataType(field),
-        field.nullable
+        field.nullable,
+        DataTypeUtil.metadata(field)
       )
     )
     // Safely get maxFieldID, default to 100 if empty
@@ -816,24 +818,23 @@ object MilvusScan extends Logging {
       storageV2ManifestList: Seq[StorageV2ManifestItem],
       v2Segments: Seq[V2SegmentInfo]
   ): Unit = {
-    (snapshotBucket(snapshotPath), connectorBucket) match {
-      case (Some(snapshot), Some(connector)) if snapshot != connector =>
-        val relativeStorageV3Paths = storageV2ManifestList
-          .map(storageV2ManifestBasePath)
-          .filter(isBucketRelativeSnapshotLocation)
-        val relativeStorageV2Paths = v2Segments
-          .flatMap(_.columnGroups.flatMap(_.filePaths))
-          .filter(isBucketRelativeSnapshotLocation)
-        val relativePaths = relativeStorageV3Paths ++ relativeStorageV2Paths
-        if (relativePaths.nonEmpty) {
-          throw new IllegalArgumentException(
-            s"Client-created snapshot metadata is in bucket '$snapshot' but " +
-              s"${Properties.FsConfig.FsBucketName} is '$connector' and snapshot data paths are bucket-relative. " +
-              "Refusing to guess which bucket native executors should use; set the connector bucket to the data bucket or use fully-qualified data paths. " +
-              s"Example relative path: ${relativePaths.head}"
-          )
-        }
-      case _ =>
+    snapshotBucket(snapshotPath).foreach { snapshot =>
+      val relativeStorageV3Paths = storageV2ManifestList
+        .map(storageV2ManifestBasePath)
+        .filter(isBucketRelativeSnapshotLocation)
+      val relativeStorageV2Paths = v2Segments
+        .flatMap(_.columnGroups.flatMap(_.filePaths))
+        .filter(isBucketRelativeSnapshotLocation)
+      val relativePaths = relativeStorageV3Paths ++ relativeStorageV2Paths
+      if (relativePaths.nonEmpty && !connectorBucket.contains(snapshot)) {
+        val connectorDescription = connectorBucket.getOrElse("<unset>")
+        throw new IllegalArgumentException(
+          s"Client-created snapshot metadata is in bucket '$snapshot' but " +
+            s"${Properties.FsConfig.FsBucketName} is '$connectorDescription' and snapshot data paths are bucket-relative. " +
+            "Refusing to guess which bucket native executors should use; set the connector bucket to the data bucket or use fully-qualified data paths. " +
+            s"Example relative path: ${relativePaths.head}"
+        )
+      }
     }
   }
 
@@ -968,6 +969,17 @@ object MilvusScan extends Logging {
         case Success(_) =>
           logInfo(s"Dropped client read snapshot $snapshotName after $reason")
           return Success(())
+        case Failure(e) if MilvusClient.isSnapshotAlreadyDropped(e) =>
+          logInfo(
+            s"Client read snapshot $snapshotName was already dropped after $reason"
+          )
+          return Success(())
+        case Failure(e) if MilvusClient.isTerminalSnapshotDropError(e) =>
+          logWarning(
+            s"Not retrying terminal failure while dropping client read snapshot $snapshotName after $reason",
+            e
+          )
+          return Failure(e)
         case Failure(e) =>
           lastFailure = Some(e)
           logWarning(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -645,6 +645,10 @@ object MilvusScan extends Logging {
   private val InitialDropRetryDelayMillis = 200L
   private val DropRetryMaxAttempts = 7
   private val MaxGeneratedSnapshotNameLength = 255
+  private val DefaultAwsCredentialsProvider =
+    "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
+  private val SimpleAwsCredentialsProvider =
+    "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
 
   private def daemonThreadFactory(namePrefix: String): ThreadFactory =
     new ThreadFactory {
@@ -666,26 +670,33 @@ object MilvusScan extends Logging {
   private val PendingCleanupFutures =
     ConcurrentHashMap.newKeySet[Future[Unit]]()
 
-  Runtime.getRuntime.addShutdownHook(
-    new Thread(
-      new Runnable {
-        override def run(): Unit = {
-          val deadline = SnapshotCleanupDrainTimeout.fromNow
-          PendingCleanupFutures.asScala.foreach { future =>
-            val remaining = deadline.timeLeft
-            if (remaining.length > 0) {
-              try Await.ready(future, remaining)
-              catch {
-                case NonFatal(e) =>
-                  logWarning("Timed out waiting for client snapshot cleanup", e)
+  Try(
+    Runtime.getRuntime.addShutdownHook(
+      new Thread(
+        new Runnable {
+          override def run(): Unit = {
+            val deadline = SnapshotCleanupDrainTimeout.fromNow
+            PendingCleanupFutures.asScala.foreach { future =>
+              val remaining = deadline.timeLeft
+              if (remaining.length > 0) {
+                try Await.ready(future, remaining)
+                catch {
+                  case NonFatal(e) =>
+                    logWarning(
+                      "Timed out waiting for client snapshot cleanup",
+                      e
+                    )
+                }
               }
             }
           }
-        }
-      },
-      "milvus-snapshot-cleanup-shutdown-drain"
+        },
+        "milvus-snapshot-cleanup-shutdown-drain"
+      )
     )
-  )
+  ).failed.foreach { e =>
+    logWarning("Failed to register client snapshot cleanup shutdown hook", e)
+  }
 
   private val SnapshotOptionKeys = Seq(
     MilvusOption.SnapshotMode,
@@ -1096,10 +1107,16 @@ class MilvusScan(
 
   override def toBatch: Batch = this
 
-  private lazy val plannedPartitions: Array[InputPartition] =
+  private lazy val plannedSnapshotPartitions: Array[InputPartition] =
     computeInputPartitions()
 
-  override def planInputPartitions(): Array[InputPartition] = plannedPartitions
+  override def planInputPartitions(): Array[InputPartition] = {
+    if (shouldCacheInputPartitions) plannedSnapshotPartitions
+    else computeInputPartitions()
+  }
+
+  private[sources] def shouldCacheInputPartitions: Boolean =
+    MilvusOption.isSnapshotMode(options)
 
   private def computeInputPartitions(): Array[InputPartition] = {
     if (MilvusOption.isSnapshotMode(options)) {
@@ -1437,11 +1454,19 @@ class MilvusScan(
         conf.unset(s"$prefix.secret.key")
         conf.set(
           s"$prefix.aws.credentials.provider",
-          "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
+          MilvusScan.DefaultAwsCredentialsProvider
         )
       } else {
         setIfDefined(s"$prefix.access.key", accessKey)
         setIfDefined(s"$prefix.secret.key", secretKey)
+        if (
+          accessKey.exists(_.trim.nonEmpty) && secretKey.exists(_.trim.nonEmpty)
+        ) {
+          conf.set(
+            s"$prefix.aws.credentials.provider",
+            MilvusScan.SimpleAwsCredentialsProvider
+          )
+        }
       }
     }
 

--- a/src/test/scala/MilvusClientCheckStatusTest.scala
+++ b/src/test/scala/MilvusClientCheckStatusTest.scala
@@ -159,6 +159,42 @@ class MilvusClientCheckStatusTest extends AnyFunSuite {
     assert(!MilvusClient.isServiceNotImplemented(err))
   }
 
+  test("classifies grpc NOT_FOUND as snapshot already dropped") {
+    val err = new StatusRuntimeException(
+      GrpcStatus.NOT_FOUND.withDescription("snapshot not found")
+    )
+    assert(MilvusClient.isSnapshotAlreadyDropped(err))
+    assert(MilvusClient.isTerminalSnapshotDropError(err))
+  }
+
+  test("classifies wrapped grpc terminal snapshot drop errors") {
+    Seq(GrpcStatus.PERMISSION_DENIED, GrpcStatus.INVALID_ARGUMENT).foreach {
+      status =>
+        val err = new RuntimeException(
+          "wrapped",
+          new StatusRuntimeException(status.withDescription("terminal"))
+        )
+        assert(!MilvusClient.isSnapshotAlreadyDropped(err))
+        assert(MilvusClient.isTerminalSnapshotDropError(err))
+    }
+  }
+
+  test("does not classify grpc UNAVAILABLE as terminal snapshot drop error") {
+    val err = new StatusRuntimeException(
+      GrpcStatus.UNAVAILABLE.withDescription("transient")
+    )
+    assert(!MilvusClient.isSnapshotAlreadyDropped(err))
+    assert(!MilvusClient.isTerminalSnapshotDropError(err))
+  }
+
+  test("snapshot drop terminal detection stops on cyclic causes") {
+    val err = new RuntimeException("ordinary error") {
+      override def getCause: Throwable = this
+    }
+    assert(!MilvusClient.isSnapshotAlreadyDropped(err))
+    assert(!MilvusClient.isTerminalSnapshotDropError(err))
+  }
+
   test("service-not-implemented detection stops on cyclic causes") {
     val err = new RuntimeException("ordinary error") {
       override def getCause: Throwable = this

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -222,6 +222,43 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     ) shouldBe true
   }
 
+  test(
+    "validateSnapshotModeOptions rejects explicit mode without segment hints"
+  ) {
+    Seq(
+      Map(MilvusOption.SnapshotMode -> "true"),
+      Map(
+        MilvusOption.SnapshotMode -> "true",
+        MilvusOption.SnapshotManifests -> " "
+      ),
+      Map(
+        MilvusOption.SnapshotMode -> "true",
+        MilvusOption.SnapshotV2Segments -> " "
+      )
+    ).foreach { options =>
+      val err = intercept[IllegalArgumentException] {
+        MilvusOption.validateSnapshotModeOptions(options)
+      }
+      err.getMessage should include(MilvusOption.SnapshotManifests)
+      err.getMessage should include(MilvusOption.SnapshotV2Segments)
+    }
+  }
+
+  test("validateSnapshotModeOptions accepts explicit mode with segment hints") {
+    MilvusOption.validateSnapshotModeOptions(
+      Map(
+        MilvusOption.SnapshotMode -> "true",
+        MilvusOption.SnapshotManifests -> "[]"
+      )
+    )
+    MilvusOption.validateSnapshotModeOptions(
+      Map(
+        MilvusOption.SnapshotMode -> "true",
+        MilvusOption.SnapshotV2Segments -> "[]"
+      )
+    )
+  }
+
   test("isSnapshotMode accepts snapshot metadata options") {
     MilvusOption.isSnapshotMode(
       Map(MilvusOption.SnapshotManifests -> "[]")

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -231,6 +231,22 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     ) shouldBe true
   }
 
+  test(
+    "isSnapshotMode respects explicit false over snapshot metadata options"
+  ) {
+    val mapOptions = Map(
+      MilvusOption.SnapshotMode -> "false",
+      MilvusOption.SnapshotManifests -> "[]"
+    )
+    MilvusOption.isSnapshotMode(mapOptions) shouldBe false
+
+    val javaOptions = new java.util.HashMap[String, String]()
+    mapOptions.foreach { case (key, value) => javaOptions.put(key, value) }
+    MilvusOption.isSnapshotMode(
+      new CaseInsensitiveStringMap(javaOptions)
+    ) shouldBe false
+  }
+
   test("isSnapshotMode is consistent across option map types") {
     Seq(
       Map(MilvusOption.SnapshotMode.toUpperCase -> "true"),

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -214,6 +214,27 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     milvusOption.options should contain key "custom.option"
     milvusOption.options("custom.option") shouldBe "custom_value"
   }
+
+  test("isSnapshotMode accepts explicit snapshot mode") {
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotMode -> "true")
+    ) shouldBe true
+  }
+
+  test("isSnapshotMode accepts snapshot metadata options") {
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotManifests -> "[]")
+    ) shouldBe true
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotV2Segments -> "[]")
+    ) shouldBe true
+  }
+
+  test("isSnapshotMode is false for normal client options") {
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.MilvusCollectionName -> "c")
+    ) shouldBe false
+  }
 }
 
 /** Unit tests for MilvusS3Option

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector
 
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -228,6 +229,21 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     MilvusOption.isSnapshotMode(
       Map(MilvusOption.SnapshotV2Segments -> "[]")
     ) shouldBe true
+  }
+
+  test("isSnapshotMode is consistent across option map types") {
+    Seq(
+      Map(MilvusOption.SnapshotMode.toUpperCase -> "true"),
+      Map(MilvusOption.SnapshotManifests.toUpperCase -> "[]"),
+      Map(MilvusOption.SnapshotV2Segments.toUpperCase -> "[]"),
+      Map(MilvusOption.MilvusCollectionName -> "c")
+    ).foreach { options =>
+      val javaOptions = new java.util.HashMap[String, String]()
+      options.foreach { case (key, value) => javaOptions.put(key, value) }
+      MilvusOption.isSnapshotMode(options) shouldBe MilvusOption.isSnapshotMode(
+        new CaseInsensitiveStringMap(javaOptions)
+      )
+    }
   }
 
   test("isSnapshotMode is false for normal client options") {

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -142,6 +142,15 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("readFieldIdsFromSchema returns Left for malformed URI") {
+    val result = MilvusParquetFooterReader.readFieldIdsFromSchema(
+      "s3a://bucket/path with spaces/[bad].parquet",
+      new Configuration()
+    )
+
+    result shouldBe a[Left[_, _]]
+  }
+
   test("readFieldIdsFromSchema returns Left when a column has no field id") {
     val tmp = Files.createTempFile("milvus-fid-test-bad-", ".parquet")
     Files.delete(tmp)

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -1,9 +1,18 @@
 package com.zilliz.spark.connector.read
 
+import java.net.URI
 import java.nio.file.Files
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{Path => HPath}
+import org.apache.hadoop.fs.{
+  FSDataInputStream,
+  FSDataOutputStream,
+  FileStatus,
+  FileSystem,
+  Path => HPath
+}
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.util.Progressable
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
 import org.apache.parquet.hadoop.example.{
   ExampleParquetWriter,
@@ -151,6 +160,18 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
     result shouldBe a[Left[_, _]]
   }
 
+  test("readFieldIdsFromSchema does not swallow fatal errors") {
+    val conf = new Configuration()
+    conf.set("fs.fatal-footer.impl", classOf[FatalFooterFileSystem].getName)
+
+    intercept[OutOfMemoryError] {
+      MilvusParquetFooterReader.readFieldIdsFromSchema(
+        "fatal-footer://bucket/file.parquet",
+        conf
+      )
+    }
+  }
+
   test("readFieldIdsFromSchema returns Left when a column has no field id") {
     val tmp = Files.createTempFile("milvus-fid-test-bad-", ".parquet")
     Files.delete(tmp)
@@ -192,4 +213,52 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
       Files.deleteIfExists(tmp)
     }
   }
+}
+
+class FatalFooterFileSystem extends FileSystem {
+  private var uri: URI = _
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    super.initialize(name, conf)
+    uri = name
+  }
+
+  override def getUri: URI = uri
+
+  override def open(path: HPath, bufferSize: Int): FSDataInputStream =
+    throw new OutOfMemoryError("fatal")
+
+  override def create(
+      path: HPath,
+      permission: FsPermission,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def append(
+      path: HPath,
+      bufferSize: Int,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def rename(src: HPath, dst: HPath): Boolean =
+    throw new UnsupportedOperationException
+
+  override def delete(path: HPath, recursive: Boolean): Boolean =
+    throw new UnsupportedOperationException
+
+  override def listStatus(path: HPath): Array[FileStatus] =
+    throw new UnsupportedOperationException
+
+  override def setWorkingDirectory(path: HPath): Unit = ()
+
+  override def getWorkingDirectory: HPath = new HPath("/")
+
+  override def mkdirs(path: HPath, permission: FsPermission): Boolean = true
+
+  override def getFileStatus(path: HPath): FileStatus =
+    new FileStatus(1L, false, 1, 1L, 0L, path)
 }

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -24,6 +24,15 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     err.getMessage should include("exceeds")
   }
 
+  test("readUtf8WithLimit rejects non-positive limit clearly") {
+    val bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val in = new java.io.ByteArrayInputStream(bytes)
+    val err = intercept[IllegalArgumentException] {
+      MilvusSnapshotReader.readUtf8WithLimit(in, "memory", -1)
+    }
+    err.getMessage should include("must be positive")
+  }
+
   test("Parse complete snapshot metadata successfully") {
     val result =
       MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -311,6 +311,9 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     sparkSchema("float").dataType shouldBe FloatType
     sparkSchema("varchar").dataType shouldBe StringType
     sparkSchema("vector").dataType shouldBe ArrayType(FloatType)
+    sparkSchema("vector").metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
+    ) shouldBe 101L
   }
 
   test(

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -3,6 +3,11 @@ package com.zilliz.spark.connector.read
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import io.milvus.grpc.schema.{
+  CollectionSchema => ProtoCollectionSchema,
+  DataType
+}
+
 /** Test suite for MilvusSnapshotReader
   */
 class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
@@ -500,5 +505,142 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     // Verify both formats work correctly
     schema.getFieldByName("id").get.dataType shouldBe 5 // Int format
     schema.getFieldByName("score").get.dataType shouldBe 10 // String format
+  }
+
+  test("toProtobufSchemaBytes preserves read-path schema attributes") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "description": "schema desc",
+          "autoID": true,
+          "enable_dynamic_field": true,
+          "properties": [{"key": "timezone", "value": "UTC"}],
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": "Int64",
+              "is_primary_key": true,
+              "is_partition_key": true,
+              "nullable": false,
+              "state": "FieldCreated",
+              "default_value": {"long_data": 7}
+            },
+            {
+              "fieldID": 101,
+              "name": "tags",
+              "data_type": "Array",
+              "element_type": "VarChar",
+              "nullable": true,
+              "is_function_output": true
+            },
+            {
+              "fieldID": 102,
+              "name": "dyn",
+              "data_type": "JSON",
+              "is_dynamic": true
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val schema = MilvusSnapshotReader
+      .parseSnapshotMetadata(json)
+      .toOption
+      .get
+      .collection
+      .schema
+    val proto = ProtoCollectionSchema.parseFrom(
+      MilvusSnapshotReader.toProtobufSchemaBytes(schema)
+    )
+
+    proto.name shouldBe "test"
+    proto.description shouldBe "schema desc"
+    proto.autoID shouldBe true
+    proto.enableDynamicField shouldBe true
+    proto.properties.map(p => p.key -> p.value) should contain(
+      "timezone" -> "UTC"
+    )
+
+    val id = proto.fields.find(_.name == "id").get
+    id.fieldID shouldBe 100L
+    id.dataType shouldBe DataType.Int64
+    id.isPrimaryKey shouldBe true
+    id.isPartitionKey shouldBe true
+    id.nullable shouldBe false
+    id.getDefaultValue.getLongData shouldBe 7L
+
+    val tags = proto.fields.find(_.name == "tags").get
+    tags.dataType shouldBe DataType.Array
+    tags.elementType shouldBe DataType.VarChar
+    tags.nullable shouldBe true
+    tags.isFunctionOutput shouldBe true
+
+    val dyn = proto.fields.find(_.name == "dyn").get
+    dyn.dataType shouldBe DataType.JSON
+    dyn.isDynamic shouldBe true
+  }
+
+  test("toSparkSchema uses array element type and snapshot nullable flag") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": "Int64",
+              "nullable": false
+            },
+            {
+              "fieldID": 101,
+              "name": "tags",
+              "data_type": "Array",
+              "element_type": "VarChar",
+              "nullable": true
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val schema = MilvusSnapshotReader
+      .parseSnapshotMetadata(json)
+      .toOption
+      .get
+      .collection
+      .schema
+    val sparkSchema = MilvusSnapshotReader.toSparkSchema(schema)
+
+    sparkSchema("id").nullable shouldBe false
+    sparkSchema("tags").dataType shouldBe org.apache.spark.sql.types.ArrayType(
+      org.apache.spark.sql.types.StringType
+    )
+    sparkSchema("tags").nullable shouldBe true
   }
 }

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -9,6 +9,21 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
 
   private val snapshotFilePath = "src/test/data/sample_snapshot.json"
 
+  test("readUtf8WithLimit reads utf8 content within limit") {
+    val bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val in = new java.io.ByteArrayInputStream(bytes)
+    MilvusSnapshotReader.readUtf8WithLimit(in, "memory", 10) shouldBe "hello"
+  }
+
+  test("readUtf8WithLimit rejects content beyond limit") {
+    val bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    val in = new java.io.ByteArrayInputStream(bytes)
+    val err = intercept[IllegalArgumentException] {
+      MilvusSnapshotReader.readUtf8WithLimit(in, "memory", 4)
+    }
+    err.getMessage should include("exceeds")
+  }
+
   test("Parse complete snapshot metadata successfully") {
     val result =
       MilvusSnapshotReader.readSnapshotMetadataFromFile(snapshotFilePath)

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -293,6 +293,15 @@ class V2SegmentLoaderTest
     err.getMessage should include("s3a://bucket/path with spaces/[bad].avro")
   }
 
+  test("readAllBytes does not swallow fatal errors") {
+    val conf = new Configuration()
+    conf.set("fs.fatal-v2.impl", classOf[FatalV2FileSystem].getName)
+
+    intercept[OutOfMemoryError] {
+      V2SegmentLoader.readAllBytes(conf, "fatal-v2://bucket/manifest.avro")
+    }
+  }
+
   test("readAllBytes closes the FileSystem instance when cache is disabled") {
     val conf = new Configuration()
     conf.set(
@@ -388,4 +397,9 @@ object CloseTrackingV2FileSystem {
   val closeCount = new AtomicInteger(0)
 
   def reset(): Unit = closeCount.set(0)
+}
+
+class FatalV2FileSystem extends CloseTrackingV2FileSystem {
+  override def open(path: HPath, bufferSize: Int): FSDataInputStream =
+    throw new OutOfMemoryError("fatal")
 }

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -1,9 +1,21 @@
 package com.zilliz.spark.connector.read
 
+import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path => NPath}
+import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{Path => HPath}
+import org.apache.hadoop.fs.{
+  FSDataInputStream,
+  FSDataOutputStream,
+  FSInputStream,
+  FileStatus,
+  FileSystem,
+  Path => HPath
+}
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.util.Progressable
 import org.apache.parquet.example.data.simple.SimpleGroupFactory
 import org.apache.parquet.hadoop.example.{
   ExampleParquetWriter,
@@ -14,6 +26,7 @@ import org.apache.parquet.schema.{MessageType, Types}
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 
 /** Unit tests for [[V2SegmentLoader.buildV2SegmentInfoFromEntry]].
   *
@@ -24,7 +37,15 @@ import org.scalatest.matchers.should.Matchers
   * settings and stamps them into Parquet's native `SchemaElement.field_id` —
   * the same place milvus-storage's arrow-cpp writer puts them.
   */
-class V2SegmentLoaderTest extends AnyFunSuite with Matchers {
+class V2SegmentLoaderTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    CloseTrackingV2FileSystem.reset()
+  }
 
   /** Write a single-column parquet at `path` carrying the given field id, so
     * `readFieldIdsFromSchema` will return `Seq(fieldId)`.
@@ -259,4 +280,100 @@ class V2SegmentLoaderTest extends AnyFunSuite with Matchers {
 
     result shouldBe Right(None)
   }
+
+  test("readAllBytes closes the FileSystem instance when cache is disabled") {
+    val conf = new Configuration()
+    conf.set(
+      "fs.close-tracking-v2.impl",
+      classOf[CloseTrackingV2FileSystem].getName
+    )
+    conf.set("fs.close-tracking-v2.impl.disable.cache", "true")
+
+    V2SegmentLoader.readAllBytes(
+      conf,
+      "close-tracking-v2://bucket/manifest.avro"
+    ) shouldBe "avro".getBytes(StandardCharsets.UTF_8)
+    CloseTrackingV2FileSystem.closeCount.get() shouldBe 1
+  }
+}
+
+class CloseTrackingV2FileSystem extends FileSystem {
+  private var uri: URI = _
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    super.initialize(name, conf)
+    uri = name
+  }
+
+  override def getUri: URI = uri
+
+  override def open(path: HPath, bufferSize: Int): FSDataInputStream = {
+    val bytes = "avro".getBytes(StandardCharsets.UTF_8)
+    val in = new FSInputStream {
+      private var pos = 0
+
+      override def read(): Int = {
+        if (pos >= bytes.length) -1
+        else {
+          val value = bytes(pos) & 0xff
+          pos += 1
+          value
+        }
+      }
+
+      override def seek(newPos: Long): Unit = {
+        pos = newPos.toInt
+      }
+
+      override def getPos: Long = pos
+
+      override def seekToNewSource(targetPos: Long): Boolean = false
+    }
+    new FSDataInputStream(in)
+  }
+
+  override def close(): Unit = {
+    CloseTrackingV2FileSystem.closeCount.incrementAndGet()
+    super.close()
+  }
+
+  override def create(
+      path: HPath,
+      permission: FsPermission,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def append(
+      path: HPath,
+      bufferSize: Int,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def rename(src: HPath, dst: HPath): Boolean =
+    throw new UnsupportedOperationException
+
+  override def delete(path: HPath, recursive: Boolean): Boolean =
+    throw new UnsupportedOperationException
+
+  override def listStatus(path: HPath): Array[FileStatus] =
+    throw new UnsupportedOperationException
+
+  override def setWorkingDirectory(path: HPath): Unit = ()
+
+  override def getWorkingDirectory: HPath = new HPath("/")
+
+  override def mkdirs(path: HPath, permission: FsPermission): Boolean = true
+
+  override def getFileStatus(path: HPath): FileStatus =
+    new FileStatus(4L, false, 1, 4L, 0L, path)
+}
+
+object CloseTrackingV2FileSystem {
+  val closeCount = new AtomicInteger(0)
+
+  def reset(): Unit = closeCount.set(0)
 }

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -281,6 +281,18 @@ class V2SegmentLoaderTest
     result shouldBe Right(None)
   }
 
+  test("readAllBytes wraps malformed URI with path context") {
+    val err = intercept[RuntimeException] {
+      V2SegmentLoader.readAllBytes(
+        new Configuration(),
+        "s3a://bucket/path with spaces/[bad].avro"
+      )
+    }
+
+    err.getMessage should include("failed to read bytes")
+    err.getMessage should include("s3a://bucket/path with spaces/[bad].avro")
+  }
+
   test("readAllBytes closes the FileSystem instance when cache is disabled") {
     val conf = new Configuration()
     conf.set(

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.types.DataTypes
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import com.zilliz.spark.connector.serde.ArrowConverter
 import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
 /** Unit tests for DataTypeUtil type conversions
@@ -271,6 +272,14 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     an[DataParseException] should be thrownBy {
       DataTypeUtil.toDataType(fieldSchema)
     }
+  }
+
+  test("metadata stores Milvus data type code") {
+    val fieldSchema = FieldSchema(dataType = MilvusDataType.Float16Vector)
+    val result = DataTypeUtil.metadata(fieldSchema)
+
+    result.getLong(ArrowConverter.MilvusDataTypeMetadataKey) shouldBe
+      MilvusDataType.Float16Vector.value.toLong
   }
 
   test("toDataType throws exception for unsupported array element type") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -252,6 +252,18 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
       MilvusScan.validateClientSnapshotMetadata(missingSchema, snapshotPath)
     }
     assert(schemaErr.getMessage.contains("collection.schema"))
+
+    val emptySnapshot = SnapshotMetadata(
+      snapshotInfo = SnapshotInfo("s"),
+      collection = Collection(CollectionSchema("c", fields = Seq.empty)),
+      manifestList = Seq.empty,
+      storageV2ManifestList = Some(Seq.empty)
+    )
+    val emptyErr = intercept[IllegalArgumentException] {
+      MilvusScan.validateClientSnapshotMetadata(emptySnapshot, snapshotPath)
+    }
+    assert(emptyErr.getMessage.contains("client snapshot is empty"))
+    assert(emptyErr.getMessage.contains("no manifests and no V2 segments"))
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1,11 +1,26 @@
 package com.zilliz.spark.connector.sources
 
 import java.{util => ju}
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{
+  FSDataInputStream,
+  FSDataOutputStream,
+  FSInputStream,
+  FileStatus,
+  FileSystem,
+  Path
+}
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.util.Progressable
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterEach
 
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
@@ -22,10 +37,15 @@ import com.zilliz.spark.connector.read.{
 }
 import com.zilliz.spark.connector.MilvusOption
 
-class MilvusScanClientSnapshotTest extends AnyFunSuite {
+class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   private val emptySchemaBytes = java.util.Base64.getEncoder.encodeToString(
     io.milvus.grpc.schema.CollectionSchema(name = "c").toByteArray
   )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    CloseTrackingFileSystem.reset()
+  }
 
   private def scanWithOptions(
       rawOptions: ju.HashMap[String, String]
@@ -107,6 +127,31 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
         }
         assert(err.getMessage.contains(Properties.FsConfig.FsBucketName))
       }
+  }
+
+  test("buildSnapshotHadoopConf disables S3A FileSystem cache") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(Properties.FsConfig.FsBucketName, "connector-bucket")
+    val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
+      "s3a://connector-bucket/files/snapshots/1/metadata/2.json"
+    )
+    assert(conf.get("fs.s3a.impl.disable.cache") == "true")
+  }
+
+  test("readAllBytes closes the FileSystem instance when cache is disabled") {
+    val rawOptions = new ju.HashMap[String, String]()
+    val conf = new Configuration()
+    conf.set(
+      "fs.close-tracking.impl",
+      classOf[CloseTrackingFileSystem].getName
+    )
+    conf.set("fs.close-tracking.impl.disable.cache", "true")
+    val content = scanWithOptions(rawOptions).readAllBytes(
+      conf,
+      "close-tracking://bucket/snapshot.json"
+    )
+    assert(content == "{}")
+    assert(CloseTrackingFileSystem.closeCount.get() == 1)
   }
 
   test(
@@ -352,4 +397,85 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(partition.segmentID == 30L)
     assert(partition.partitionID == 20L)
   }
+}
+
+class CloseTrackingFileSystem extends FileSystem {
+  private var uri: URI = _
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    super.initialize(name, conf)
+    uri = name
+  }
+
+  override def getUri: URI = uri
+
+  override def open(path: Path, bufferSize: Int): FSDataInputStream = {
+    val bytes = "{}".getBytes(StandardCharsets.UTF_8)
+    val in = new FSInputStream {
+      private var pos = 0
+
+      override def read(): Int = {
+        if (pos >= bytes.length) -1
+        else {
+          val value = bytes(pos) & 0xff
+          pos += 1
+          value
+        }
+      }
+
+      override def seek(newPos: Long): Unit = {
+        pos = newPos.toInt
+      }
+
+      override def getPos: Long = pos
+
+      override def seekToNewSource(targetPos: Long): Boolean = false
+    }
+    new FSDataInputStream(in)
+  }
+
+  override def close(): Unit = {
+    CloseTrackingFileSystem.closeCount.incrementAndGet()
+    super.close()
+  }
+
+  override def create(
+      path: Path,
+      permission: FsPermission,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def append(
+      path: Path,
+      bufferSize: Int,
+      progress: Progressable
+  ): FSDataOutputStream = throw new UnsupportedOperationException
+
+  override def rename(src: Path, dst: Path): Boolean =
+    throw new UnsupportedOperationException
+
+  override def delete(path: Path, recursive: Boolean): Boolean =
+    throw new UnsupportedOperationException
+
+  override def listStatus(path: Path): Array[FileStatus] =
+    throw new UnsupportedOperationException
+
+  override def setWorkingDirectory(path: Path): Unit = ()
+
+  override def getWorkingDirectory: Path = new Path("/")
+
+  override def mkdirs(path: Path, permission: FsPermission): Boolean = true
+
+  override def getFileStatus(path: Path): FileStatus =
+    new FileStatus(2L, false, 1, 2L, 0L, path)
+}
+
+object CloseTrackingFileSystem {
+  val closeCount = new AtomicInteger(0)
+
+  def reset(): Unit = closeCount.set(0)
 }

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -106,7 +106,6 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
       collectionName = "snapshot_collection",
       collectionId = 10L,
       partitionIds = Seq(20L, 21L),
-      snapshotJson = "{\"snapshot_info\":{},\"collection\":{}}",
       schemaBytesBase64 = "abc",
       manifestList = Seq.empty,
       v2Segments = Seq.empty
@@ -115,7 +114,7 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(out(MilvusOption.MilvusCollectionName) == "snapshot_collection")
     assert(out(MilvusOption.SnapshotCollectionId) == "10")
     assert(out(MilvusOption.SnapshotPartitionIds) == "20,21")
-    assert(out(MilvusOption.SnapshotSchemaJson).nonEmpty)
+    assert(!out.contains(MilvusOption.SnapshotSchemaJson))
     assert(out(MilvusOption.SnapshotSchemaBytes) == "abc")
     assert(out.contains(MilvusOption.SnapshotManifests))
     assert(out(MilvusOption.MilvusExtraColumns) == "partition")

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1,0 +1,194 @@
+package com.zilliz.spark.connector.sources
+
+import java.{util => ju}
+
+import org.apache.spark.sql.connector.read.InputPartition
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.zilliz.spark.connector.read.{
+  MilvusPackedV2InputPartition,
+  MilvusSnapshotReader,
+  MilvusStorageV3InputPartition,
+  StorageV2ManifestItem,
+  V2ColumnGroup,
+  V2SegmentInfo
+}
+import com.zilliz.spark.connector.MilvusOption
+
+class MilvusScanClientSnapshotTest extends AnyFunSuite {
+  private val emptySchemaBytes = java.util.Base64.getEncoder.encodeToString(
+    io.milvus.grpc.schema.CollectionSchema(name = "c").toByteArray
+  )
+
+  private def scanWithOptions(
+      rawOptions: ju.HashMap[String, String]
+  ): MilvusScan = {
+    new MilvusScan(
+      StructType(Seq(StructField("RowID", LongType, nullable = false))),
+      new CaseInsensitiveStringMap(rawOptions)
+    )
+  }
+
+  test(
+    "resolveClientSnapshotLocation prefixes bucket-relative snapshot locations"
+  ) {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "files/snapshots/1/metadata/2.json",
+        "a-bucket"
+      ) == "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+    )
+  }
+
+  test("resolveClientSnapshotLocation normalizes s3 scheme to s3a") {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "s3://a-bucket/files/snapshots/1/metadata/2.json",
+        "ignored"
+      ) == "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+    )
+  }
+
+  test("snapshotBucketsToConfigure includes cross-bucket snapshot locations") {
+    assert(
+      MilvusScan.snapshotBucketsToConfigure(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/2.json",
+        "connector-bucket"
+      ) == Seq("connector-bucket", "snapshot-bucket")
+    )
+    assert(
+      MilvusScan.snapshotBucketsToConfigure(
+        "s3a://connector-bucket/files/snapshots/1/metadata/2.json",
+        "connector-bucket"
+      ) == Seq("connector-bucket")
+    )
+  }
+
+  test(
+    "client snapshot fast path is disabled when partition or segment selectors are set"
+  ) {
+    val base = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusCollectionName -> "c"
+    )
+    assert(MilvusScan.canUseClientSnapshotFastPath(MilvusOption(base)))
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusPartitionName -> "p"))
+      )
+    )
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusPartitionID -> "20"))
+      )
+    )
+    assert(
+      !MilvusScan.canUseClientSnapshotFastPath(
+        MilvusOption(base + (MilvusOption.MilvusSegmentID -> "30"))
+      )
+    )
+  }
+
+  test(
+    "buildClientSnapshotOptions preserves read options and adds snapshot options"
+  ) {
+    val base = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusCollectionName -> "c",
+      MilvusOption.MilvusExtraColumns -> "partition",
+      MilvusOption.SnapshotMode -> "false",
+      MilvusOption.SnapshotCollectionId -> "old"
+    )
+    val out = MilvusScan.buildClientSnapshotOptions(
+      baseOptions = base,
+      collectionName = "snapshot_collection",
+      collectionId = 10L,
+      partitionIds = Seq(20L, 21L),
+      snapshotJson = "{\"snapshot_info\":{},\"collection\":{}}",
+      schemaBytesBase64 = "abc",
+      manifestList = Seq.empty,
+      v2Segments = Seq.empty
+    )
+    assert(out(MilvusOption.SnapshotMode) == "true")
+    assert(out(MilvusOption.MilvusCollectionName) == "snapshot_collection")
+    assert(out(MilvusOption.SnapshotCollectionId) == "10")
+    assert(out(MilvusOption.SnapshotPartitionIds) == "20,21")
+    assert(out(MilvusOption.SnapshotSchemaJson).nonEmpty)
+    assert(out(MilvusOption.SnapshotSchemaBytes) == "abc")
+    assert(out.contains(MilvusOption.SnapshotManifests))
+    assert(out(MilvusOption.MilvusExtraColumns) == "partition")
+  }
+
+  test("snapshot planner returns no partitions for empty snapshots") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, "[]")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+    assert(partitions.isEmpty)
+  }
+
+  test("snapshot planner fails loudly on malformed manifest JSON") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, "not-json")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val err = intercept[Exception] {
+      scanWithOptions(rawOptions).planInputPartitions()
+    }
+    assert(err.getMessage.contains("Failed to parse snapshot manifests"))
+  }
+
+  test("snapshot planner tags V3 partitions with partition ID string") {
+    val manifestJson = MilvusSnapshotReader.serializeManifestList(
+      Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+        )
+      )
+    )
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, manifestJson)
+    rawOptions.put(MilvusOption.SnapshotPartitionIds, "20,21")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+    assert(partitions.length == 1)
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.partitionName == "20")
+    assert(partition.segmentID == 30L)
+    assert(partition.readVersion == 7L)
+  }
+
+  test("snapshot planner accepts V2-only snapshot segments") {
+    val v2Json = MilvusSnapshotReader.serializeV2Segments(
+      Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        )
+      )
+    )
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotV2Segments, v2Json)
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+    assert(partitions.length == 1)
+    val partition = partitions.head.asInstanceOf[MilvusPackedV2InputPartition]
+    assert(partition.segmentID == 30L)
+    assert(partition.partitionID == 20L)
+  }
+}

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -96,6 +96,34 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test("snapshotBucket returns None for bucket-relative snapshot locations") {
+    assert(
+      MilvusScan.snapshotBucket("files/snapshots/1/metadata/2.json") == None
+    )
+  }
+
+  test("snapshotBucket rejects unsupported schemes") {
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.snapshotBucket("gs://a-bucket/files/snapshot.json")
+    }
+    assert(err.getMessage.contains("Unsupported snapshot s3_location scheme"))
+  }
+
+  test("snapshotS3BucketForRelativePaths prefers snapshot bucket") {
+    assert(
+      MilvusScan.snapshotS3BucketForRelativePaths(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/2.json",
+        Map(Properties.FsConfig.FsBucketName -> "connector-bucket")
+      ) == Some("snapshot-bucket")
+    )
+    assert(
+      MilvusScan.snapshotS3BucketForRelativePaths(
+        "files/snapshots/1/metadata/2.json",
+        Map(Properties.FsConfig.FsBucketName -> "connector-bucket")
+      ) == Some("connector-bucket")
+    )
+  }
+
   test("snapshotBucketsToConfigure includes cross-bucket snapshot locations") {
     assert(
       MilvusScan.snapshotBucketsToConfigure(
@@ -216,6 +244,24 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(CloseTrackingFileSystem.closeCount.get() == 1)
   }
 
+  test("readAllBytes ignores cache close config for scheme-less paths") {
+    val rawOptions = new ju.HashMap[String, String]()
+    val conf = new Configuration()
+    conf.set("fs.defaultFS", "close-tracking://bucket")
+    conf.set(
+      "fs.close-tracking.impl",
+      classOf[CloseTrackingFileSystem].getName
+    )
+    conf.set("fs.close-tracking.impl.disable.cache", "true")
+    val content = scanWithOptions(rawOptions).readAllBytes(
+      conf,
+      "/snapshot.json"
+    )
+    assert(content == "{}")
+    assert(CloseTrackingFileSystem.closeCount.get() == 0)
+    assert(conf.get("fs.null.impl.disable.cache") == null)
+  }
+
   test(
     "client snapshot fast path is disabled when partition or segment selectors are set"
   ) {
@@ -271,6 +317,22 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(out(MilvusOption.MilvusExtraColumns) == "partition")
   }
 
+  test("buildClientSnapshotOptions overrides relative-path bucket") {
+    val out = MilvusScan.buildClientSnapshotOptions(
+      baseOptions = Map(
+        Properties.FsConfig.FsBucketName.toUpperCase -> "connector-bucket"
+      ),
+      collectionName = "snapshot_collection",
+      collectionId = 10L,
+      partitionIds = Seq(20L),
+      schemaBytesBase64 = "abc",
+      manifestList = Seq.empty,
+      v2Segments = Seq.empty,
+      snapshotBucketForRelativePaths = Some("snapshot-bucket")
+    )
+    assert(out(Properties.FsConfig.FsBucketName) == "snapshot-bucket")
+  }
+
   test("snapshot option keys use dotted lowercase suffixes") {
     assert(
       MilvusOption.SnapshotMaxJsonBytes == "milvus.snapshot.max.json.bytes"
@@ -312,6 +374,15 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(name.length <= 255)
     assert(name.startsWith("spark_read_"))
     assert(name.endsWith("_1_" + "u" * 32))
+  }
+
+  test("generatedClientSnapshotName sanitizes collection names") {
+    val name = MilvusScan.generatedClientSnapshotName(
+      collectionName = "col-name.with unicode值",
+      currentTimeMillis = 1L,
+      uuid = "u" * 32
+    )
+    assert(name == s"spark_read_col_name_with_unicode__1_${"u" * 32}")
   }
 
   test("buildClientSnapshotOptions enables snapshot mode") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -132,6 +132,57 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test(
+    "validateSnapshotBucketForRelativeDataPaths rejects unset connector bucket with relative V3 paths"
+  ) {
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.validateSnapshotBucketForRelativeDataPaths(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/snapshot.json",
+        None,
+        Seq(
+          StorageV2ManifestItem(
+            30L,
+            "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+          )
+        ),
+        Seq.empty
+      )
+    }
+    assert(err.getMessage.contains("snapshot-bucket"))
+    assert(err.getMessage.contains("<unset>"))
+    assert(err.getMessage.contains("files/insert_log/10/20/30"))
+  }
+
+  test(
+    "validateSnapshotBucketForRelativeDataPaths rejects unset connector bucket with relative V2 paths"
+  ) {
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.validateSnapshotBucketForRelativeDataPaths(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/snapshot.json",
+        None,
+        Seq.empty,
+        Seq(
+          V2SegmentInfo(
+            segmentId = 30L,
+            partitionId = 20L,
+            numOfRows = 1L,
+            storageVersion = 2L,
+            columnGroups = Seq(
+              V2ColumnGroup(
+                fieldIds = Seq(100L),
+                filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+                fileRowCounts = Seq(1L)
+              )
+            )
+          )
+        )
+      )
+    }
+    assert(err.getMessage.contains("snapshot-bucket"))
+    assert(err.getMessage.contains("<unset>"))
+    assert(err.getMessage.contains("files/insert_log/10/20/30/100/1.parquet"))
+  }
+
+  test(
     "validateSnapshotBucketForRelativeDataPaths accepts cross-bucket fully-qualified data paths"
   ) {
     MilvusScan.validateSnapshotBucketForRelativeDataPaths(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -7,6 +7,7 @@ import org.apache.spark.sql.types.{LongType, StructField, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 
+import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusPackedV2InputPartition,
   MilvusSnapshotReader,
@@ -86,6 +87,24 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
+  test("resolveConnectorS3Bucket trims configured bucket") {
+    assert(
+      MilvusScan.resolveConnectorS3Bucket(
+        Map(Properties.FsConfig.FsBucketName -> " connector-bucket ")
+      ) == "connector-bucket"
+    )
+  }
+
+  test("resolveConnectorS3Bucket rejects missing or blank bucket") {
+    Seq(Map.empty[String, String], Map(Properties.FsConfig.FsBucketName -> " "))
+      .foreach { options =>
+        val err = intercept[IllegalArgumentException] {
+          MilvusScan.resolveConnectorS3Bucket(options)
+        }
+        assert(err.getMessage.contains(Properties.FsConfig.FsBucketName))
+      }
+  }
+
   test(
     "client snapshot fast path is disabled when partition or segment selectors are set"
   ) {
@@ -139,6 +158,16 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(out(MilvusOption.SnapshotSchemaBytes) == "abc")
     assert(out.contains(MilvusOption.SnapshotManifests))
     assert(out(MilvusOption.MilvusExtraColumns) == "partition")
+  }
+
+  test("snapshot option keys use dotted lowercase suffixes") {
+    assert(
+      MilvusOption.SnapshotMaxJsonBytes == "milvus.snapshot.max.json.bytes"
+    )
+    assert(
+      MilvusOption.ClientSnapshotCompactionProtectionSeconds ==
+        "milvus.client.snapshot.compaction.protection.seconds"
+    )
   }
 
   test("parsePositiveLongOption rejects non-numeric and non-positive values") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -138,6 +138,68 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(conf.get("fs.s3a.impl.disable.cache") == "true")
   }
 
+  test("buildSnapshotHadoopConf maps connector S3 options to S3A") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(Properties.FsConfig.FsBucketName, "connector-bucket")
+    rawOptions.put(Properties.FsConfig.FsAddress, "minio:9000")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyId, "ak")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyValue, "sk")
+    rawOptions.put(Properties.FsConfig.FsUseSSL, "false")
+    rawOptions.put(Properties.FsConfig.FsRegion, "us-west-2")
+    rawOptions.put(Properties.FsConfig.FsUseVirtualHost, "false")
+
+    val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
+      "s3a://snapshot-bucket/files/snapshots/1/metadata/2.json"
+    )
+
+    assert(conf.get("fs.s3a.endpoint") == "minio:9000")
+    assert(conf.get("fs.s3a.connection.ssl.enabled") == "false")
+    assert(conf.get("fs.s3a.path.style.access") == "true")
+    assert(conf.get("fs.s3a.endpoint.region") == "us-west-2")
+    assert(conf.get("fs.s3a.access.key") == "ak")
+    assert(conf.get("fs.s3a.secret.key") == "sk")
+    assert(conf.get("fs.s3a.bucket.connector-bucket.endpoint") == "minio:9000")
+    assert(conf.get("fs.s3a.bucket.snapshot-bucket.endpoint") == "minio:9000")
+    assert(
+      conf.get("fs.s3a.bucket.snapshot-bucket.path.style.access") == "true"
+    )
+  }
+
+  test("buildSnapshotHadoopConf maps IAM mode without static credentials") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(Properties.FsConfig.FsBucketName, "connector-bucket")
+    rawOptions.put(Properties.FsConfig.FsUseIam, "true")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyId, "ak")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyValue, "sk")
+
+    val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
+      "s3a://connector-bucket/files/snapshots/1/metadata/2.json"
+    )
+
+    assert(conf.get("fs.s3a.access.key") == null)
+    assert(conf.get("fs.s3a.secret.key") == null)
+    assert(
+      conf.get("fs.s3a.aws.credentials.provider") ==
+        "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
+    )
+    assert(conf.get("fs.s3a.bucket.connector-bucket.access.key") == null)
+    assert(conf.get("fs.s3a.bucket.connector-bucket.secret.key") == null)
+    assert(
+      conf.get("fs.s3a.bucket.connector-bucket.aws.credentials.provider") ==
+        "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
+    )
+  }
+
+  test(
+    "buildSnapshotHadoopConf accepts snapshot bucket without connector bucket"
+  ) {
+    val conf = scanWithOptions(new ju.HashMap[String, String]())
+      .buildSnapshotHadoopConf(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/2.json"
+      )
+    assert(conf.get("fs.s3a.impl.disable.cache") == "true")
+  }
+
   test("readAllBytes closes the FileSystem instance when cache is disabled") {
     val rawOptions = new ju.HashMap[String, String]()
     val conf = new Configuration()

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -51,6 +51,26 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     )
   }
 
+  test("resolveClientSnapshotLocation rejects unsupported schemes") {
+    Seq("gs://a-bucket/files/snapshot.json", "file:///tmp/snapshot.json")
+      .foreach { location =>
+        val err = intercept[IllegalArgumentException] {
+          MilvusScan.resolveClientSnapshotLocation(location, "ignored")
+        }
+        assert(
+          err.getMessage.contains("Unsupported snapshot s3_location scheme")
+        )
+      }
+  }
+
+  test("snapshotBucket extracts authority when URI host is null") {
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3a://snapshot_bucket/files/snapshots/1/metadata/2.json"
+      ) == Some("snapshot_bucket")
+    )
+  }
+
   test("snapshotBucketsToConfigure includes cross-bucket snapshot locations") {
     assert(
       MilvusScan.snapshotBucketsToConfigure(
@@ -99,7 +119,8 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
       MilvusOption.MilvusCollectionName -> "c",
       MilvusOption.MilvusExtraColumns -> "partition",
       MilvusOption.SnapshotMode -> "false",
-      MilvusOption.SnapshotCollectionId -> "old"
+      MilvusOption.SnapshotCollectionId -> "old",
+      MilvusOption.SnapshotSchemaJson -> "stale-schema-json"
     )
     val out = MilvusScan.buildClientSnapshotOptions(
       baseOptions = base,
@@ -120,13 +141,38 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
     assert(out(MilvusOption.MilvusExtraColumns) == "partition")
   }
 
+  test("parsePositiveLongOption rejects non-numeric and non-positive values") {
+    Seq("not-a-number", "0", "-1").foreach { value =>
+      val rawOptions = new ju.HashMap[String, String]()
+      rawOptions.put(
+        MilvusOption.ClientSnapshotCompactionProtectionSeconds,
+        value
+      )
+      val err = intercept[IllegalArgumentException] {
+        MilvusScan.parsePositiveLongOption(
+          new CaseInsensitiveStringMap(rawOptions),
+          MilvusOption.ClientSnapshotCompactionProtectionSeconds,
+          86400L
+        )
+      }
+      assert(
+        err.getMessage.contains(
+          MilvusOption.ClientSnapshotCompactionProtectionSeconds
+        )
+      )
+    }
+  }
+
   test("snapshot planner returns no partitions for empty snapshots") {
     val rawOptions = new ju.HashMap[String, String]()
     rawOptions.put(MilvusOption.SnapshotMode, "true")
     rawOptions.put(MilvusOption.SnapshotManifests, "[]")
     rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
-    val partitions = scanWithOptions(rawOptions).planInputPartitions()
-    assert(partitions.isEmpty)
+    val scan = scanWithOptions(rawOptions)
+    val firstPartitions = scan.planInputPartitions()
+    val secondPartitions = scan.planInputPartitions()
+    assert(firstPartitions.isEmpty)
+    assert(firstPartitions eq secondPartitions)
   }
 
   test("snapshot planner fails loudly on malformed manifest JSON") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -186,10 +186,22 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(conf.get("fs.s3a.endpoint.region") == "us-west-2")
     assert(conf.get("fs.s3a.access.key") == "ak")
     assert(conf.get("fs.s3a.secret.key") == "sk")
+    assert(
+      conf.get("fs.s3a.aws.credentials.provider") ==
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+    )
     assert(conf.get("fs.s3a.bucket.connector-bucket.endpoint") == "minio:9000")
     assert(conf.get("fs.s3a.bucket.snapshot-bucket.endpoint") == "minio:9000")
     assert(
       conf.get("fs.s3a.bucket.snapshot-bucket.path.style.access") == "true"
+    )
+    assert(
+      conf.get("fs.s3a.bucket.connector-bucket.aws.credentials.provider") ==
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+    )
+    assert(
+      conf.get("fs.s3a.bucket.snapshot-bucket.aws.credentials.provider") ==
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
     )
   }
 
@@ -467,6 +479,18 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     val secondPartitions = scan.planInputPartitions()
     assert(firstPartitions.isEmpty)
     assert(firstPartitions eq secondPartitions)
+  }
+
+  test("client mode does not cache planned input partitions") {
+    val clientOptions = new ju.HashMap[String, String]()
+    clientOptions.put(MilvusOption.MilvusUri, "http://localhost:19530")
+    clientOptions.put(MilvusOption.MilvusCollectionName, "c")
+    assert(!scanWithOptions(clientOptions).shouldCacheInputPartitions)
+
+    val snapshotOptions = new ju.HashMap[String, String]()
+    snapshotOptions.put(MilvusOption.SnapshotMode, "true")
+    snapshotOptions.put(MilvusOption.SnapshotManifests, "[]")
+    assert(scanWithOptions(snapshotOptions).shouldCacheInputPartitions)
   }
 
   test("snapshot planner fails loudly on malformed manifest JSON") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -4,6 +4,7 @@ import java.{util => ju}
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicInteger
+import scala.util.{Failure, Success}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{
@@ -107,6 +108,59 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       MilvusScan.snapshotBucket("gs://a-bucket/files/snapshot.json")
     }
     assert(err.getMessage.contains("Unsupported snapshot s3_location scheme"))
+  }
+
+  test(
+    "validateSnapshotBucketForRelativeDataPaths rejects cross-bucket relative data paths"
+  ) {
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.validateSnapshotBucketForRelativeDataPaths(
+        "s3a://snapshot-bucket/files/snapshots/1/metadata/snapshot.json",
+        Some("connector-bucket"),
+        Seq(
+          StorageV2ManifestItem(
+            30L,
+            "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+          )
+        ),
+        Seq.empty
+      )
+    }
+    assert(err.getMessage.contains("snapshot-bucket"))
+    assert(err.getMessage.contains("connector-bucket"))
+    assert(err.getMessage.contains("bucket-relative"))
+  }
+
+  test(
+    "validateSnapshotBucketForRelativeDataPaths accepts cross-bucket fully-qualified data paths"
+  ) {
+    MilvusScan.validateSnapshotBucketForRelativeDataPaths(
+      "s3a://snapshot-bucket/files/snapshots/1/metadata/snapshot.json",
+      Some("connector-bucket"),
+      Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":7,\"base_path\":\"s3a://data-bucket/files/insert_log/10/20/30\"}"
+        )
+      ),
+      Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq(
+                "s3a://data-bucket/files/insert_log/10/20/30/100/1.parquet"
+              ),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        )
+      )
+    )
   }
 
   test("snapshotS3BucketForRelativePaths prefers snapshot bucket") {
@@ -375,6 +429,69 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
         )
       )
     }
+  }
+
+  test("readAllBytes reuses positive long parser for max json bytes") {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMaxJsonBytes, "not-a-number")
+    val err = intercept[IllegalArgumentException] {
+      scanWithOptions(rawOptions).readAllBytes(
+        new Configuration(),
+        "close-tracking://bucket/snapshot.json"
+      )
+    }
+    assert(err.getMessage.contains(MilvusOption.SnapshotMaxJsonBytes))
+  }
+
+  test(
+    "parseClientSnapshotCompactionProtectionSeconds rejects excessive values"
+  ) {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(
+      MilvusOption.ClientSnapshotCompactionProtectionSeconds,
+      (8L * 24L * 60L * 60L).toString
+    )
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.parseClientSnapshotCompactionProtectionSeconds(
+        new CaseInsensitiveStringMap(rawOptions)
+      )
+    }
+    assert(
+      err.getMessage.contains(
+        MilvusOption.ClientSnapshotCompactionProtectionSeconds
+      )
+    )
+  }
+
+  test("preserveResultWhenCloseFails keeps the original cleanup result") {
+    val ok = MilvusScan.preserveResultWhenCloseFails(
+      Success(()),
+      throw new RuntimeException("close failed"),
+      "test client"
+    )
+    assert(ok == Success(()))
+
+    val original = new RuntimeException("drop failed")
+    val failed = MilvusScan.preserveResultWhenCloseFails(
+      Failure(original),
+      (),
+      "test client"
+    )
+    assert(failed == Failure(original))
+  }
+
+  test(
+    "ensureClientSnapshotHasPackedSegments rejects filtered-empty snapshots"
+  ) {
+    val err = intercept[IllegalArgumentException] {
+      MilvusScan.ensureClientSnapshotHasPackedSegments(
+        Seq.empty,
+        Seq.empty,
+        "c"
+      )
+    }
+    assert(err.getMessage.contains("No packed-parquet segments"))
+    assert(err.getMessage.contains("c"))
   }
 
   test("generatedClientSnapshotName caps long collection names") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -9,9 +9,13 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
+  Collection,
+  CollectionSchema,
   MilvusPackedV2InputPartition,
   MilvusSnapshotReader,
   MilvusStorageV3InputPartition,
+  SnapshotInfo,
+  SnapshotMetadata,
   StorageV2ManifestItem,
   V2ColumnGroup,
   V2SegmentInfo
@@ -190,6 +194,77 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite {
         )
       )
     }
+  }
+
+  test("generatedClientSnapshotName caps long collection names") {
+    val name = MilvusScan.generatedClientSnapshotName(
+      collectionName = "c" * 300,
+      currentTimeMillis = 1L,
+      uuid = "u" * 32
+    )
+    assert(name.length <= 255)
+    assert(name.startsWith("spark_read_"))
+    assert(name.endsWith("_1_" + "u" * 32))
+  }
+
+  test("buildClientSnapshotOptions enables snapshot mode") {
+    val out = MilvusScan.buildClientSnapshotOptions(
+      baseOptions = Map(MilvusOption.SnapshotMode.toUpperCase -> "false"),
+      collectionName = "snapshot_collection",
+      collectionId = 10L,
+      partitionIds = Seq(20L),
+      schemaBytesBase64 = "abc",
+      manifestList = Seq.empty,
+      v2Segments = Seq.empty
+    )
+    assert(MilvusOption.isSnapshotMode(out))
+    assert(!out.contains(MilvusOption.SnapshotMode.toUpperCase))
+  }
+
+  test("validateClientSnapshotMetadata rejects missing required fields") {
+    val snapshotPath = "s3a://bucket/snapshot.json"
+    val missingSnapshotInfo = SnapshotMetadata(
+      snapshotInfo = null,
+      collection = Collection(CollectionSchema("c", fields = Seq.empty))
+    )
+    val snapshotInfoErr = intercept[IllegalArgumentException] {
+      MilvusScan.validateClientSnapshotMetadata(
+        missingSnapshotInfo,
+        snapshotPath
+      )
+    }
+    assert(snapshotInfoErr.getMessage.contains("snapshot_info"))
+
+    val missingCollection = SnapshotMetadata(
+      snapshotInfo = SnapshotInfo("s"),
+      collection = null
+    )
+    val collectionErr = intercept[IllegalArgumentException] {
+      MilvusScan.validateClientSnapshotMetadata(missingCollection, snapshotPath)
+    }
+    assert(collectionErr.getMessage.contains("collection"))
+
+    val missingSchema = SnapshotMetadata(
+      snapshotInfo = SnapshotInfo("s"),
+      collection = Collection(null)
+    )
+    val schemaErr = intercept[IllegalArgumentException] {
+      MilvusScan.validateClientSnapshotMetadata(missingSchema, snapshotPath)
+    }
+    assert(schemaErr.getMessage.contains("collection.schema"))
+  }
+
+  test(
+    "snapshot planner rejects explicit snapshot mode without segment hints"
+  ) {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val err = intercept[IllegalArgumentException] {
+      scanWithOptions(rawOptions).planInputPartitions()
+    }
+    assert(err.getMessage.contains(MilvusOption.SnapshotManifests))
+    assert(err.getMessage.contains(MilvusOption.SnapshotV2Segments))
   }
 
   test("snapshot planner returns no partitions for empty snapshots") {


### PR DESCRIPTION
Use snapshot RPCs as the default client-read planning path when no partition or segment selector is set, then reuse snapshot-only planning from the returned metadata. Fall back to legacy segment planning only when snapshot RPCs are unavailable, and add bounded snapshot JSON reads plus focused planner tests.