### PR TITLE
enhance!: [reader] canonicalize metadata extra columns

### DIFF
--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -65,8 +65,17 @@ object MilvusOption {
 
   val MilvusExtraColumns = "milvus.extra.columns"
   val MilvusExtraColumnPartition = "partition"
-  val MilvusExtraColumnSegmentID = "segment_id"
-  val MilvusExtraColumnRowOffset = "row_offset"
+  val MilvusExtraColumnSegmentID = "$segment_id"
+  val MilvusExtraColumnRowOffset = "$row_offset"
+  private[connector] val MilvusExtraColumnSegmentIDAlias = "segment_id"
+  private[connector] val MilvusExtraColumnRowOffsetAlias = "row_offset"
+
+  private[connector] def normalizeExtraColumnName(name: String): String =
+    name match {
+      case MilvusExtraColumnSegmentIDAlias => MilvusExtraColumnSegmentID
+      case MilvusExtraColumnRowOffsetAlias => MilvusExtraColumnRowOffset
+      case other                           => other
+    }
 
   // reader config
   val ReaderPath = "path"
@@ -246,6 +255,7 @@ object MilvusOption {
       .split(",")
       .map(_.trim)
       .filter(_.nonEmpty)
+      .map(normalizeExtraColumnName)
       .toSeq
 
     // Convert CaseInsensitiveStringMap to regular Map for storage

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -171,7 +171,10 @@ case class BackfillConfig(
       "milvus.token" -> milvusToken,
       "milvus.database.name" -> databaseName,
       "milvus.collection.name" -> collectionName,
-      "milvus.extra.columns" -> "segment_id,row_offset", // this is used to match with the original sequence of rows for each segment
+      MilvusOption.MilvusExtraColumns -> Seq(
+        MilvusOption.MilvusExtraColumnSegmentID,
+        MilvusOption.MilvusExtraColumnRowOffset
+      ).mkString(","),
       "fs.address" -> s3Endpoint,
       "fs.bucket_name" -> s3BucketName,
       "fs.root_path" -> s3RootPath,

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -42,6 +42,8 @@ object MilvusBackfill {
     * function, and stripped from the projection written to parquet.
     */
   private[backfill] val MatchFlagCol = "__bf_matched__"
+  private[backfill] val SegmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
+  private[backfill] val RowOffsetCol = MilvusOption.MilvusExtraColumnRowOffset
 
   /** Per-field flag columns added in any mode that reads source-side target
     * values (coalesce + overwrite). For each new field, one boolean marker
@@ -554,8 +556,8 @@ object MilvusBackfill {
     Right(renamed)
   }
 
-  /** Read collection data with segment_id and row_offset metadata segment_id
-    * and row_offset are used to match with the original sequence of rows for
+  /** Read collection data with $segment_id and $row_offset metadata $segment_id
+    * and $row_offset are used to match with the original sequence of rows for
     * each segment
     *
     * @param pkFieldId
@@ -664,17 +666,12 @@ object MilvusBackfill {
             case (acc, (_, _, field)) => acc.add(field)
           }
 
-          // Add extra columns for segment tracking
-          val fullSchema = withExtras
-            .add("segment_id", org.apache.spark.sql.types.LongType, false)
-            .add("row_offset", org.apache.spark.sql.types.LongType, false)
-
           logger.info(
-            s"Reading with schema: ${fullSchema.fieldNames.mkString(", ")}"
+            s"Reading with schema: ${withExtras.fieldNames.mkString(", ")}"
           )
 
           spark.read
-            .schema(fullSchema)
+            .schema(withExtras)
             .format("com.zilliz.spark.connector.sources.MilvusDataSource")
             .options(options)
             .load()
@@ -687,14 +684,13 @@ object MilvusBackfill {
             .load()
       }
 
-      // Validate that segment_id and row_offset are present
       if (
-        !df.columns.contains("segment_id") || !df.columns.contains("row_offset")
+        !df.columns.contains(SegmentIdCol) || !df.columns.contains(RowOffsetCol)
       ) {
         return Left(
           ConnectionError(
             message =
-              "Failed to read collection data with segment_id and row_offset. " +
+              s"Failed to read collection data with $SegmentIdCol and $RowOffsetCol. " +
                 "Ensure milvus.extra.columns is set correctly."
           )
         )
@@ -964,7 +960,7 @@ object MilvusBackfill {
   ): Either[BackfillError, Map[Long, SegmentBackfillResult]] = {
 
     try {
-      // Prepare data: select only needed columns and add segment_id for
+      // Prepare data: select only needed columns and add $segment_id for
       // partitioning. Trailing column is the backfill match flag — retained
       // here so executors can count PK-matched rows, stripped from the
       // projection that reaches the writer. In any source-reading mode
@@ -979,12 +975,12 @@ object MilvusBackfill {
         else Seq.empty
       val preparedDF = joinedDF
         .select(
-          (Seq("segment_id", "row_offset") ++ newFieldNames ++ Seq(
+          (Seq(SegmentIdCol, RowOffsetCol) ++ newFieldNames ++ Seq(
             MatchFlagCol
           ) ++ flagColNames).map(col): _*
         )
 
-      // Get the schema for new fields only (without segment_id, row_offset,
+      // Get the schema for new fields only (without $segment_id, $row_offset,
       // or the match flag)
       val targetSchema = org.apache.spark.sql.types.StructType(
         newFieldNames.map(fieldName =>
@@ -995,19 +991,19 @@ object MilvusBackfill {
       val segmentIds = segmentToPartitionMap.keys.toArray
       val segmentPartitioner = new SegmentPartitioner(segmentIds)
 
-      // Repartition using custom partitioner, then sort by row_offset within each partition
+      // Repartition using custom partitioner, then sort by $row_offset within each partition
       // CRITICAL: .copy() is required because queryExecution.toRdd produces an iterator
       // that reuses the same UnsafeRow buffer. Without copy, keyBy/partitionBy's
       // ExternalSorter stores references to the same mutable buffer, causing all
       // rows to contain the last row's data.
       val repartitionedRDD = preparedDF.queryExecution.toRdd
         .map(_.copy()) // Materialize each row to avoid UnsafeRow reuse
-        .keyBy(_.getLong(0)) // segment_id is at index 0
+        .keyBy(_.getLong(0)) // $segment_id is at index 0
         .partitionBy(segmentPartitioner)
         .values
         .mapPartitions(iter =>
           iter.toSeq.sortBy(_.getLong(1)).iterator
-        ) // Sort by row_offset
+        ) // Sort by $row_offset
 
       // Broadcast configuration to executors
       val broadcastConfig = spark.sparkContext.broadcast(config)
@@ -1182,7 +1178,7 @@ object MilvusBackfill {
     val readsSourceFields = config.readsSourceFields
     val newFieldNames = targetSchema.fieldNames.toSeq
     val numNewFields = newFieldNames.size
-    // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
+    // Row layout (fixed prefix): [$segment_id, $row_offset, ...newFields,
     // __bf_matched__, (usedSrc, usedBf)*numNewFields in source-reading modes
     // (coalesce / overwrite) only].
     val matchFlagIdx = 2 + numNewFields
@@ -1492,7 +1488,7 @@ object MilvusBackfill {
 
     val readsSourceFields = config.readsSourceFields
     val numNewFields = fieldNames.size
-    // Row layout (fixed prefix): [segment_id, row_offset, ...newFields,
+    // Row layout (fixed prefix): [$segment_id, $row_offset, ...newFields,
     // __bf_matched__, (usedSrc, usedBf)*numNewFields in source-reading modes
     // (coalesce / overwrite) only].
     val matchFlagIdx = 2 + numNewFields

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -245,12 +245,12 @@ Override via `customOutputPath` if needed.
    Milvus client in client mode).
 4. Read the new-field parquet, configuring S3A credentials for the source
    bucket as needed.
-5. Read the original PK column + `segment_id` / `row_offset` via
+5. Read the original PK column + `$segment_id` / `$row_offset` via
    `spark.read.format("com.zilliz.spark.connector.sources.MilvusDataSource")`
    in snapshot mode (FQCN avoids shortName collisions with other connectors).
 6. Validate PK type compatibility, then left-join on the PK.
 7. For each segment, repartition with a custom segment partitioner, sort by
-   `row_offset`, and write per-segment binlogs via `MilvusLoonWriter`.
+   `$row_offset`, and write per-segment binlogs via `MilvusLoonWriter`.
 8. Return a `BackfillResult` with manifest paths and per-segment stats.
 
 ## Testing helper

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -19,7 +19,7 @@ import com.zilliz.spark.connector.MilvusOption
 case class MilvusStorageV3InputPartition(
     manifestPath: String, // Path to manifest in S3/MinIO
     milvusSchemaBytes: Array[Byte], // Serialized protobuf
-    partitionName: String,
+    partitionName: String, // Snapshot reads store the partition ID string here.
     milvusOption: MilvusOption,
     topK: Option[Int] = None,
     queryVector: Option[Array[Float]] = None,

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -37,6 +37,14 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
+object MilvusLoonPartitionReader {
+  private case class VectorSearchResult(
+      row: InternalRow,
+      distance: Double,
+      rowOffset: Long
+  )
+}
+
 // for Milvus 2.6+ version data source and milvus lake data
 class MilvusLoonPartitionReader(
     schema: StructType,
@@ -97,6 +105,10 @@ class MilvusLoonPartitionReader(
 
   private var _currentBatch: VectorSchemaRoot = null
   private var _currentRowIndex: Int = 0
+  private var _currentBatchStartRowOffset: Long = 0L
+  private var _lastReturnedRowOffset: Long = -1L
+
+  def lastReturnedRowOffset: Long = _lastReturnedRowOffset
 
   try {
     // Create Arrow schema from Milvus schema.
@@ -176,7 +188,9 @@ class MilvusLoonPartitionReader(
 
   // Vector search state
   private val vectorSearchEnabled = topK.isDefined && queryVector.isDefined
-  private var vectorSearchResults: Iterator[(InternalRow, Double)] = _
+  private var vectorSearchResults: Iterator[
+    MilvusLoonPartitionReader.VectorSearchResult
+  ] = _
   private var vectorSearchCompleted = false
 
   override def next(): Boolean = {
@@ -215,6 +229,7 @@ class MilvusLoonPartitionReader(
         } else {
           // Try to load next batch
           if (_currentBatch != null) {
+            _currentBatchStartRowOffset += _currentBatch.getRowCount
             _currentBatch.close()
             _currentBatch = null
           }
@@ -237,9 +252,10 @@ class MilvusLoonPartitionReader(
   override def get(): InternalRow = {
     if (vectorSearchEnabled) {
       // Vector search mode: return row with distance appended
-      val (row, distance) = vectorSearchResults.next()
-      val rowSeq = row.toSeq(sourceSchema)
-      val resultRow = InternalRow.fromSeq(rowSeq :+ distance)
+      val result = vectorSearchResults.next()
+      _lastReturnedRowOffset = result.rowOffset
+      val rowSeq = result.row.toSeq(sourceSchema)
+      val resultRow = InternalRow.fromSeq(rowSeq :+ result.distance)
       resultRow
     } else {
       // Normal mode
@@ -247,6 +263,7 @@ class MilvusLoonPartitionReader(
         throw new IllegalStateException("No batch loaded")
       }
 
+      _lastReturnedRowOffset = _currentBatchStartRowOffset + _currentRowIndex
       val row = ArrowConverter.arrowToInternalRow(
         _currentBatch,
         _currentRowIndex,
@@ -344,19 +361,27 @@ class MilvusLoonPartitionReader(
     // Use priority queue to maintain top-K
     // For L2: min-heap (smaller distance is better, so we keep max at top to evict)
     // For IP/COSINE: max-heap (larger score is better, so we keep min at top to evict)
-    val ordering: Ordering[(InternalRow, Double)] = metric match {
-      case "L2" =>
-        Ordering.by[(InternalRow, Double), Double](_._2) // Max-heap for L2
-      case "IP" | "COSINE" =>
-        Ordering
-          .by[(InternalRow, Double), Double](_._2)
-          .reverse // Min-heap for IP/COSINE
-      case _ => Ordering.by[(InternalRow, Double), Double](_._2)
-    }
+    val ordering: Ordering[MilvusLoonPartitionReader.VectorSearchResult] =
+      metric match {
+        case "L2" =>
+          Ordering.by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+            _.distance
+          )
+        case "IP" | "COSINE" =>
+          Ordering
+            .by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+              _.distance
+            )
+            .reverse
+        case _ =>
+          Ordering.by[MilvusLoonPartitionReader.VectorSearchResult, Double](
+            _.distance
+          )
+      }
 
     val heap = scala.collection.mutable.PriorityQueue
-      .empty[(InternalRow, Double)](ordering)
-    var rowCount = 0
+      .empty[MilvusLoonPartitionReader.VectorSearchResult](ordering)
+    var rowCount = 0L
 
     // Helper function to process a batch
     def processBatch(batch: VectorSchemaRoot): Unit = {
@@ -389,24 +414,26 @@ class MilvusLoonPartitionReader(
           }
 
         if (vector != null) {
-          // Calculate distance
           val distance = calculateDistance(qv, vector, metric)
+          val result = MilvusLoonPartitionReader.VectorSearchResult(
+            row.copy(),
+            distance,
+            rowCount
+          )
 
-          // Maintain top-K heap
           if (heap.size < k) {
-            heap.enqueue((row.copy(), distance))
+            heap.enqueue(result)
           } else {
-            val (_, worstDist) = heap.head
+            val worst = heap.head
             val shouldReplace = metric match {
-              case "L2" => distance < worstDist // Smaller L2 distance is better
-              case "IP" | "COSINE" =>
-                distance > worstDist // Larger IP/COSINE is better
-              case _ => distance < worstDist
+              case "L2"            => distance < worst.distance
+              case "IP" | "COSINE" => distance > worst.distance
+              case _               => distance < worst.distance
             }
 
             if (shouldReplace) {
               heap.dequeue()
-              heap.enqueue((row.copy(), distance))
+              heap.enqueue(result)
             }
           }
         }
@@ -439,13 +466,20 @@ class MilvusLoonPartitionReader(
       s"Per-segment vector search completed: processed $rowCount rows, kept ${heap.size} top-K results"
     )
 
-    // Sort results and create iterator
+    val results = heap.dequeueAll
     val sortedResults = metric match {
       case "L2" =>
-        heap.dequeueAll.sortBy[(Double)](x => x._2) // Ascending for L2
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          result.distance
+        )
       case "IP" | "COSINE" =>
-        heap.dequeueAll.sortBy[(Double)](x => -x._2) // Descending for IP/COSINE
-      case _ => heap.dequeueAll.sortBy[(Double)](x => x._2)
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          -result.distance
+        )
+      case _ =>
+        results.sortBy((result: MilvusLoonPartitionReader.VectorSearchResult) =>
+          result.distance
+        )
     }
 
     vectorSearchResults = sortedResults.iterator

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -10,6 +10,7 @@ import org.apache.spark.sql.connector.read.{
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 
+import com.zilliz.spark.connector.MilvusOption
 import io.milvus.grpc.schema.CollectionSchema
 
 // PartitionReaderFactory for Storage V2 (Milvus 2.6+)
@@ -20,6 +21,14 @@ class MilvusPartitionReaderFactory(
 ) extends PartitionReaderFactory
     with Logging {
 
+  private def isSystemField(name: String): Boolean =
+    name == "row_id" || name == "timestamp"
+
+  private def isMetadataExtraField(name: String): Boolean =
+    name == MilvusOption.MilvusExtraColumnPartition ||
+      name == MilvusOption.MilvusExtraColumnSegmentID ||
+      name == MilvusOption.MilvusExtraColumnRowOffset
+
   override def createReader(
       partition: InputPartition
   ): PartitionReader[InternalRow] = {
@@ -29,13 +38,8 @@ class MilvusPartitionReaderFactory(
           s"Creating V3 reader for partition with segmentID=${p.segmentID}"
         )
 
-        // Storage V3 doesn't support system fields (row_id, timestamp) and extra metadata columns (segment_id, row_offset)
-        // Filter them out from the schema for the underlying reader
-        val v2Schema = StructType(schema.fields.filter { field =>
-          field.name != "row_id" &&
-          field.name != "timestamp" &&
-          field.name != "segment_id" &&
-          field.name != "row_offset"
+        val v2Schema = StructType(schema.fields.filterNot { field =>
+          isSystemField(field.name) || isMetadataExtraField(field.name)
         })
 
         // Deserialize the protobuf schema
@@ -56,55 +60,34 @@ class MilvusPartitionReaderFactory(
           p.readVersion
         )
 
-        // If the expected schema includes system/metadata fields, wrap the reader to add them
-        val hasRowId = schema.fieldNames.contains("row_id")
-        val hasTimestamp = schema.fieldNames.contains("timestamp")
-        val hasSegmentId = schema.fieldNames.contains("segment_id")
-        val hasRowOffset = schema.fieldNames.contains("row_offset")
+        val hasSyntheticFields = schema.fieldNames.exists { name =>
+          isSystemField(name) || isMetadataExtraField(name)
+        }
 
-        if (hasRowId || hasTimestamp || hasSegmentId || hasRowOffset) {
+        if (hasSyntheticFields) {
           new PartitionReader[InternalRow] {
-            private var rowOffset: Long = 0L
-
             override def next(): Boolean = underlyingReader.next()
 
             override def get(): InternalRow = {
               val row = underlyingReader.get()
-
-              // Build result row with system/metadata fields
-              val numFields = schema.fields.length
-              val resultValues = new Array[Any](numFields)
-
-              var writeIdx = 0
+              val resultValues = new Array[Any](schema.fields.length)
               var readIdx = 0
 
-              // Add system fields with null values
-              if (hasRowId) {
-                resultValues(writeIdx) = null
-                writeIdx += 1
-              }
-              if (hasTimestamp) {
-                resultValues(writeIdx) = null
-                writeIdx += 1
-              }
-
-              // Copy actual data from underlying reader
-              while (readIdx < v2Schema.fields.length) {
-                val value = row.get(readIdx, v2Schema.fields(readIdx).dataType)
-                resultValues(writeIdx) = value
-                readIdx += 1
-                writeIdx += 1
-              }
-
-              // Add metadata fields (segment_id and row_offset)
-              if (hasSegmentId) {
-                resultValues(writeIdx) = p.segmentID
-                writeIdx += 1
-              }
-              if (hasRowOffset) {
-                resultValues(writeIdx) = rowOffset
-                rowOffset += 1
-                writeIdx += 1
+              schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
+                field.name match {
+                  case "row_id" | "timestamp" =>
+                    resultValues(writeIdx) = null
+                  case MilvusOption.MilvusExtraColumnPartition =>
+                    resultValues(writeIdx) = p.partitionName
+                  case MilvusOption.MilvusExtraColumnSegmentID =>
+                    resultValues(writeIdx) = p.segmentID
+                  case MilvusOption.MilvusExtraColumnRowOffset =>
+                    resultValues(writeIdx) =
+                      underlyingReader.lastReturnedRowOffset
+                  case _ =>
+                    resultValues(writeIdx) = row.get(readIdx, field.dataType)
+                    readIdx += 1
+                }
               }
 
               InternalRow.fromSeq(resultValues.toSeq)
@@ -122,11 +105,8 @@ class MilvusPartitionReaderFactory(
             s"with ${p.columnGroups.size} column group(s)"
         )
 
-        // V2 reader does not emit system/metadata columns itself; same
-        // masking rule as V3.
-        val innerSchema = StructType(schema.fields.filter { f =>
-          f.name != "row_id" && f.name != "timestamp" &&
-          f.name != "segment_id" && f.name != "row_offset"
+        val innerSchema = StructType(schema.fields.filterNot { field =>
+          isSystemField(field.name) || isMetadataExtraField(field.name)
         })
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
@@ -139,12 +119,11 @@ class MilvusPartitionReaderFactory(
           p.neededColumnFieldIds
         )
 
-        val hasSegmentId = schema.fieldNames.contains("segment_id")
-        val hasRowOffset = schema.fieldNames.contains("row_offset")
-        val hasRowId = schema.fieldNames.contains("row_id")
-        val hasTimestamp = schema.fieldNames.contains("timestamp")
+        val hasSyntheticFields = schema.fieldNames.exists { name =>
+          isSystemField(name) || isMetadataExtraField(name)
+        }
 
-        if (hasRowId || hasTimestamp || hasSegmentId || hasRowOffset) {
+        if (hasSyntheticFields) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -152,27 +131,25 @@ class MilvusPartitionReaderFactory(
 
             override def get(): InternalRow = {
               val row = underlying.get()
-              val numFields = schema.fields.length
-              val out = new Array[Any](numFields)
-              var writeIdx = 0
+              val out = new Array[Any](schema.fields.length)
               var readIdx = 0
 
-              if (hasRowId) { out(writeIdx) = null; writeIdx += 1 }
-              if (hasTimestamp) { out(writeIdx) = null; writeIdx += 1 }
-
-              while (readIdx < innerSchema.fields.length) {
-                out(writeIdx) =
-                  row.get(readIdx, innerSchema.fields(readIdx).dataType)
-                readIdx += 1
-                writeIdx += 1
+              schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
+                field.name match {
+                  case "row_id" | "timestamp" =>
+                    out(writeIdx) = null
+                  case MilvusOption.MilvusExtraColumnPartition =>
+                    out(writeIdx) = p.partitionID.toString
+                  case MilvusOption.MilvusExtraColumnSegmentID =>
+                    out(writeIdx) = p.segmentID
+                  case MilvusOption.MilvusExtraColumnRowOffset =>
+                    out(writeIdx) = rowOffset
+                  case _ =>
+                    out(writeIdx) = row.get(readIdx, field.dataType)
+                    readIdx += 1
+                }
               }
-
-              if (hasSegmentId) { out(writeIdx) = p.segmentID; writeIdx += 1 }
-              if (hasRowOffset) {
-                out(writeIdx) = rowOffset
-                rowOffset += 1
-                writeIdx += 1
-              }
+              rowOffset += 1
 
               InternalRow.fromSeq(out.toSeq)
             }

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -9,9 +9,38 @@ import org.apache.spark.sql.connector.read.{
 }
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.unsafe.types.UTF8String
 
 import com.zilliz.spark.connector.MilvusOption
 import io.milvus.grpc.schema.CollectionSchema
+
+object MilvusPartitionReaderFactory {
+  private[read] def requestedExtraColumns(
+      optionsMap: Map[String, String]
+  ): Set[String] = {
+    optionsMap
+      .collectFirst {
+        case (key, value)
+            if key.equalsIgnoreCase(MilvusOption.MilvusExtraColumns) =>
+          value
+      }
+      .toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(MilvusOption.normalizeExtraColumnName)
+      .toSet
+  }
+
+  private[read] def isMetadataExtraField(
+      name: String,
+      requestedExtraColumns: Set[String]
+  ): Boolean =
+    requestedExtraColumns.contains(name)
+
+  private[read] def stringValue(value: String): UTF8String =
+    UTF8String.fromString(value)
+}
 
 // PartitionReaderFactory for Storage V2 (Milvus 2.6+)
 class MilvusPartitionReaderFactory(
@@ -24,10 +53,14 @@ class MilvusPartitionReaderFactory(
   private def isSystemField(name: String): Boolean =
     name == "row_id" || name == "timestamp"
 
+  private val requestedExtraColumns =
+    MilvusPartitionReaderFactory.requestedExtraColumns(optionsMap)
+
   private def isMetadataExtraField(name: String): Boolean =
-    name == MilvusOption.MilvusExtraColumnPartition ||
-      name == MilvusOption.MilvusExtraColumnSegmentID ||
-      name == MilvusOption.MilvusExtraColumnRowOffset
+    MilvusPartitionReaderFactory.isMetadataExtraField(
+      name,
+      requestedExtraColumns
+    )
 
   override def createReader(
       partition: InputPartition
@@ -78,7 +111,8 @@ class MilvusPartitionReaderFactory(
                   case "row_id" | "timestamp" =>
                     resultValues(writeIdx) = null
                   case MilvusOption.MilvusExtraColumnPartition =>
-                    resultValues(writeIdx) = p.partitionName
+                    resultValues(writeIdx) =
+                      MilvusPartitionReaderFactory.stringValue(p.partitionName)
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     resultValues(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>
@@ -139,7 +173,9 @@ class MilvusPartitionReaderFactory(
                   case "row_id" | "timestamp" =>
                     out(writeIdx) = null
                   case MilvusOption.MilvusExtraColumnPartition =>
-                    out(writeIdx) = p.partitionID.toString
+                    out(writeIdx) = MilvusPartitionReaderFactory.stringValue(
+                      p.partitionID.toString
+                    )
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     out(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -328,6 +328,36 @@ case class MilvusTable(
 
   override def name(): String = milvusOption.collectionName
 
+  private def appendExtraColumns(baseSchema: StructType): StructType = {
+    var fields = baseSchema.fields.toSeq
+
+    def addIfRequested(name: String, field: StructField): Unit = {
+      if (milvusOption.extraColumns.contains(name)) {
+        if (fields.exists(_.name == name)) {
+          throw new IllegalArgumentException(
+            s"Requested metadata extra column '$name' conflicts with an existing field named '$name'"
+          )
+        }
+        fields = fields :+ field
+      }
+    }
+
+    addIfRequested(
+      MilvusOption.MilvusExtraColumnPartition,
+      StructField(MilvusOption.MilvusExtraColumnPartition, StringType, true)
+    )
+    addIfRequested(
+      MilvusOption.MilvusExtraColumnSegmentID,
+      StructField(MilvusOption.MilvusExtraColumnSegmentID, LongType, false)
+    )
+    addIfRequested(
+      MilvusOption.MilvusExtraColumnRowOffset,
+      StructField(MilvusOption.MilvusExtraColumnRowOffset, LongType, false)
+    )
+
+    StructType(fields)
+  }
+
   override def schema(): StructType = {
     // In snapshot mode with provided sparkSchema, use it directly
     // This avoids the need to parse milvusCollection.schema which may be incomplete
@@ -335,7 +365,7 @@ case class MilvusTable(
       logInfo(
         s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
       )
-      return sparkSchema.get
+      return appendExtraColumns(sparkSchema.get)
     }
 
     // Client-based mode or snapshot mode without provided schema: compute from milvusCollection
@@ -375,28 +405,7 @@ case class MilvusTable(
     ) {
       fields = fields :+ StructField("$meta", StringType, true)
     }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnPartition
-      )
-    ) {
-      fields = fields :+ StructField("partition", StringType, true)
-    }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnSegmentID
-      )
-    ) {
-      fields = fields :+ StructField("segment_id", LongType, false)
-    }
-    if (
-      milvusOption.extraColumns.contains(
-        MilvusOption.MilvusExtraColumnRowOffset
-      )
-    ) {
-      fields = fields :+ StructField("row_offset", LongType, false)
-    }
-    StructType(fields)
+    appendExtraColumns(StructType(fields))
   }
 
   override def capabilities(): ju.Set[TableCapability] = {
@@ -421,6 +430,7 @@ class MilvusScanBuilder(
     .split(",")
     .map(_.trim)
     .filter(_.nonEmpty)
+    .map(MilvusOption.normalizeExtraColumnName)
     .toSeq
 
   // Store the filters that can be pushed down
@@ -495,21 +505,21 @@ class MilvusScanBuilder(
     }
     if (
       extraColumns.contains(MilvusOption.MilvusExtraColumnPartition) &&
-      !fieldNames.contains("partition")
+      !fieldNames.contains(MilvusOption.MilvusExtraColumnPartition)
     ) {
-      fieldNames = fieldNames :+ "partition"
+      fieldNames = fieldNames :+ MilvusOption.MilvusExtraColumnPartition
     }
     if (
       extraColumns.contains(MilvusOption.MilvusExtraColumnSegmentID) &&
-      !fieldNames.contains("segment_id")
+      !fieldNames.contains(MilvusOption.MilvusExtraColumnSegmentID)
     ) {
-      fieldNames = fieldNames :+ "segment_id"
+      fieldNames = fieldNames :+ MilvusOption.MilvusExtraColumnSegmentID
     }
     if (
       extraColumns.contains(MilvusOption.MilvusExtraColumnRowOffset) &&
-      !fieldNames.contains("row_offset")
+      !fieldNames.contains(MilvusOption.MilvusExtraColumnRowOffset)
     ) {
-      fieldNames = fieldNames :+ "row_offset"
+      fieldNames = fieldNames :+ MilvusOption.MilvusExtraColumnRowOffset
     }
 
     currentOptions = new CaseInsensitiveStringMap(tmpMap)

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1768,6 +1768,9 @@ class MilvusScan(
         if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
           pathParts(insertLogIdx + 2)
         } else {
+          logWarning(
+            s"Manifest path '$basePath' does not match expected insert_log/{collectionID}/{partitionID}/{segmentID} layout; using fallback partitionID=$defaultPartitionId"
+          )
           defaultPartitionId
         }
       logInfo(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -328,11 +328,14 @@ case class MilvusTable(
 
   override def name(): String = milvusOption.collectionName
 
-  private def appendExtraColumns(baseSchema: StructType): StructType = {
+  private def appendExtraColumns(
+      baseSchema: StructType,
+      rejectLegacyAliases: Boolean
+  ): StructType = {
     var fields = baseSchema.fields.toSeq
 
     def failIfPresent(alias: String, canonical: String): Unit = {
-      if (fields.exists(_.name == alias)) {
+      if (rejectLegacyAliases && fields.exists(_.name == alias)) {
         throw new IllegalArgumentException(
           s"Field '$alias' is a legacy alias for metadata extra column '$canonical'; use '$canonical' in the schema or remove it and request '$canonical' via ${MilvusOption.MilvusExtraColumns}"
         )
@@ -394,7 +397,7 @@ case class MilvusTable(
       logInfo(
         s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
       )
-      return appendExtraColumns(sparkSchema.get)
+      return appendExtraColumns(sparkSchema.get, rejectLegacyAliases = true)
     }
 
     // Client-based mode or snapshot mode without provided schema: compute from milvusCollection
@@ -434,7 +437,7 @@ case class MilvusTable(
     ) {
       fields = fields :+ StructField("$meta", StringType, true)
     }
-    appendExtraColumns(StructType(fields))
+    appendExtraColumns(StructType(fields), rejectLegacyAliases = false)
   }
 
   override def capabilities(): ju.Set[TableCapability] = {
@@ -1748,28 +1751,32 @@ class MilvusScan(
             ) // Backward compatible: plain basePath, latest version
         }
 
-      // Extract segmentID from manifest path if item.segmentID is 0
+      // Extract segmentID and partitionID from manifest path if needed
       // Path format: files/insert_log/{collectionID}/{partitionID}/{segmentID}
+      val pathParts = basePath.split("/").filter(_.nonEmpty)
       val segmentID = if (item.segmentID != 0L) {
         item.segmentID
-      } else {
-        // Try to extract from basePath
-        val pathParts = basePath.split("/")
-        if (pathParts.length >= 1) {
-          try {
-            pathParts.last.toLong
-          } catch {
-            case _: NumberFormatException => 0L
-          }
-        } else 0L
-      }
+      } else if (pathParts.nonEmpty) {
+        try {
+          pathParts.last.toLong
+        } catch {
+          case _: NumberFormatException => 0L
+        }
+      } else 0L
+      val insertLogIdx = pathParts.lastIndexOf("insert_log")
+      val partitionId =
+        if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
+          pathParts(insertLogIdx + 2)
+        } else {
+          defaultPartitionId
+        }
       logInfo(
-        s"Creating partition with manifestPath=$basePath, segmentID=$segmentID, readVersion=$readVersion"
+        s"Creating partition with manifestPath=$basePath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
       )
       MilvusStorageV3InputPartition(
         basePath, // The basePath extracted from manifest JSON
         schemaBytes, // Protobuf CollectionSchema bytes from snapshot
-        defaultPartitionId, // Partition name/ID
+        partitionId, // Partition name/ID
         milvusOption,
         vectorSearchConfig.map(_.topK),
         vectorSearchConfig.map(_.queryVector),

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -331,6 +331,14 @@ case class MilvusTable(
   private def appendExtraColumns(baseSchema: StructType): StructType = {
     var fields = baseSchema.fields.toSeq
 
+    def failIfPresent(alias: String, canonical: String): Unit = {
+      if (fields.exists(_.name == alias)) {
+        throw new IllegalArgumentException(
+          s"Field '$alias' is a legacy alias for metadata extra column '$canonical'; use '$canonical' in the schema or remove it and request '$canonical' via ${MilvusOption.MilvusExtraColumns}"
+        )
+      }
+    }
+
     def addIfRequested(name: String, field: StructField): Unit = {
       if (milvusOption.extraColumns.contains(name)) {
         if (fields.exists(_.name == name)) {
@@ -340,6 +348,27 @@ case class MilvusTable(
         }
         fields = fields :+ field
       }
+    }
+
+    if (
+      milvusOption.extraColumns.contains(
+        MilvusOption.MilvusExtraColumnSegmentID
+      )
+    ) {
+      failIfPresent(
+        MilvusOption.MilvusExtraColumnSegmentIDAlias,
+        MilvusOption.MilvusExtraColumnSegmentID
+      )
+    }
+    if (
+      milvusOption.extraColumns.contains(
+        MilvusOption.MilvusExtraColumnRowOffset
+      )
+    ) {
+      failIfPresent(
+        MilvusOption.MilvusExtraColumnRowOffsetAlias,
+        MilvusOption.MilvusExtraColumnRowOffset
+      )
     }
 
     addIfRequested(

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -64,7 +64,23 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
     milvusOption.segmentID shouldBe "111222333"
   }
 
-  test("Parse extra columns configuration") {
+  test("Parse extra columns configuration with canonical names") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      MilvusOption.MilvusExtraColumns -> "partition, $segment_id, $row_offset"
+    )
+
+    val milvusOption = MilvusOption(options)
+
+    milvusOption.extraColumns should contain allOf (
+      MilvusOption.MilvusExtraColumnPartition,
+      MilvusOption.MilvusExtraColumnSegmentID,
+      MilvusOption.MilvusExtraColumnRowOffset
+    )
+    milvusOption.extraColumns.size shouldBe 3
+  }
+
+  test("Parse legacy extra column aliases as canonical requests") {
     val options = Map(
       MilvusOption.MilvusUri -> "http://localhost:19530",
       MilvusOption.MilvusExtraColumns -> "partition, segment_id, row_offset"
@@ -72,8 +88,13 @@ class MilvusOptionTest extends AnyFunSuite with Matchers {
 
     val milvusOption = MilvusOption(options)
 
-    milvusOption.extraColumns should contain allOf ("partition", "segment_id", "row_offset")
-    milvusOption.extraColumns.size shouldBe 3
+    milvusOption.extraColumns should contain allOf (
+      "partition",
+      "$segment_id",
+      "$row_offset"
+    )
+    milvusOption.extraColumns should not contain "segment_id"
+    milvusOption.extraColumns should not contain "row_offset"
   }
 
   test("Parse empty extra columns") {

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -243,7 +243,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     options("milvus.token") shouldBe "root:Milvus"
     options("milvus.database.name") shouldBe "my_database"
     options("milvus.collection.name") shouldBe "test_collection"
-    options("milvus.extra.columns") shouldBe "segment_id,row_offset"
+    options("milvus.extra.columns") shouldBe "$segment_id,$row_offset"
     options("fs.address") shouldBe "localhost:9000"
     options("fs.bucket_name") shouldBe "test-bucket"
     options("fs.root_path") shouldBe "data/milvus"

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -110,14 +110,14 @@ class BackfillModeTest
   private def buildOriginal(
       rows: Seq[(Int, java.lang.Integer, java.lang.String, Long, Long)]
   ): DataFrame = {
-    // columns: pk, f1 (nullable Int), f2 (nullable String), segment_id, row_offset
+    // columns: pk, f1 (nullable Int), f2 (nullable String), $segment_id, $row_offset
     val schema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
         StructField("f1", IntegerType, nullable = true),
         StructField("f2", StringType, nullable = true),
-        StructField("segment_id", LongType, nullable = false),
-        StructField("row_offset", LongType, nullable = false)
+        StructField(MilvusBackfill.SegmentIdCol, LongType, nullable = false),
+        StructField(MilvusBackfill.RowOffsetCol, LongType, nullable = false)
       )
     )
     val javaRows = rows.map { case (pk, f1, f2, seg, off) =>
@@ -144,8 +144,8 @@ class BackfillModeTest
     val originalSchema = StructType(
       Seq(
         StructField("pk", IntegerType, nullable = false),
-        StructField("segment_id", LongType, nullable = false),
-        StructField("row_offset", LongType, nullable = false)
+        StructField(MilvusBackfill.SegmentIdCol, LongType, nullable = false),
+        StructField(MilvusBackfill.RowOffsetCol, LongType, nullable = false)
       )
     )
     val originalRows = Seq(Row(1, 10L, 0L), Row(2, 10L, 1L), Row(3, 10L, 2L))
@@ -226,8 +226,8 @@ class BackfillModeTest
       "pk",
       "f1",
       "f2",
-      "segment_id",
-      "row_offset",
+      MilvusBackfill.SegmentIdCol,
+      MilvusBackfill.RowOffsetCol,
       MilvusBackfill.MatchFlagCol,
       MilvusBackfill.usedSrcCol("f1"),
       MilvusBackfill.usedBfCol("f1"),
@@ -450,8 +450,8 @@ class BackfillModeTest
       "pk",
       "f1",
       "f2",
-      "segment_id",
-      "row_offset",
+      MilvusBackfill.SegmentIdCol,
+      MilvusBackfill.RowOffsetCol,
       MilvusBackfill.MatchFlagCol,
       MilvusBackfill.usedSrcCol("f1"),
       MilvusBackfill.usedBfCol("f1"),

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
+import com.zilliz.spark.connector.{MilvusCollectionInfo, MilvusOption}
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   Collection,
@@ -36,7 +37,6 @@ import com.zilliz.spark.connector.read.{
   V2ColumnGroup,
   V2SegmentInfo
 }
-import com.zilliz.spark.connector.MilvusOption
 
 class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   private val emptySchemaBytes = java.util.Base64.getEncoder.encodeToString(
@@ -466,6 +466,57 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test(
+    "client-derived schema allows user fields named legacy metadata aliases"
+  ) {
+    val options = Map(
+      MilvusOption.SnapshotMode -> "true",
+      MilvusOption.SnapshotManifests -> "[]",
+      MilvusOption.SnapshotCollectionId -> "10",
+      MilvusOption.MilvusCollectionName -> "c",
+      MilvusOption.MilvusExtraColumns -> "segment_id,row_offset"
+    )
+    val collectionSchema = io.milvus.grpc.schema.CollectionSchema(
+      name = "c",
+      fields = Seq(
+        io.milvus.grpc.schema.FieldSchema(
+          fieldID = 100,
+          name = "segment_id",
+          dataType = io.milvus.grpc.schema.DataType.Int64,
+          nullable = false
+        ),
+        io.milvus.grpc.schema.FieldSchema(
+          fieldID = 101,
+          name = "row_offset",
+          dataType = io.milvus.grpc.schema.DataType.Int64,
+          nullable = false
+        )
+      )
+    )
+
+    val schema = new MilvusTable(MilvusOption(options), None) {
+      override def initInfo(): Unit = {
+        milvusCollection = MilvusCollectionInfo(
+          dbName = "",
+          collectionName = "c",
+          collectionID = 10L,
+          schema = collectionSchema
+        )
+      }
+    }.schema()
+
+    assert(
+      schema.fieldNames.toSeq == Seq(
+        "row_id",
+        "timestamp",
+        "segment_id",
+        "row_offset",
+        "$segment_id",
+        "$row_offset"
+      )
+    )
+  }
+
+  test(
     "scan pruning preserves canonical metadata fields requested by legacy aliases"
   ) {
     val rawOptions = new ju.HashMap[String, String]()
@@ -769,6 +820,10 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
         StorageV2ManifestItem(
           30L,
           "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+        ),
+        StorageV2ManifestItem(
+          31L,
+          "{\"ver\":8,\"base_path\":\"files/insert_log/10/21/31\"}"
         )
       )
     )
@@ -778,11 +833,15 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     rawOptions.put(MilvusOption.SnapshotPartitionIds, "20,21")
     rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
     val partitions = scanWithOptions(rawOptions).planInputPartitions()
-    assert(partitions.length == 1)
-    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
-    assert(partition.partitionName == "20")
-    assert(partition.segmentID == 30L)
-    assert(partition.readVersion == 7L)
+    assert(partitions.length == 2)
+    val first = partitions(0).asInstanceOf[MilvusStorageV3InputPartition]
+    val second = partitions(1).asInstanceOf[MilvusStorageV3InputPartition]
+    assert(first.partitionName == "20")
+    assert(first.segmentID == 30L)
+    assert(first.readVersion == 7L)
+    assert(second.partitionName == "21")
+    assert(second.segmentID == 31L)
+    assert(second.readVersion == 8L)
   }
 
   test("snapshot planner accepts V2-only snapshot segments") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -844,6 +844,30 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(second.readVersion == 8L)
   }
 
+  test(
+    "snapshot planner falls back to default partition ID for unexpected V3 paths"
+  ) {
+    val manifestJson = MilvusSnapshotReader.serializeManifestList(
+      Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":7,\"base_path\":\"files/unexpected/10/20/30\"}"
+        )
+      )
+    )
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.SnapshotMode, "true")
+    rawOptions.put(MilvusOption.SnapshotManifests, manifestJson)
+    rawOptions.put(MilvusOption.SnapshotPartitionIds, "20,21")
+    rawOptions.put(MilvusOption.SnapshotSchemaBytes, emptySchemaBytes)
+    val partitions = scanWithOptions(rawOptions).planInputPartitions()
+    assert(partitions.length == 1)
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.partitionName == "20")
+    assert(partition.segmentID == 30L)
+    assert(partition.readVersion == 7L)
+  }
+
   test("snapshot planner accepts V2-only snapshot segments") {
     val v2Json = MilvusSnapshotReader.serializeV2Segments(
       Seq(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -57,6 +57,20 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  private def snapshotTableSchema(
+      baseSchema: StructType,
+      extraColumns: String
+  ): StructType = {
+    val options = Map(
+      MilvusOption.SnapshotMode -> "true",
+      MilvusOption.SnapshotManifests -> "[]",
+      MilvusOption.SnapshotCollectionId -> "10",
+      MilvusOption.MilvusCollectionName -> "c",
+      MilvusOption.MilvusExtraColumns -> extraColumns
+    )
+    MilvusTable(MilvusOption(options), Some(baseSchema)).schema()
+  }
+
   test(
     "resolveClientSnapshotLocation prefixes bucket-relative snapshot locations"
   ) {
@@ -400,6 +414,79 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(
       !MilvusScan.canUseClientSnapshotFastPath(
         MilvusOption(base + (MilvusOption.MilvusSegmentID -> "30"))
+      )
+    )
+  }
+
+  test(
+    "table schema emits canonical metadata extra column names from legacy aliases"
+  ) {
+    val schema = snapshotTableSchema(
+      StructType(Seq(StructField("pk", LongType, nullable = false))),
+      "partition,segment_id,row_offset"
+    )
+
+    assert(
+      schema.fieldNames.toSeq == Seq(
+        "pk",
+        "partition",
+        "$segment_id",
+        "$row_offset"
+      )
+    )
+  }
+
+  test(
+    "table schema rejects user field conflicting with canonical metadata column"
+  ) {
+    val err = intercept[IllegalArgumentException] {
+      snapshotTableSchema(
+        StructType(Seq(StructField("$segment_id", LongType, nullable = false))),
+        "$segment_id"
+      )
+    }
+
+    assert(err.getMessage.contains("$segment_id"))
+    assert(err.getMessage.contains("metadata extra column"))
+  }
+
+  test(
+    "table schema keeps legacy alias user field separate from canonical metadata"
+  ) {
+    val schema = snapshotTableSchema(
+      StructType(Seq(StructField("segment_id", LongType, nullable = false))),
+      "segment_id"
+    )
+
+    assert(schema.fieldNames.toSeq == Seq("segment_id", "$segment_id"))
+  }
+
+  test(
+    "scan pruning preserves canonical metadata fields requested by legacy aliases"
+  ) {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.MilvusExtraColumns, "segment_id,row_offset")
+    val schema = StructType(
+      Seq(
+        StructField("pk", LongType, nullable = false),
+        StructField("$segment_id", LongType, nullable = false),
+        StructField("$row_offset", LongType, nullable = false)
+      )
+    )
+    val builder = new MilvusScanBuilder(
+      schema,
+      new CaseInsensitiveStringMap(rawOptions)
+    )
+
+    builder.pruneColumns(
+      StructType(Seq(StructField("pk", LongType, nullable = false)))
+    )
+
+    assert(
+      builder.build().readSchema().fieldNames.toSeq == Seq(
+        "pk",
+        "$segment_id",
+        "$row_offset"
       )
     )
   }

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -451,14 +451,18 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test(
-    "table schema keeps legacy alias user field separate from canonical metadata"
+    "table schema rejects legacy metadata aliases in provided schema"
   ) {
-    val schema = snapshotTableSchema(
-      StructType(Seq(StructField("segment_id", LongType, nullable = false))),
-      "segment_id"
-    )
+    val err = intercept[IllegalArgumentException] {
+      snapshotTableSchema(
+        StructType(Seq(StructField("segment_id", LongType, nullable = false))),
+        "segment_id"
+      )
+    }
 
-    assert(schema.fieldNames.toSeq == Seq("segment_id", "$segment_id"))
+    assert(err.getMessage.contains("segment_id"))
+    assert(err.getMessage.contains("legacy alias"))
+    assert(err.getMessage.contains("$segment_id"))
   }
 
   test(


### PR DESCRIPTION
Freeze metadata extra-column output names as `partition`, `$segment_id`, and `$row_offset`, while preserving `segment_id` / `row_offset` as input aliases. Update reader metadata wrapping and backfill consumers to use canonical names without changing snapshot lifecycle or snapshot option keys.

BREAKING CHANGE: `milvus.extra.columns=segment_id,row_offset` still works as input, but emitted schemas now use `$segment_id` and `$row_offset`.