### PR TITLE
enhance: [reader] unify system field aliases around canonical RowID/Timestamp

### DIFF
--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -38,6 +38,27 @@ import io.milvus.storage.{
 }
 
 object MilvusLoonPartitionReader {
+  private[read] val SystemFieldAliases: Seq[(String, Long)] = Seq(
+    "RowID" -> 0L,
+    "row_id" -> 0L,
+    "rowid" -> 0L,
+    "Timestamp" -> 1L,
+    "timestamp" -> 1L
+  )
+
+  private[read] def buildFieldNameToId(
+      milvusSchema: CollectionSchema
+  ): Map[String, Long] = {
+    val userFieldNames = milvusSchema.fields.map(_.name).toSet
+    val systemFields = SystemFieldAliases.filterNot { case (alias, _) =>
+      userFieldNames.contains(alias)
+    }.toMap
+    val userFields = milvusSchema.fields.map { field =>
+      field.name -> field.fieldID
+    }.toMap
+    systemFields ++ userFields
+  }
+
   private case class VectorSearchResult(
       row: InternalRow,
       distance: Double,
@@ -69,13 +90,8 @@ class MilvusLoonPartitionReader(
 
   private val sourceSchema = schema
 
-  private val fieldNameToId: Map[String, Long] = {
-    val systemFields = Map("row_id" -> 0L, "timestamp" -> 1L)
-    val userFields = milvusSchema.fields.map { field =>
-      field.name -> field.fieldID
-    }.toMap
-    systemFields ++ userFields
-  }
+  private val fieldNameToId: Map[String, Long] =
+    MilvusLoonPartitionReader.buildFieldNameToId(milvusSchema)
 
   private val fieldNameToIdString: Map[String, String] =
     fieldNameToId.map { case (name, id) => name -> id.toString }
@@ -326,10 +342,8 @@ class MilvusLoonPartitionReader(
   }
 
   private def getColumnNames(): Array[String] = {
-    // Convert column names to field IDs for manifest/reader matching
-    // The manifest stores column groups with field IDs (e.g., "100", "101")
-    // Note: System fields (row_id, timestamp) are handled by MilvusPartitionReaderFactory
-    // and should NOT be requested from milvus-storage reader
+    // Convert column names to field IDs for manifest/reader matching.
+    // System fields are mapped to Milvus field IDs 0 and 1 and requested from storage.
     sourceSchema.fieldNames.flatMap { name =>
       fieldNameToId.get(name).map(_.toString)
     }

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -25,6 +25,8 @@ import io.milvus.storage.{
 }
 
 object MilvusPackedV2PartitionReader {
+  private val ToleratedUnmappedColumns = Set("$meta")
+
   private[read] case class FieldMappings(
       fieldIdToName: Map[Long, String],
       fieldNameToId: Map[String, Long],
@@ -89,8 +91,9 @@ object MilvusPackedV2PartitionReader {
         }
         neededColumnFieldIds
       } else {
-        val missingNames = sourceSchema.fieldNames.filterNot(
-          fieldMappings.fieldNameToId.contains
+        val missingNames = sourceSchema.fieldNames.filterNot(name =>
+          fieldMappings.fieldNameToId.contains(name) ||
+            ToleratedUnmappedColumns.contains(name)
         )
         if (missingNames.nonEmpty) {
           throw new IllegalArgumentException(
@@ -98,7 +101,7 @@ object MilvusPackedV2PartitionReader {
               s"; schema columns=${fieldMappings.fieldNameToId.keys.toSeq.sorted.mkString(",")}"
           )
         }
-        sourceSchema.fieldNames.toSeq.map(fieldMappings.fieldNameToId)
+        sourceSchema.fieldNames.toSeq.flatMap(fieldMappings.fieldNameToId.get)
       }
     val missingFieldIds = requestedFieldIds.filterNot(declaredFieldIds.contains)
     if (missingFieldIds.nonEmpty) {

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -71,6 +71,10 @@ object MilvusPackedV2PartitionReader {
       fieldMappings: FieldMappings,
       neededColumnFieldIds: Seq[Long]
   ): Array[String] = {
+    if (columnGroups.isEmpty) {
+      return Array.empty
+    }
+
     val declaredFieldIds = columnGroups.flatMap(_.fieldIds).toSet
     val requestedFieldIds: Seq[Long] =
       if (neededColumnFieldIds.nonEmpty) {

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -24,6 +24,97 @@ import io.milvus.storage.{
   NativeLibraryLoader
 }
 
+object MilvusPackedV2PartitionReader {
+  private[read] case class FieldMappings(
+      fieldIdToName: Map[Long, String],
+      fieldNameToId: Map[String, Long],
+      fieldNameToArrowColumn: Map[String, String]
+  )
+
+  private[read] val SystemFieldAliases: Seq[(String, (Long, String))] = Seq(
+    "RowID" -> (0L, "RowID"),
+    "row_id" -> (0L, "RowID"),
+    "rowid" -> (0L, "RowID"),
+    "Timestamp" -> (1L, "Timestamp"),
+    "timestamp" -> (1L, "Timestamp")
+  )
+
+  private[read] def buildFieldMappings(
+      milvusSchema: CollectionSchema
+  ): FieldMappings = {
+    val systemFields = Map(0L -> "RowID", 1L -> "Timestamp")
+    val userFields = milvusSchema.fields.map(f => f.fieldID -> f.name).toMap
+    val fieldIdToName = systemFields ++ userFields
+    val userFieldNames = milvusSchema.fields.map(_.name).toSet
+    val systemAliases = SystemFieldAliases.filterNot { case (alias, _) =>
+      userFieldNames.contains(alias)
+    }
+    val userFieldNameToId =
+      milvusSchema.fields.map(f => f.name -> f.fieldID).toMap
+    val systemFieldNameToId = systemAliases.map { case (alias, (id, _)) =>
+      alias -> id
+    }.toMap
+    val systemFieldNameToArrowColumn = systemAliases.map {
+      case (alias, (_, column)) => alias -> column
+    }.toMap
+
+    FieldMappings(
+      fieldIdToName,
+      systemFieldNameToId ++ userFieldNameToId,
+      systemFieldNameToArrowColumn
+    )
+  }
+
+  private[read] def resolveNeededColumns(
+      sourceSchema: StructType,
+      columnGroups: Seq[V2ColumnGroup],
+      fieldMappings: FieldMappings,
+      neededColumnFieldIds: Seq[Long]
+  ): Array[String] = {
+    val declaredFieldIds = columnGroups.flatMap(_.fieldIds).toSet
+    val requestedFieldIds: Seq[Long] =
+      if (neededColumnFieldIds.nonEmpty) {
+        val missingIds = neededColumnFieldIds.filterNot(
+          fieldMappings.fieldIdToName.contains
+        )
+        if (missingIds.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"Packed V2 requested unknown field IDs: ${missingIds.distinct.mkString(",")}" +
+              s"; schema field IDs=${fieldMappings.fieldIdToName.keys.toSeq.sorted.mkString(",")}"
+          )
+        }
+        neededColumnFieldIds
+      } else {
+        val missingNames = sourceSchema.fieldNames.filterNot(
+          fieldMappings.fieldNameToId.contains
+        )
+        if (missingNames.nonEmpty) {
+          throw new IllegalArgumentException(
+            s"Packed V2 requested unknown columns: ${missingNames.distinct.mkString(",")}" +
+              s"; schema columns=${fieldMappings.fieldNameToId.keys.toSeq.sorted.mkString(",")}"
+          )
+        }
+        sourceSchema.fieldNames.toSeq.map(fieldMappings.fieldNameToId)
+      }
+    val missingFieldIds = requestedFieldIds.filterNot(declaredFieldIds.contains)
+    if (missingFieldIds.nonEmpty) {
+      val missingColumns = missingFieldIds
+        .flatMap(fieldMappings.fieldIdToName.get)
+        .distinct
+      val declaredColumns = declaredFieldIds
+        .flatMap(fieldMappings.fieldIdToName.get)
+        .toSeq
+        .sorted
+      throw new IllegalArgumentException(
+        s"Packed V2 column groups do not contain requested columns: ${missingColumns
+            .mkString(",")}" +
+          s"; declared columns=${declaredColumns.mkString(",")}"
+      )
+    }
+    requestedFieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
+  }
+}
+
 /** Spark partition reader for milvus-segment-info `storage_version = 2`
   * (StorageV2, non-manifest packed parquet) segments.
   *
@@ -54,43 +145,25 @@ class MilvusPackedV2PartitionReader(
   private val allocator = ArrowUtils.getAllocator
   private val sourceSchema = schema
 
-  // Field ID -> logical column name. StorageV2 packed-parquet files written
-  // by milvus segcore use the field's logical name in the parquet schema
-  // (with PARQUET:field_id metadata for cross-reference). The packed reader
-  // matches columns by name, so we must pass logical names — NOT
-  // field-id-as-string like the V3 reader does.
-  private val fieldIdToName: Map[Long, String] = {
-    val systemFields = Map(0L -> "RowID", 1L -> "Timestamp")
-    val userFields =
-      milvusSchema.fields.map(f => f.fieldID -> f.name).toMap
-    systemFields ++ userFields
-  }
-  private val fieldNameToId: Map[String, Long] =
-    fieldIdToName.map { case (id, name) => name -> id }
-
-  // V3 readers pass a {sparkName -> fieldId-as-string} map to ArrowConverter
-  // because their on-disk parquet uses fieldId-as-string column names. V2
-  // packed parquet uses LOGICAL names (e.g. "ID"), so we must NOT remap —
-  // ArrowConverter calls `root.getVector(field.name)` directly when the
-  // mapping is empty, which is exactly what we need here. Remapping would
-  // make it look up a non-existent column and silently null every cell.
-  private val fieldNameToArrowColumn: Map[String, String] = Map.empty
+  private val fieldMappings =
+    MilvusPackedV2PartitionReader.buildFieldMappings(milvusSchema)
+  private val fieldNameToArrowColumn = fieldMappings.fieldNameToArrowColumn
 
   // Which column names to ask the packed reader for. Prefer explicit
   // projection from neededColumnFieldIds; fall back to sourceSchema's Spark
   // field names. In both cases we coerce to logical names that the parquet
   // actually carries.
-  private val neededColumns: Array[String] = {
-    val explicitNames: Seq[String] =
-      if (neededColumnFieldIds.nonEmpty)
-        neededColumnFieldIds.flatMap(fid => fieldIdToName.get(fid))
-      else sourceSchema.fieldNames.toSeq.filter(fieldNameToId.contains)
-    // Drop names that aren't declared by any of the v2 column groups —
-    // `loon_reader_new` would reject unknown columns.
-    val declared: Set[String] =
-      columnGroups.flatMap(_.fieldIds.flatMap(fieldIdToName.get)).toSet
-    explicitNames.filter(name => declared.contains(name)).toArray
-  }
+  private val neededColumns: Array[String] =
+    MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups,
+      fieldMappings,
+      neededColumnFieldIds
+    )
+
+  // V2 packed parquet uses logical names (e.g. "ID"). When callers request
+  // aliases such as row_id/timestamp, ArrowConverter must look up the canonical
+  // packed column names RowID/Timestamp instead.
 
   // Native resource handles. Initialized to safe defaults so a partial-init
   // failure can roll back whatever was allocated so far. Spark only calls
@@ -127,7 +200,7 @@ class MilvusPackedV2PartitionReader(
     // from the AVRO's AvroBinlog.entries_num — required because the packed
     // reader rejects negative end indices.
     val cols = columnGroups.map { cg =>
-      cg.fieldIds.flatMap(fieldIdToName.get).toArray
+      cg.fieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
     }.toArray
     val files = columnGroups.map(_.filePaths.toArray).toArray
     val rowCounts = columnGroups.map { cg =>

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -51,7 +51,11 @@ class MilvusPartitionReaderFactory(
     with Logging {
 
   private def isSystemField(name: String): Boolean =
-    name == "row_id" || name == "timestamp"
+    name == "RowID" ||
+      name == "Timestamp" ||
+      name == "row_id" ||
+      name == "rowid" ||
+      name == "timestamp"
 
   private val requestedExtraColumns =
     MilvusPartitionReaderFactory.requestedExtraColumns(optionsMap)
@@ -72,7 +76,7 @@ class MilvusPartitionReaderFactory(
         )
 
         val v2Schema = StructType(schema.fields.filterNot { field =>
-          isSystemField(field.name) || isMetadataExtraField(field.name)
+          isMetadataExtraField(field.name)
         })
 
         // Deserialize the protobuf schema
@@ -93,11 +97,11 @@ class MilvusPartitionReaderFactory(
           p.readVersion
         )
 
-        val hasSyntheticFields = schema.fieldNames.exists { name =>
-          isSystemField(name) || isMetadataExtraField(name)
+        val hasMetadataExtraFields = schema.fieldNames.exists { name =>
+          isMetadataExtraField(name)
         }
 
-        if (hasSyntheticFields) {
+        if (hasMetadataExtraFields) {
           new PartitionReader[InternalRow] {
             override def next(): Boolean = underlyingReader.next()
 
@@ -108,8 +112,6 @@ class MilvusPartitionReaderFactory(
 
               schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
                 field.name match {
-                  case "row_id" | "timestamp" =>
-                    resultValues(writeIdx) = null
                   case MilvusOption.MilvusExtraColumnPartition =>
                     resultValues(writeIdx) =
                       MilvusPartitionReaderFactory.stringValue(p.partitionName)
@@ -140,7 +142,7 @@ class MilvusPartitionReaderFactory(
         )
 
         val innerSchema = StructType(schema.fields.filterNot { field =>
-          isSystemField(field.name) || isMetadataExtraField(field.name)
+          isMetadataExtraField(field.name)
         })
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
@@ -153,11 +155,11 @@ class MilvusPartitionReaderFactory(
           p.neededColumnFieldIds
         )
 
-        val hasSyntheticFields = schema.fieldNames.exists { name =>
-          isSystemField(name) || isMetadataExtraField(name)
+        val hasMetadataExtraFields = schema.fieldNames.exists { name =>
+          isMetadataExtraField(name)
         }
 
-        if (hasSyntheticFields) {
+        if (hasMetadataExtraFields) {
           new PartitionReader[InternalRow] {
             private var rowOffset: Long = 0L
 
@@ -170,8 +172,6 @@ class MilvusPartitionReaderFactory(
 
               schema.fields.zipWithIndex.foreach { case (field, writeIdx) =>
                 field.name match {
-                  case "row_id" | "timestamp" =>
-                    out(writeIdx) = null
                   case MilvusOption.MilvusExtraColumnPartition =>
                     out(writeIdx) = MilvusPartitionReaderFactory.stringValue(
                       p.partitionID.toString

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -50,13 +50,6 @@ class MilvusPartitionReaderFactory(
 ) extends PartitionReaderFactory
     with Logging {
 
-  private def isSystemField(name: String): Boolean =
-    name == "RowID" ||
-      name == "Timestamp" ||
-      name == "row_id" ||
-      name == "rowid" ||
-      name == "timestamp"
-
   private val requestedExtraColumns =
     MilvusPartitionReaderFactory.requestedExtraColumns(optionsMap)
 

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -34,12 +34,30 @@ object MilvusSchemaUtil {
     )
   }
 
-  private def systemFieldNameAliases(field: FieldSchema): Set[String] = {
+  private[connector] val CanonicalSystemFields: Seq[FieldSchema] = Seq(
+    FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
+    FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
+  )
+
+  private[connector] def systemFieldNameAliases(
+      field: FieldSchema
+  ): Set[String] = {
     field.fieldID match {
       case 0 => Set("rowid", "row_id")
       case 1 => Set("timestamp")
       case _ => Set(field.name.toLowerCase)
     }
+  }
+
+  private[connector] def missingSystemFields(
+      collectionSchema: io.milvus.grpc.schema.CollectionSchema
+  ): Seq[FieldSchema] = {
+    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
+    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
+    CanonicalSystemFields.filterNot(field =>
+      systemFieldNameAliases(field).exists(existingNames.contains) ||
+        existingFieldIds.contains(field.fieldID)
+    )
   }
 
   /** Convert Milvus FieldSchema to Arrow Field
@@ -143,18 +161,9 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
-    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
-    val systemFields = Seq(
-      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
-      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
-    ).filterNot(field =>
-      systemFieldNameAliases(field).exists(existingNames.contains) ||
-        existingFieldIds.contains(field.fieldID)
-    )
-
-    (systemFields ++ collectionSchema.fields).foreach { field =>
-      appendArrowField(field)
+    (missingSystemFields(collectionSchema) ++ collectionSchema.fields).foreach {
+      field =>
+        appendArrowField(field)
     }
 
     // Create and return Arrow Schema
@@ -229,18 +238,9 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
-    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
-    val systemFields = Seq(
-      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
-      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
-    ).filterNot(field =>
-      systemFieldNameAliases(field).exists(existingNames.contains) ||
-        existingFieldIds.contains(field.fieldID)
-    )
-
-    (systemFields ++ collectionSchema.fields).foreach { field =>
-      appendArrowFieldWithIdName(field)
+    (missingSystemFields(collectionSchema) ++ collectionSchema.fields).foreach {
+      field =>
+        appendArrowFieldWithIdName(field)
     }
 
     // Create and return Arrow Schema

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -34,6 +34,14 @@ object MilvusSchemaUtil {
     )
   }
 
+  private def systemFieldNameAliases(field: FieldSchema): Set[String] = {
+    field.fieldID match {
+      case 0 => Set("rowid", "row_id")
+      case 1 => Set("timestamp")
+      case _ => Set(field.name.toLowerCase)
+    }
+  }
+
   /** Convert Milvus FieldSchema to Arrow Field
     */
   def convertToArrowField(
@@ -135,8 +143,17 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    // Process all fields in the collection schema
-    collectionSchema.fields.foreach { field =>
+    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
+    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
+    val systemFields = Seq(
+      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
+      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
+    ).filterNot(field =>
+      systemFieldNameAliases(field).exists(existingNames.contains) ||
+        existingFieldIds.contains(field.fieldID)
+    )
+
+    (systemFields ++ collectionSchema.fields).foreach { field =>
       appendArrowField(field)
     }
 
@@ -152,8 +169,9 @@ object MilvusSchemaUtil {
     * the Arrow schema must use field IDs as field names for the reader to
     * correctly match requested columns with column groups.
     *
-    * Note: System fields (row_id, timestamp) are NOT included here. They are
-    * handled by MilvusPartitionReaderFactory.
+    * System fields (RowID=0, Timestamp=1) are included when the Milvus schema
+    * does not already declare them, so readers can project system fields
+    * consistently.
     *
     * @param collectionSchema
     *   The Milvus collection schema
@@ -211,8 +229,17 @@ object MilvusSchemaUtil {
       arrowFields += arrowField
     }
 
-    // Process all fields in the collection schema
-    collectionSchema.fields.foreach { field =>
+    val existingNames = collectionSchema.fields.map(_.name.toLowerCase).toSet
+    val existingFieldIds = collectionSchema.fields.map(_.fieldID).toSet
+    val systemFields = Seq(
+      FieldSchema(name = "RowID", fieldID = 0, dataType = DataType.Int64),
+      FieldSchema(name = "Timestamp", fieldID = 1, dataType = DataType.Int64)
+    ).filterNot(field =>
+      systemFieldNameAliases(field).exists(existingNames.contains) ||
+        existingFieldIds.contains(field.fieldID)
+    )
+
+    (systemFields ++ collectionSchema.fields).foreach { field =>
       appendArrowFieldWithIdName(field)
     }
 
@@ -287,8 +314,8 @@ object MilvusSchemaUtil {
           )
       }
 
-      // Use explicit field ID if provided, otherwise fall back to idx + 1
-      val fieldId = fieldIds.getOrElse(field.name, (idx + 1).toLong)
+      // Use explicit field ID if provided, otherwise avoid Milvus system IDs 0/1.
+      val fieldId = fieldIds.getOrElse(field.name, (idx + 100).toLong)
       val metadata = Map("PARQUET:field_id" -> fieldId.toString).asJava
 
       val fieldType = new FieldType(true, arrowType, null, metadata)

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -411,10 +411,10 @@ case class MilvusTable(
       }
     }
     if (fieldIDs.isEmpty || fieldIDs.contains("0")) {
-      fields = fields :+ StructField("row_id", LongType, false)
+      fields = fields :+ StructField("RowID", LongType, false)
     }
     if (fieldIDs.isEmpty || fieldIDs.contains("1")) {
-      fields = fields :+ StructField("timestamp", LongType, false)
+      fields = fields :+ StructField("Timestamp", LongType, false)
     }
     val filteredFields = milvusCollection.schema.fields
       .filter(field =>
@@ -516,9 +516,10 @@ class MilvusScanBuilder(
 
     fieldNames = fieldNames.sortBy(fieldName => fieldName2ID(fieldName))
     logInfo(s"fieldNames after sort: $fieldNames")
-    if (fieldNames.isEmpty) {
-      fieldNames = fieldNames :+ "row_id"
-      logInfo(s"fieldNames after add row_id: $fieldNames")
+    if (fieldNames.isEmpty && fieldName2ID.nonEmpty) {
+      val fallbackFieldName = fieldName2ID.toSeq.sortBy(_._2).head._1
+      fieldNames = fieldNames :+ fallbackFieldName
+      logInfo(s"fieldNames after add fallback field: $fieldNames")
     }
 
     val tmpMap = new HashMap[String, String]()

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -53,6 +53,7 @@ import com.zilliz.spark.connector.{
   MilvusClient,
   MilvusCollectionInfo,
   MilvusOption,
+  MilvusSchemaUtil,
   VectorSearchConfig
 }
 import com.zilliz.spark.connector.loon.Properties
@@ -410,10 +411,20 @@ case class MilvusTable(
         field.fieldID
       }
     }
-    if (fieldIDs.isEmpty || fieldIDs.contains("0")) {
+    val missingSystemFields = MilvusSchemaUtil
+      .missingSystemFields(milvusCollection.schema)
+      .map(_.fieldID)
+      .toSet
+    if (
+      missingSystemFields.contains(0L) &&
+      (fieldIDs.isEmpty || fieldIDs.contains("0"))
+    ) {
       fields = fields :+ StructField("RowID", LongType, false)
     }
-    if (fieldIDs.isEmpty || fieldIDs.contains("1")) {
+    if (
+      missingSystemFields.contains(1L) &&
+      (fieldIDs.isEmpty || fieldIDs.contains("1"))
+    ) {
       fields = fields :+ StructField("Timestamp", LongType, false)
     }
     val filteredFields = milvusCollection.schema.fields

--- a/src/test/scala/serde/SchemaUtilTest.scala
+++ b/src/test/scala/serde/SchemaUtilTest.scala
@@ -331,7 +331,54 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
     // PARQUET:field_id metadata is always stamped, regardless of rename.
     byIdx(0).getMetadata.get("PARQUET:field_id") shouldBe "100"
     byIdx(1).getMetadata.get("PARQUET:field_id") shouldBe "101"
-    byIdx(2).getMetadata.get("PARQUET:field_id") shouldBe "3" // idx+1 fallback
+    byIdx(2).getMetadata.get("PARQUET:field_id") shouldBe "102"
+  }
+
+  test("field ID fallback avoids Milvus system field IDs") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import org.apache.spark.sql.types._
+
+    val schema = StructType(
+      Seq(
+        StructField("first", LongType),
+        StructField("second", StringType)
+      )
+    )
+
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
+    val metadata = arrowSchema.getFields.asScala.map(_.getMetadata)
+
+    metadata.head.get("PARQUET:field_id") shouldBe "100"
+    metadata(1).get("PARQUET:field_id") shouldBe "101"
+  }
+
+  test("system fields are not appended over case-insensitive name conflicts") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import io.milvus.grpc.schema.{
+      CollectionSchema => MilvusCollectionSchema,
+      DataType => MilvusDataType,
+      FieldSchema => MilvusFieldSchema
+    }
+
+    val schema = MilvusCollectionSchema(
+      fields = Seq(
+        MilvusFieldSchema(
+          name = "row_id",
+          fieldID = 100,
+          dataType = MilvusDataType.Int64
+        ),
+        MilvusFieldSchema(
+          name = "timestamp",
+          fieldID = 101,
+          dataType = MilvusDataType.Int64
+        )
+      )
+    )
+
+    val arrowSchema = MilvusSchemaUtil.convertToArrowSchema(schema)
+    val names = arrowSchema.getFields.asScala.map(_.getName)
+
+    names shouldBe Seq("row_id", "timestamp")
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -506,8 +506,8 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
 
     assert(
       schema.fieldNames.toSeq == Seq(
-        "row_id",
-        "timestamp",
+        "RowID",
+        "Timestamp",
         "segment_id",
         "row_offset",
         "$segment_id",


### PR DESCRIPTION
The reader stack still exposed lowercase system-field names on some paths while snapshot and packed-V2 code already treated RowID and Timestamp as canonical. That split made projection behavior inconsistent and forced the reader factory to synthesize null system columns instead of reading the real values.

Standardize on RowID and Timestamp as the public contract, while keeping row_id, rowid, and timestamp as compatible read-time aliases. This aligns schema inference with the underlying storage field IDs and avoids collisions with Milvus-reserved system-field slots.