### PR TITLE
enhance!: [reader] harden Arrow vector decoding

### DIFF
--- a/src/main/scala/expressions/VectorExpressions.scala
+++ b/src/main/scala/expressions/VectorExpressions.scala
@@ -346,6 +346,8 @@ case class HammingDistanceExpression(_left: Expression, _right: Expression)
 
   private def extractByteArray(value: Any): Array[Byte] = {
     value match {
+      case bytes: Array[Byte] =>
+        bytes
       case arrayData: ArrayData =>
         val size = arrayData.numElements()
         val result = new Array[Byte](size)
@@ -422,6 +424,8 @@ case class JaccardDistanceExpression(_left: Expression, _right: Expression)
 
   private def extractByteArray(value: Any): Array[Byte] = {
     value match {
+      case bytes: Array[Byte] =>
+        bytes
       case arrayData: ArrayData =>
         val size = arrayData.numElements()
         val result = new Array[Byte](size)

--- a/src/main/scala/filter/VectorBruteForceSearch.scala
+++ b/src/main/scala/filter/VectorBruteForceSearch.scala
@@ -198,13 +198,31 @@ object VectorBruteForceSearch {
     }
   })
 
-  // UDF for converting Array[Byte] to binary vector (keep as Array[Byte])
-  private val arrayByteToBinaryVectorUDF = udf((arr: Seq[Byte]) => {
-    if (arr == null) {
-      null
-    } else {
-      arr.toArray
+  private def byteArrayFromBinaryValue(value: Any): Array[Byte] = {
+    value match {
+      case null =>
+        null
+      case arr: Array[Byte] =>
+        arr
+      case seq: Seq[_] =>
+        seq.map {
+          case b: Byte   => b
+          case n: Number => n.byteValue()
+          case other =>
+            throw new IllegalArgumentException(
+              s"Cannot convert ${other.getClass.getName} to Byte in binary vector"
+            )
+        }.toArray
+      case other =>
+        throw new IllegalArgumentException(
+          s"Unsupported binary vector value type: ${other.getClass.getName}"
+        )
     }
+  }
+
+  // UDF for normalizing binary vectors to raw bytes
+  private val arrayByteToBinaryVectorUDF = udf((value: Any) => {
+    byteArrayFromBinaryValue(value)
   })
 
   // UDF for converting Map[Long, Float] to SparseVector
@@ -239,13 +257,13 @@ object VectorBruteForceSearch {
     }
 
     schema(vectorCol).dataType match {
-      case ArrayType(FloatType, _)         => DENSE_FLOAT
-      case ArrayType(ByteType, _)          => BINARY
-      case MapType(LongType, FloatType, _) => SPARSE
+      case ArrayType(FloatType, _)             => DENSE_FLOAT
+      case BinaryType | ArrayType(ByteType, _) => BINARY
+      case MapType(LongType, FloatType, _)     => SPARSE
       case _ =>
         throw new IllegalArgumentException(
           s"Unsupported vector column type: ${schema(vectorCol).dataType}. " +
-            s"Supported types are: Array[Float] (dense float), Array[Byte] (binary), Map[Long, Float] (sparse)"
+            s"Supported types are: Array[Float] (dense float), BinaryType/Array[Byte] (binary), Map[Long, Float] (sparse)"
         )
     }
   }
@@ -592,10 +610,10 @@ object VectorBruteForceSearch {
 
     // Validate vector type
     schema(vectorCol).dataType match {
-      case ArrayType(ByteType, _) => // Valid
+      case BinaryType | ArrayType(ByteType, _) => // Valid
       case _ =>
         throw new IllegalArgumentException(
-          s"Vector column '$vectorCol' must be of type Array[Byte]. Found: ${schema(vectorCol).dataType}"
+          s"Vector column '$vectorCol' must be of type BinaryType or Array[Byte]. Found: ${schema(vectorCol).dataType}"
         )
     }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -291,12 +291,11 @@ object MilvusBackfill {
                   )
                 )
               )
-            val sparkType = MilvusSnapshotReader.fieldToSparkType(field)
+            val structField = MilvusSnapshotReader.fieldToStructField(field)
             (
               n,
               fid,
-              org.apache.spark.sql.types
-                .StructField(n, sparkType, nullable = true)
+              structField
             )
           }
         } else Seq.empty
@@ -644,10 +643,7 @@ object MilvusBackfill {
             case Some(field) =>
               // Create schema with only the PK field
               import org.apache.spark.sql.types._
-              val pkFieldType = MilvusSnapshotReader.fieldToSparkType(field)
-              StructType(
-                Seq(StructField(field.name, pkFieldType, nullable = true))
-              )
+              StructType(Seq(MilvusSnapshotReader.fieldToStructField(field)))
             case None =>
               // Fallback: use full schema if PK field not found
               logger.warn(

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.types.{
   LongType,
   ShortType,
   StringType,
+  StructField,
   StructType
 }
 
@@ -27,7 +28,7 @@ import com.zilliz.spark.connector.filter.VectorBruteForceSearch
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
 import com.zilliz.spark.connector.MilvusOption
-import io.milvus.grpc.schema.CollectionSchema
+import io.milvus.grpc.schema.{CollectionSchema, DataType}
 import io.milvus.storage.{
   ArrowUtils,
   LatestColumnGroupsResult,
@@ -64,6 +65,34 @@ object MilvusLoonPartitionReader {
       distance: Double,
       rowOffset: Long
   )
+
+  private[read] def decodeBinaryTypeVectorForSearch(
+      bytes: Array[Byte],
+      field: StructField
+  ): Array[Float] = {
+    if (!field.metadata.contains(ArrowConverter.MilvusDataTypeMetadataKey)) {
+      throw new IllegalArgumentException(
+        s"BinaryType vector search requires ${ArrowConverter.MilvusDataTypeMetadataKey} metadata"
+      )
+    }
+
+    field.metadata
+      .getLong(ArrowConverter.MilvusDataTypeMetadataKey)
+      .toInt match {
+      case DataType.FloatVector.value | DataType.Float16Vector.value |
+          DataType.BFloat16Vector.value =>
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+      case DataType.BinaryVector.value =>
+        throw new IllegalArgumentException(
+          "BinaryVector does not support vector.search.* dense-float metrics; use binary search utilities with Hamming/Jaccard instead"
+        )
+      case other =>
+        throw new IllegalArgumentException(
+          s"BinaryType vector search is unsupported for Milvus data type $other"
+        )
+    }
+  }
 }
 
 // for Milvus 2.6+ version data source and milvus lake data
@@ -508,17 +537,16 @@ class MilvusLoonPartitionReader(
   ): Array[Float] = {
     dataType match {
       case ArrayType(FloatType, _) =>
-        // Array[Float] type
         val arrayData = row.getArray(colIndex)
         (0 until arrayData.numElements())
           .map(i => arrayData.getFloat(i))
           .toArray
 
       case BinaryType =>
-        // Binary type (for FixedSizeBinary float vectors)
-        val bytes = row.getBinary(colIndex)
-        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+        MilvusLoonPartitionReader.decodeBinaryTypeVectorForSearch(
+          row.getBinary(colIndex),
+          sourceSchema(colIndex)
+        )
 
       case _ =>
         throw new IllegalArgumentException(

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -24,10 +24,10 @@ import org.apache.spark.sql.types.{
   StructType
 }
 
+import com.zilliz.spark.connector.{FloatConverter, MilvusOption}
 import com.zilliz.spark.connector.filter.VectorBruteForceSearch
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
-import com.zilliz.spark.connector.MilvusOption
 import io.milvus.grpc.schema.{CollectionSchema, DataType}
 import io.milvus.storage.{
   ArrowUtils,
@@ -79,10 +79,19 @@ object MilvusLoonPartitionReader {
     field.metadata
       .getLong(ArrowConverter.MilvusDataTypeMetadataKey)
       .toInt match {
-      case DataType.FloatVector.value | DataType.Float16Vector.value |
-          DataType.BFloat16Vector.value =>
+      case DataType.FloatVector.value =>
         val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
         (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+      case DataType.Float16Vector.value =>
+        bytes
+          .grouped(2)
+          .map(b => FloatConverter.fromFloat16Bytes(b.toSeq))
+          .toArray
+      case DataType.BFloat16Vector.value =>
+        bytes
+          .grouped(2)
+          .map(b => FloatConverter.fromBFloat16Bytes(b.toSeq))
+          .toArray
       case DataType.BinaryVector.value =>
         throw new IllegalArgumentException(
           "BinaryVector does not support vector.search.* dense-float metrics; use binary search utilities with Hamming/Jaccard instead"

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -66,6 +66,28 @@ object MilvusLoonPartitionReader {
       rowOffset: Long
   )
 
+  private[read] def validateVectorSearchField(
+      field: StructField,
+      metric: String
+  ): Unit = {
+    field.dataType match {
+      case BinaryType
+          if field.metadata.contains(
+            ArrowConverter.MilvusDataTypeMetadataKey
+          ) =>
+        field.metadata
+          .getLong(ArrowConverter.MilvusDataTypeMetadataKey)
+          .toInt match {
+          case DataType.BinaryVector.value =>
+            throw new IllegalArgumentException(
+              s"Vector column '${field.name}' uses BinaryVector storage and does not support vector.search.* dense-float metric '$metric'; use binary search utilities with Hamming/Jaccard instead"
+            )
+          case _ =>
+        }
+      case _ =>
+    }
+  }
+
   private[read] def decodeBinaryTypeVectorForSearch(
       bytes: Array[Byte],
       field: StructField
@@ -409,6 +431,11 @@ class MilvusLoonPartitionReader(
             s"Vector column '$vecCol' not found in schema: ${sourceSchema.fieldNames.mkString(", ")}"
           )
       }
+
+    MilvusLoonPartitionReader.validateVectorSearchField(
+      sourceSchema(vectorColIndex),
+      metric
+    )
 
     // Use priority queue to maintain top-K
     // For L2: min-heap (smaller distance is better, so we keep max at top to evict)

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -685,17 +685,21 @@ object MilvusSnapshotReader {
       .filterNot(f =>
         !includeSystemFields && (f.name == "RowID" || f.name == "Timestamp")
       )
-      .map { field =>
-        StructField(
-          field.name,
-          dataTypeToSparkType(field.dataType, field.elementType),
-          nullable = field.nullable.getOrElse(true),
-          metadata = new MetadataBuilder()
-            .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType)
-            .build()
-        )
-      }
+      .map(fieldToStructField)
     StructType(userFields)
+  }
+
+  /** Convert a Field to Spark StructField with Milvus metadata preserved.
+    */
+  def fieldToStructField(field: Field): StructField = {
+    StructField(
+      field.name,
+      dataTypeToSparkType(field.dataType, field.elementType),
+      nullable = field.nullable.getOrElse(true),
+      metadata = new MetadataBuilder()
+        .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType)
+        .build()
+    )
   }
 
   /** Convert a Field to Spark DataType
@@ -706,7 +710,7 @@ object MilvusSnapshotReader {
     *   Corresponding Spark DataType
     */
   def fieldToSparkType(field: Field): DataType = {
-    dataTypeToSparkType(field.dataType, field.elementType)
+    fieldToStructField(field).dataType
   }
 
   /** Convert Milvus data type to Spark DataType

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -737,12 +737,12 @@ object MilvusSnapshotReader {
       case 24  => StringType // Geometry
       case 25  => StringType // Text
       case 26  => LongType // Timestamptz
-      case 100 => ArrayType(ByteType) // BinaryVector
+      case 100 => BinaryType // BinaryVector
       case 101 => ArrayType(FloatType) // FloatVector
       case 102 => ArrayType(FloatType) // Float16Vector
       case 103 => ArrayType(FloatType) // BFloat16Vector
       case 104 => MapType(LongType, FloatType) // SparseFloatVector
-      case 105 => ArrayType(ByteType) // Int8Vector
+      case 105 => ArrayType(ShortType) // Int8Vector
       case _   => BinaryType // Unknown types as binary
     }
   }

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -216,6 +216,10 @@ object ArrowConverter extends Logging {
                   s"FixedSizeBinary binary vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
                 )
             }
+          case other =>
+            throw new IllegalArgumentException(
+              s"Cannot decode ${other.getClass.getSimpleName} as BinaryType"
+            )
         }
 
       case MapType(keyType, valueType, _) =>

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -1,6 +1,11 @@
 package com.zilliz.spark.connector.serde
 
 import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.{
+  CharacterCodingException,
+  CodingErrorAction,
+  StandardCharsets
+}
 import scala.collection.JavaConverters._
 
 import org.apache.arrow.vector._
@@ -101,6 +106,9 @@ object ArrowConverter extends Logging {
       case IntegerType =>
         vector.asInstanceOf[IntVector].get(rowIndex)
 
+      case ByteType =>
+        vector.asInstanceOf[TinyIntVector].get(rowIndex)
+
       case ShortType =>
         vector.asInstanceOf[SmallIntVector].get(rowIndex)
 
@@ -114,18 +122,39 @@ object ArrowConverter extends Logging {
         vector.asInstanceOf[BitVector].get(rowIndex) != 0
 
       case StringType =>
-        val bytes = vector.asInstanceOf[VarCharVector].get(rowIndex)
-        UTF8String.fromBytes(bytes)
+        utf8StringFromVariableWidth(vector, rowIndex)
 
       case ArrayType(ByteType, _)
           if vector.isInstanceOf[FixedSizeBinaryVector] =>
         val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
-        ArrayData.toArrayData(bytes)
+        milvusType match {
+          case Some(MilvusDataType.BinaryVector) =>
+            ArrayData.toArrayData(bytes)
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot decode FixedSizeBinary as Array[Byte] for Milvus type $other"
+            )
+          case None =>
+            throw new IllegalArgumentException(
+              s"FixedSizeBinary byte vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
+            )
+        }
 
       case ArrayType(ShortType, _)
           if vector.isInstanceOf[FixedSizeBinaryVector] =>
         val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
-        ArrayData.toArrayData(bytes.map(_.toShort))
+        milvusType match {
+          case Some(MilvusDataType.Int8Vector) =>
+            ArrayData.toArrayData(bytes.map(_.toShort))
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot decode FixedSizeBinary as Array[Short] for Milvus type $other"
+            )
+          case None =>
+            throw new IllegalArgumentException(
+              s"FixedSizeBinary short vectors require ${MilvusDataTypeMetadataKey} metadata"
+            )
+        }
 
       case ArrayType(FloatType, _)
           if vector.isInstanceOf[FixedSizeBinaryVector] =>
@@ -171,8 +200,23 @@ object ArrowConverter extends Logging {
         ArrayData.toArrayData(arrayElements)
 
       case BinaryType =>
-        val bytes = vector.asInstanceOf[VarBinaryVector].get(rowIndex)
-        bytes
+        vector match {
+          case v: VarBinaryVector =>
+            v.get(rowIndex)
+          case v: FixedSizeBinaryVector =>
+            milvusType match {
+              case Some(MilvusDataType.BinaryVector) =>
+                v.get(rowIndex)
+              case Some(other) =>
+                throw new IllegalArgumentException(
+                  s"Cannot decode FixedSizeBinary as BinaryType for Milvus type $other"
+                )
+              case None =>
+                throw new IllegalArgumentException(
+                  s"FixedSizeBinary binary vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
+                )
+            }
+        }
 
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]
@@ -213,6 +257,37 @@ object ArrowConverter extends Logging {
       .filter(_.contains(MilvusDataTypeMetadataKey))
       .map(_.getLong(MilvusDataTypeMetadataKey).toInt)
       .map(MilvusDataType.fromValue)
+  }
+
+  private def utf8StringFromVariableWidth(
+      vector: FieldVector,
+      rowIndex: Int
+  ): UTF8String = {
+    val bytes = vector match {
+      case v: VarCharVector =>
+        v.get(rowIndex)
+      case v: VarBinaryVector =>
+        val bytes = v.get(rowIndex)
+        try {
+          StandardCharsets.UTF_8
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes))
+        } catch {
+          case e: CharacterCodingException =>
+            throw new IllegalArgumentException(
+              s"Arrow VarBinary value in column ${vector.getName} at row $rowIndex is not valid UTF-8",
+              e
+            )
+        }
+        bytes
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Cannot decode ${vector.getClass.getSimpleName} as StringType"
+        )
+    }
+    UTF8String.fromBytes(bytes)
   }
 
   private def decodeFixedSizeBinaryFloats(

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -95,7 +95,7 @@ object DataTypeUtil {
       case MilvusDataType.FloatVector =>
         DataTypes.createArrayType(DataTypes.FloatType)
       case MilvusDataType.BinaryVector =>
-        DataTypes.createArrayType(DataTypes.BinaryType)
+        DataTypes.BinaryType
       case MilvusDataType.Int8Vector =>
         DataTypes.createArrayType(DataTypes.ShortType)
       case MilvusDataType.Float16Vector =>

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{
   DataTypes => SparkDataTypes,
   LongType,
+  MetadataBuilder,
   StringType,
   StructField,
   StructType
@@ -67,6 +68,7 @@ import com.zilliz.spark.connector.read.{
   V2SegmentInfo,
   V2SegmentLoader
 }
+import com.zilliz.spark.connector.serde.ArrowConverter
 import com.zilliz.spark.connector.write.{MilvusWrite, MilvusWriteBuilder}
 import io.milvus.grpc.schema.CollectionSchema
 
@@ -329,6 +331,35 @@ case class MilvusTable(
 
   override def name(): String = milvusOption.collectionName
 
+  private def rehydrateSnapshotSchemaMetadata(
+      baseSchema: StructType
+  ): StructType = {
+    val fieldTypeByName = milvusCollection.schema.fields.map { field =>
+      field.name -> field.dataType.value.toLong
+    }.toMap
+
+    val fields = baseSchema.fields.map { field =>
+      if (
+        milvusOption.extraColumns.contains(field.name) ||
+        field.metadata.contains(ArrowConverter.MilvusDataTypeMetadataKey)
+      ) {
+        field
+      } else {
+        fieldTypeByName.get(field.name) match {
+          case Some(milvusType) =>
+            val metadataBuilder = new MetadataBuilder()
+              .withMetadata(field.metadata)
+              .putLong(ArrowConverter.MilvusDataTypeMetadataKey, milvusType)
+            field.copy(metadata = metadataBuilder.build())
+          case None =>
+            field
+        }
+      }
+    }
+
+    StructType(fields)
+  }
+
   private def appendExtraColumns(
       baseSchema: StructType,
       rejectLegacyAliases: Boolean
@@ -398,7 +429,10 @@ case class MilvusTable(
       logInfo(
         s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
       )
-      return appendExtraColumns(sparkSchema.get, rejectLegacyAliases = true)
+      return appendExtraColumns(
+        rehydrateSnapshotSchemaMetadata(sparkSchema.get),
+        rejectLegacyAliases = true
+      )
     }
 
     // Client-based mode or snapshot mode without provided schema: compute from milvusCollection

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -220,14 +220,31 @@ case class MilvusTable(
     // Use first partition ID if available
     partitionID = partitionIds.headOption.getOrElse(0L)
 
-    // Try to build schema from snapshot JSON if provided
-    val schemaJson = milvusOption.options.get(MilvusOption.SnapshotSchemaJson)
-    val snapshotSchema = schemaJson.flatMap { json =>
-      MilvusSnapshotReader.parseSnapshotMetadata(json) match {
-        case Right(metadata) => Some(metadata.collection.schema)
-        case Left(_)         => None
+    val snapshotSchema = milvusOption.options
+      .get(MilvusOption.SnapshotSchemaJson)
+      .flatMap { json =>
+        MilvusSnapshotReader.parseSnapshotMetadata(json) match {
+          case Right(metadata) =>
+            Try {
+              CollectionSchema.parseFrom(
+                MilvusSnapshotReader.toProtobufSchemaBytes(
+                  metadata.collection.schema
+                )
+              )
+            }.toOption
+          case Left(_) => None
+        }
       }
-    }
+      .orElse {
+        milvusOption.options.get(MilvusOption.SnapshotSchemaBytes).flatMap {
+          base64 =>
+            Try {
+              CollectionSchema.parseFrom(
+                Base64.getDecoder.decode(base64)
+              )
+            }.toOption
+        }
+      }
 
     // Create a minimal MilvusCollectionInfo
     // For snapshot mode, we use the passed-in sparkSchema for actual schema operations
@@ -247,24 +264,14 @@ case class MilvusTable(
     * have snapshot data but need a protobuf schema structure
     */
   private def createMinimalCollectionSchema(
-      snapshotSchema: Option[com.zilliz.spark.connector.read.CollectionSchema]
+      snapshotSchema: Option[CollectionSchema]
   ): CollectionSchema = {
-    import io.milvus.grpc.schema.{CollectionSchema => ProtoCollectionSchema}
-
-    snapshotSchema match {
-      case Some(schema) =>
-        ProtoCollectionSchema.parseFrom(
-          MilvusSnapshotReader.toProtobufSchemaBytes(schema)
-        )
-
-      case None =>
-        // If no schema provided, create empty schema
-        // The actual schema will come from sparkSchema passed to the table
-        ProtoCollectionSchema(
-          name = milvusOption.collectionName,
-          description = "",
-          fields = Seq.empty
-        )
+    snapshotSchema.getOrElse {
+      CollectionSchema(
+        name = milvusOption.collectionName,
+        description = "",
+        fields = Seq.empty
+      )
     }
   }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -222,28 +222,11 @@ case class MilvusTable(
 
     val snapshotSchema = milvusOption.options
       .get(MilvusOption.SnapshotSchemaJson)
-      .flatMap { json =>
-        MilvusSnapshotReader.parseSnapshotMetadata(json) match {
-          case Right(metadata) =>
-            Try {
-              CollectionSchema.parseFrom(
-                MilvusSnapshotReader.toProtobufSchemaBytes(
-                  metadata.collection.schema
-                )
-              )
-            }.toOption
-          case Left(_) => None
-        }
-      }
+      .map(parseSnapshotSchemaJson)
       .orElse {
-        milvusOption.options.get(MilvusOption.SnapshotSchemaBytes).flatMap {
-          base64 =>
-            Try {
-              CollectionSchema.parseFrom(
-                Base64.getDecoder.decode(base64)
-              )
-            }.toOption
-        }
+        milvusOption.options
+          .get(MilvusOption.SnapshotSchemaBytes)
+          .map(parseSnapshotSchemaBytes)
       }
 
     // Create a minimal MilvusCollectionInfo
@@ -263,6 +246,31 @@ case class MilvusTable(
   /** Create a minimal CollectionSchema for snapshot mode This is used when we
     * have snapshot data but need a protobuf schema structure
     */
+  private def parseSnapshotSchemaJson(json: String): CollectionSchema = {
+    MilvusSnapshotReader.parseSnapshotMetadata(json) match {
+      case Right(metadata) =>
+        CollectionSchema.parseFrom(
+          MilvusSnapshotReader.toProtobufSchemaBytes(metadata.collection.schema)
+        )
+      case Left(err) =>
+        throw new IllegalArgumentException(
+          s"Failed to parse ${MilvusOption.SnapshotSchemaJson}: $err"
+        )
+    }
+  }
+
+  private def parseSnapshotSchemaBytes(base64: String): CollectionSchema = {
+    try {
+      CollectionSchema.parseFrom(Base64.getDecoder.decode(base64))
+    } catch {
+      case NonFatal(e) =>
+        throw new IllegalArgumentException(
+          s"Failed to parse ${MilvusOption.SnapshotSchemaBytes}: ${e.getMessage}",
+          e
+        )
+    }
+  }
+
   private def createMinimalCollectionSchema(
       snapshotSchema: Option[CollectionSchema]
   ): CollectionSchema = {

--- a/src/main/scala/write/MilvusInsertDataWriter.scala
+++ b/src/main/scala/write/MilvusInsertDataWriter.scala
@@ -425,9 +425,26 @@ object MilvusInsertDataWriter {
               )
           }
         case MilvusDataType.BinaryVector =>
+          val sparkField: StructField = sparkSchema(fieldIndex)
+          val binaryVector = sparkField.dataType match {
+            case SparkDataTypes.BinaryType =>
+              row.getBinary(fieldIndex)
+            case arrayType: ArrayType =>
+              arrayType.elementType match {
+                case SparkDataTypes.ByteType =>
+                  row.getArray(fieldIndex).toByteArray()
+                case _ =>
+                  throw new DataTypeException(
+                    s"Unsupported data type: ${sparkField.dataType}, field name: ${fieldName}, element type: ${arrayType.elementType}"
+                  )
+              }
+            case _ =>
+              throw new DataTypeException(
+                s"Unsupported data type: ${sparkField.dataType}, field name: ${fieldName}"
+              )
+          }
           buffer(fieldName)
-            .asInstanceOf[ArrayBuffer[Array[Byte]]] += row
-            .getBinary(fieldIndex)
+            .asInstanceOf[ArrayBuffer[Array[Byte]]] += binaryVector
         case MilvusDataType.Int8Vector =>
           buffer(fieldName)
             .asInstanceOf[ArrayBuffer[Array[Short]]] += row

--- a/src/main/scala/write/MilvusInsertDataWriter.scala
+++ b/src/main/scala/write/MilvusInsertDataWriter.scala
@@ -427,8 +427,7 @@ object MilvusInsertDataWriter {
         case MilvusDataType.BinaryVector =>
           buffer(fieldName)
             .asInstanceOf[ArrayBuffer[Array[Byte]]] += row
-            .getArray(fieldIndex)
-            .toByteArray()
+            .getBinary(fieldIndex)
         case MilvusDataType.Int8Vector =>
           buffer(fieldName)
             .asInstanceOf[ArrayBuffer[Array[Short]]] += row

--- a/src/test/scala/filter/VectorBruteForceSearchTest.scala
+++ b/src/test/scala/filter/VectorBruteForceSearchTest.scala
@@ -1,14 +1,38 @@
 package com.zilliz.spark.connector.filter
 
 import org.apache.spark.ml.linalg.{DenseVector, Vectors}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.types.BinaryType
+import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+import com.zilliz.spark.connector.expressions.HammingDistanceExpression
 
 import VectorBruteForceSearch.DistanceType._
 
 /** Unit tests for VectorBruteForceSearch distance calculations
   */
-class VectorBruteForceSearchTest extends AnyFunSuite with Matchers {
+class VectorBruteForceSearchTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("VectorBruteForceSearchTest")
+      .master("local[*]")
+      .getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
 
   // Tolerance for floating point comparisons
   val epsilon = 1e-6
@@ -273,5 +297,38 @@ class VectorBruteForceSearchTest extends AnyFunSuite with Matchers {
         similarity should be <= 1.0 + epsilon
       }
     }
+  }
+
+  test("filterSimilarVectors accepts BinaryType columns") {
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    val df = Seq(
+      (1L, Array[Byte](0x00.toByte, 0x0f.toByte)),
+      (2L, Array[Byte](0x00.toByte, 0xf0.toByte))
+    ).toDF("id", "vector")
+
+    df.schema("vector").dataType shouldBe BinaryType
+
+    val result = VectorBruteForceSearch.filterSimilarVectors(
+      df = df,
+      queryVector = Array[Byte](0x00.toByte, 0x0f.toByte),
+      k = 2,
+      threshold = 16.0,
+      vectorCol = "vector",
+      idCol = Some("id"),
+      distanceType = HAMMING
+    )
+
+    result.count() shouldBe 2L
+    result.schema("vector").dataType shouldBe BinaryType
+  }
+
+  test("HammingDistanceExpression accepts raw byte arrays") {
+    val expr = HammingDistanceExpression(Literal(1), Literal(2))
+    expr.nullSafeEval(
+      Array[Byte](0x00.toByte, 0x0f.toByte),
+      Array[Byte](0x00.toByte, 0xf0.toByte)
+    ) shouldBe 8.0
   }
 }

--- a/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
@@ -1,0 +1,142 @@
+package com.zilliz.spark.connector.read
+
+import org.apache.spark.sql.types.{
+  BinaryType,
+  MetadataBuilder,
+  StructField,
+  StructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.zilliz.spark.connector.serde.ArrowConverter
+import com.zilliz.spark.connector.FloatConverter
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
+
+class MilvusLoonPartitionReaderTest extends AnyFunSuite {
+  test("buildFieldNameToId exposes non-conflicting system aliases") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+
+    val mapping = MilvusLoonPartitionReader.buildFieldNameToId(schema)
+
+    assert(mapping("RowID") == 0L)
+    assert(mapping("row_id") == 0L)
+    assert(mapping("rowid") == 0L)
+    assert(mapping("Timestamp") == 1L)
+    assert(mapping("timestamp") == 1L)
+    assert(mapping("pk") == 100L)
+  }
+
+  test("buildFieldNameToId preserves user fields that use system alias names") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "Timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        ),
+        FieldSchema(name = "rowid", fieldID = 102, dataType = DataType.Int64)
+      )
+    )
+
+    val mapping = MilvusLoonPartitionReader.buildFieldNameToId(schema)
+
+    assert(mapping("RowID") == 100L)
+    assert(mapping("Timestamp") == 101L)
+    assert(mapping("rowid") == 102L)
+    assert(mapping("row_id") == 0L)
+    assert(mapping("timestamp") == 1L)
+  }
+
+  test("validateVectorSearchField rejects BinaryVector dense search") {
+    val field = StructField(
+      "binary_vec",
+      BinaryType,
+      nullable = true,
+      metadata = new MetadataBuilder()
+        .putLong(
+          ArrowConverter.MilvusDataTypeMetadataKey,
+          DataType.BinaryVector.value.toLong
+        )
+        .build()
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      MilvusLoonPartitionReader.validateVectorSearchField(field, "L2")
+    }
+
+    assert(err.getMessage.contains("binary_vec"))
+    assert(err.getMessage.contains("BinaryVector"))
+    assert(err.getMessage.contains("Hamming/Jaccard"))
+  }
+
+  test("decodeBinaryTypeVectorForSearch rejects BinaryVector metadata") {
+    val field = StructField(
+      "binary_vec",
+      BinaryType,
+      nullable = true,
+      metadata = new MetadataBuilder()
+        .putLong(
+          ArrowConverter.MilvusDataTypeMetadataKey,
+          DataType.BinaryVector.value.toLong
+        )
+        .build()
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      MilvusLoonPartitionReader.decodeBinaryTypeVectorForSearch(
+        Array[Byte](1, 2, 3, 4),
+        field
+      )
+    }
+
+    assert(err.getMessage.contains("BinaryVector"))
+    assert(err.getMessage.contains("Hamming/Jaccard"))
+  }
+
+  test("decodeBinaryTypeVectorForSearch decodes Float16Vector bytes") {
+    val field = StructField(
+      "fp16_vec",
+      BinaryType,
+      nullable = true,
+      metadata = new MetadataBuilder()
+        .putLong(
+          ArrowConverter.MilvusDataTypeMetadataKey,
+          DataType.Float16Vector.value.toLong
+        )
+        .build()
+    )
+    val bytes = FloatConverter.toFloat16Bytes(1.5f).toArray ++
+      FloatConverter.toFloat16Bytes(-2.0f).toArray
+
+    val decoded =
+      MilvusLoonPartitionReader.decodeBinaryTypeVectorForSearch(bytes, field)
+
+    assert(decoded.sameElements(Array(1.5f, -2.0f)))
+  }
+
+  test("decodeBinaryTypeVectorForSearch decodes BFloat16Vector bytes") {
+    val field = StructField(
+      "bf16_vec",
+      BinaryType,
+      nullable = true,
+      metadata = new MetadataBuilder()
+        .putLong(
+          ArrowConverter.MilvusDataTypeMetadataKey,
+          DataType.BFloat16Vector.value.toLong
+        )
+        .build()
+    )
+    val bytes = FloatConverter.toBFloat16Bytes(1.5f).toArray ++
+      FloatConverter.toBFloat16Bytes(-2.0f).toArray
+
+    val decoded =
+      MilvusLoonPartitionReader.decodeBinaryTypeVectorForSearch(bytes, field)
+
+    assert(decoded.sameElements(Array(1.5f, -2.0f)))
+  }
+}

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -646,4 +646,58 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     )
     sparkSchema("tags").nullable shouldBe true
   }
+
+  test("toSparkSchema maps BinaryVector and Int8Vector consistently") {
+    import org.apache.spark.sql.types.{ArrayType, BinaryType, ShortType}
+
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "binary_vec",
+              "data_type": "BinaryVector",
+              "type_params": [{"key": "dim", "value": "128"}]
+            },
+            {
+              "fieldID": 101,
+              "name": "int8_vec",
+              "data_type": "Int8Vector",
+              "type_params": [{"key": "dim", "value": "4"}]
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val schema = MilvusSnapshotReader
+      .parseSnapshotMetadata(json)
+      .toOption
+      .get
+      .collection
+      .schema
+    val sparkSchema = MilvusSnapshotReader.toSparkSchema(schema)
+
+    sparkSchema("binary_vec").dataType shouldBe BinaryType
+    sparkSchema("binary_vec").metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
+    ) shouldBe 100L
+    sparkSchema("int8_vec").dataType shouldBe ArrayType(ShortType)
+    sparkSchema("int8_vec").metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
+    ) shouldBe 105L
+  }
 }

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -700,4 +700,22 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
       com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
     ) shouldBe 105L
   }
+
+  test("fieldToStructField preserves milvus.data_type metadata") {
+    val field = Field(
+      name = "binary_vec",
+      rawDataType =
+        Some(com.fasterxml.jackson.databind.node.IntNode.valueOf(100)),
+      nullable = Some(false)
+    )
+
+    val structField = MilvusSnapshotReader.fieldToStructField(field)
+
+    structField.name shouldBe "binary_vec"
+    structField.dataType shouldBe org.apache.spark.sql.types.BinaryType
+    structField.nullable shouldBe false
+    structField.metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
+    ) shouldBe 100L
+  }
 }

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -1,0 +1,509 @@
+package com.zilliz.spark.connector.serde
+
+import scala.collection.JavaConverters._
+
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.{
+  FixedSizeBinaryVector,
+  VarBinaryVector,
+  VarCharVector,
+  VectorSchemaRoot
+}
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.types.{
+  ArrayType,
+  BinaryType,
+  ByteType,
+  FloatType,
+  MetadataBuilder,
+  ShortType,
+  StringType,
+  StructField,
+  StructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.zilliz.spark.connector.FloatConverter
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
+
+class ArrowConverterTest extends AnyFunSuite with Matchers {
+
+  private def withFixedSizeBinaryRoot(
+      name: String,
+      byteWidth: Int,
+      bytes: Array[Byte]
+  )(check: VectorSchemaRoot => Unit): Unit = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val schema = new Schema(
+        Seq(
+          new Field(
+            name,
+            FieldType.nullable(new ArrowType.FixedSizeBinary(byteWidth)),
+            null
+          )
+        ).asJava
+      )
+      val root = VectorSchemaRoot.create(schema, allocator)
+      try {
+        val vector = root.getVector(name).asInstanceOf[FixedSizeBinaryVector]
+        vector.allocateNew(1)
+        vector.setSafe(0, bytes)
+        vector.setValueCount(1)
+        root.setRowCount(1)
+        check(root)
+      } finally root.close()
+    } finally allocator.close()
+  }
+
+  private def withVariableWidthRoot(
+      name: String,
+      arrowType: ArrowType,
+      bytes: Array[Byte]
+  )(check: VectorSchemaRoot => Unit): Unit = {
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val schema = new Schema(
+        Seq(new Field(name, FieldType.nullable(arrowType), null)).asJava
+      )
+      val root = VectorSchemaRoot.create(schema, allocator)
+      try {
+        root.getVector(name) match {
+          case vector: VarBinaryVector =>
+            vector.allocateNew()
+            vector.setSafe(0, bytes)
+            vector.setValueCount(1)
+          case vector: VarCharVector =>
+            vector.allocateNew()
+            vector.setSafe(0, bytes)
+            vector.setValueCount(1)
+          case other =>
+            throw new IllegalArgumentException(
+              s"Unexpected vector type ${other.getClass.getSimpleName}"
+            )
+        }
+        root.setRowCount(1)
+        check(root)
+      } finally root.close()
+    } finally allocator.close()
+  }
+
+  private def vectorField(
+      name: String,
+      sparkType: org.apache.spark.sql.types.DataType,
+      milvusType: MilvusDataType
+  ): StructField = {
+    StructField(
+      name,
+      sparkType,
+      nullable = true,
+      metadata = new MetadataBuilder()
+        .putLong(ArrowConverter.MilvusDataTypeMetadataKey, milvusType.value)
+        .build()
+    )
+  }
+
+  test("arrowToInternalRow reads BinaryVector fixed-size bytes") {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(vectorField("binary", BinaryType, MilvusDataType.BinaryVector))
+        )
+      )
+      row.getBinary(0) shouldBe bytes
+    }
+  }
+
+  test("arrowToInternalRow decodes valid UTF-8 from VarBinary as StringType") {
+    val bytes = "hello, 世界".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    withVariableWidthRoot("text", new ArrowType.Binary(), bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(Seq(StructField("text", StringType)))
+      )
+      row.getUTF8String(0).toString shouldBe "hello, 世界"
+    }
+  }
+
+  test(
+    "arrowToInternalRow rejects invalid UTF-8 from VarBinary as StringType"
+  ) {
+    val bytes = Array[Byte](0xc3.toByte, 0x28.toByte)
+    withVariableWidthRoot("text", new ArrowType.Binary(), bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(Seq(StructField("text", StringType)))
+        )
+      }
+      err.getMessage should include("not valid UTF-8")
+    }
+  }
+
+  test(
+    "arrowToInternalRow rejects BinaryType for FloatVector fixed-size bytes"
+  ) {
+    val bytes = java.nio.ByteBuffer
+      .allocate(8)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.5f)
+      .putFloat(-2.0f)
+      .array()
+    withFixedSizeBinaryRoot("float", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(
+            Seq(vectorField("float", BinaryType, MilvusDataType.FloatVector))
+          )
+        )
+      }
+      err.getMessage should include("BinaryType")
+    }
+  }
+
+  test(
+    "arrowToInternalRow rejects Array[Short] for BinaryVector fixed-size bytes"
+  ) {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(
+            Seq(
+              vectorField(
+                "binary",
+                ArrayType(ShortType),
+                MilvusDataType.BinaryVector
+              )
+            )
+          )
+        )
+      }
+      err.getMessage should include("Array[Short]")
+    }
+  }
+
+  test(
+    "arrowToInternalRow rejects Array[Byte] for Int8Vector fixed-size bytes"
+  ) {
+    val bytes = Array[Byte](-128, -1, 0, 127)
+    withFixedSizeBinaryRoot("int8", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(
+            Seq(
+              vectorField(
+                "int8",
+                ArrayType(ByteType),
+                MilvusDataType.Int8Vector
+              )
+            )
+          )
+        )
+      }
+      err.getMessage should include("Array[Byte]")
+    }
+  }
+
+  test(
+    "arrowToInternalRow rejects Array[Float] for BinaryVector fixed-size bytes"
+  ) {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(
+            Seq(
+              vectorField(
+                "binary",
+                ArrayType(FloatType),
+                MilvusDataType.BinaryVector
+              )
+            )
+          )
+        )
+      }
+      err.getMessage should include("Array[Float]")
+    }
+  }
+
+  test("arrowToInternalRow rejects BinaryType without BinaryVector metadata") {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(Seq(StructField("binary", BinaryType)))
+        )
+      }
+      err.getMessage should include("BinaryVector")
+    }
+  }
+
+  test("arrowToInternalRow rejects Array[Byte] without fixed-size metadata") {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(Seq(StructField("binary", ArrayType(ByteType))))
+        )
+      }
+      err.getMessage should include(ArrowConverter.MilvusDataTypeMetadataKey)
+    }
+  }
+
+  test("arrowToInternalRow decodes UTF-8 from VarChar as StringType") {
+    val bytes = "hello".getBytes(java.nio.charset.StandardCharsets.UTF_8)
+    withVariableWidthRoot("text", new ArrowType.Utf8(), bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(Seq(StructField("text", StringType)))
+      )
+      row.getUTF8String(0).toString shouldBe "hello"
+    }
+  }
+
+  test("arrowToInternalRow reads VarBinary as BinaryType") {
+    val bytes = Array[Byte](1, 2, 3, 4)
+    withVariableWidthRoot("blob", new ArrowType.Binary(), bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(Seq(StructField("blob", BinaryType)))
+      )
+      row.getBinary(0) shouldBe bytes
+    }
+  }
+
+  test("arrowToInternalRow reads ByteType from TinyIntVector") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val schema = new Schema(
+        Seq(
+          new Field(
+            "tiny",
+            FieldType.nullable(new ArrowType.Int(8, true)),
+            null
+          )
+        ).asJava
+      )
+      val root = VectorSchemaRoot.create(schema, allocator)
+      try {
+        val vector = root
+          .getVector("tiny")
+          .asInstanceOf[org.apache.arrow.vector.TinyIntVector]
+        vector.allocateNew(1)
+        vector.setSafe(0, 7.toByte)
+        vector.setValueCount(1)
+        root.setRowCount(1)
+        val row = ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(Seq(StructField("tiny", ByteType)))
+        )
+        row.getByte(0) shouldBe 7.toByte
+      } finally root.close()
+    } finally allocator.close()
+  }
+
+  test("arrowToInternalRow rejects unsupported BinaryType vector clearly") {
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val schema = new Schema(
+        Seq(
+          new Field(
+            "bad",
+            FieldType.nullable(new ArrowType.Int(32, true)),
+            null
+          )
+        ).asJava
+      )
+      val root = VectorSchemaRoot.create(schema, allocator)
+      try {
+        val vector = root
+          .getVector("bad")
+          .asInstanceOf[org.apache.arrow.vector.IntVector]
+        vector.allocateNew(1)
+        vector.setSafe(0, 42)
+        vector.setValueCount(1)
+        root.setRowCount(1)
+        val err = intercept[IllegalArgumentException] {
+          ArrowConverter.arrowToInternalRow(
+            root,
+            0,
+            StructType(Seq(StructField("bad", BinaryType)))
+          )
+        }
+        err.getMessage should include("IntVector")
+      } finally root.close()
+    } finally allocator.close()
+  }
+
+  test(
+    "arrowToInternalRow keeps legacy Array[Byte] BinaryVector fixed-size decoding"
+  ) {
+    val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
+    withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "binary",
+              ArrayType(ByteType),
+              MilvusDataType.BinaryVector
+            )
+          )
+        )
+      )
+      row.getArray(0).toByteArray() shouldBe bytes
+    }
+  }
+
+  test("arrowToInternalRow decodes Float16Vector fixed-size bytes") {
+    val bytes = FloatConverter.toFloat16Bytes(1.5f).toArray ++
+      FloatConverter.toFloat16Bytes(-2.0f).toArray
+    withFixedSizeBinaryRoot("float16", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "float16",
+              ArrayType(FloatType),
+              MilvusDataType.Float16Vector
+            )
+          )
+        )
+      )
+      val out = row.getArray(0).toFloatArray
+      out(0) shouldBe 1.5f
+      out(1) shouldBe -2.0f
+    }
+  }
+
+  test("arrowToInternalRow decodes BFloat16Vector fixed-size bytes") {
+    val bytes = FloatConverter.toBFloat16Bytes(1.5f).toArray ++
+      FloatConverter.toBFloat16Bytes(-2.0f).toArray
+    withFixedSizeBinaryRoot("bfloat16", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "bfloat16",
+              ArrayType(FloatType),
+              MilvusDataType.BFloat16Vector
+            )
+          )
+        )
+      )
+      val out = row.getArray(0).toFloatArray
+      out(0) shouldBe 1.5f
+      out(1) shouldBe -2.0f
+    }
+  }
+
+  test("arrowToInternalRow reads Int8Vector fixed-size bytes as shorts") {
+    val bytes = Array[Byte](-128, -1, 0, 127)
+    withFixedSizeBinaryRoot("int8", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "int8",
+              ArrayType(ShortType),
+              MilvusDataType.Int8Vector
+            )
+          )
+        )
+      )
+      row.getArray(0).toShortArray shouldBe bytes.map(_.toShort)
+    }
+  }
+
+  test("arrowValueToSparkValue keeps legacy FloatVector fixed-size decoding") {
+    val bytes = java.nio.ByteBuffer
+      .allocate(8)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.5f)
+      .putFloat(-2.0f)
+      .array()
+    withFixedSizeBinaryRoot("float", bytes.length, bytes) { root =>
+      val vector = root.getVector("float").asInstanceOf[FixedSizeBinaryVector]
+      val out = ArrowConverter
+        .arrowValueToSparkValue(vector, 0, ArrayType(FloatType))
+        .asInstanceOf[ArrayData]
+        .toFloatArray
+      out shouldBe Array(1.5f, -2.0f)
+    }
+  }
+
+  test(
+    "arrowToInternalRow decodes FloatVector fixed-size bytes with metadata"
+  ) {
+    val bytes = java.nio.ByteBuffer
+      .allocate(8)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.5f)
+      .putFloat(-2.0f)
+      .array()
+    withFixedSizeBinaryRoot("float", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "float",
+              ArrayType(FloatType),
+              MilvusDataType.FloatVector
+            )
+          )
+        )
+      )
+      row.getArray(0).toFloatArray shouldBe Array(1.5f, -2.0f)
+    }
+  }
+
+  test(
+    "Float16Vector fixed-size bytes without metadata fail instead of corrupting"
+  ) {
+    val bytes = FloatConverter.toFloat16Bytes(1.5f).toArray ++
+      FloatConverter.toFloat16Bytes(-2.0f).toArray
+    withFixedSizeBinaryRoot("float16", bytes.length, bytes) { root =>
+      val err = intercept[IllegalArgumentException] {
+        ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(Seq(StructField("float16", ArrayType(FloatType))))
+        )
+      }
+      err.getMessage should include(ArrowConverter.MilvusDataTypeMetadataKey)
+    }
+  }
+}

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -201,6 +201,12 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
     result shouldBe DataTypes.createArrayType(DataTypes.FloatType)
   }
 
+  test("toDataType converts BinaryVector to Spark BinaryType") {
+    val fieldSchema = FieldSchema(dataType = MilvusDataType.BinaryVector)
+    val result = DataTypeUtil.toDataType(fieldSchema)
+    result shouldBe DataTypes.BinaryType
+  }
+
   test("toDataType converts Int8Vector to Spark Array[Short]") {
     val fieldSchema = FieldSchema(dataType = MilvusDataType.Int8Vector)
     val result = DataTypeUtil.toDataType(fieldSchema)

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -18,7 +18,18 @@ import org.apache.hadoop.fs.{
 import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.util.Progressable
 import org.apache.spark.sql.connector.read.InputPartition
-import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.types.{
+  ArrayType,
+  BinaryType,
+  ByteType,
+  FloatType,
+  LongType,
+  MetadataBuilder,
+  ShortType,
+  StringType,
+  StructField,
+  StructType
+}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
@@ -37,6 +48,7 @@ import com.zilliz.spark.connector.read.{
   V2ColumnGroup,
   V2SegmentInfo
 }
+import com.zilliz.spark.connector.serde.ArrowConverter
 
 class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   private val emptySchemaBytes = java.util.Base64.getEncoder.encodeToString(
@@ -57,16 +69,71 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  private val vectorSnapshotSchemaJson =
+    """
+      {
+        "snapshot-info": {
+          "name": "test",
+          "id": 1,
+          "collection_id": 10,
+          "partition_ids": [1],
+          "create_ts": 1
+        },
+        "collection": {
+          "schema": {
+            "name": "c",
+            "fields": [
+              {
+                "fieldID": 100,
+                "name": "binary_vec",
+                "data_type": "BinaryVector",
+                "type_params": [{"key": "dim", "value": "128"}]
+              },
+              {
+                "fieldID": 101,
+                "name": "float_vec",
+                "data_type": "FloatVector",
+                "type_params": [{"key": "dim", "value": "4"}]
+              },
+              {
+                "fieldID": 102,
+                "name": "int8_vec",
+                "data_type": "Int8Vector",
+                "type_params": [{"key": "dim", "value": "4"}]
+              },
+              {
+                "fieldID": 103,
+                "name": "json_payload",
+                "data_type": "JSON"
+              }
+            ]
+          }
+        },
+        "indexes": [],
+        "manifest-list": []
+      }
+    """
+
+  private def metadata(
+      entries: (String, Long)*
+  ): org.apache.spark.sql.types.Metadata = {
+    val builder = new MetadataBuilder()
+    entries.foreach { case (key, value) => builder.putLong(key, value) }
+    builder.build()
+  }
+
   private def snapshotTableSchema(
       baseSchema: StructType,
-      extraColumns: String
+      extraColumns: String,
+      snapshotSchemaJson: String = vectorSnapshotSchemaJson
   ): StructType = {
     val options = Map(
       MilvusOption.SnapshotMode -> "true",
       MilvusOption.SnapshotManifests -> "[]",
       MilvusOption.SnapshotCollectionId -> "10",
       MilvusOption.MilvusCollectionName -> "c",
-      MilvusOption.MilvusExtraColumns -> extraColumns
+      MilvusOption.MilvusExtraColumns -> extraColumns,
+      MilvusOption.SnapshotSchemaJson -> snapshotSchemaJson
     )
     MilvusTable(MilvusOption(options), Some(baseSchema)).schema()
   }
@@ -463,6 +530,101 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(err.getMessage.contains("segment_id"))
     assert(err.getMessage.contains("legacy alias"))
     assert(err.getMessage.contains("$segment_id"))
+  }
+
+  test(
+    "snapshot mode injects milvus.data_type metadata into provided external schema"
+  ) {
+    val schema = snapshotTableSchema(
+      StructType(
+        Seq(
+          StructField("binary_vec", BinaryType, nullable = true),
+          StructField("float_vec", ArrayType(FloatType), nullable = true),
+          StructField("int8_vec", ArrayType(ShortType), nullable = true),
+          StructField("json_payload", StringType, nullable = true)
+        )
+      ),
+      "partition"
+    )
+
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 100L
+    )
+    assert(
+      schema("float_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 101L
+    )
+    assert(
+      schema("int8_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 105L
+    )
+    assert(
+      schema("json_payload").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 23L
+    )
+    assert(schema.fieldNames.toSeq.last == "partition")
+  }
+
+  test(
+    "snapshot mode preserves caller metadata when injecting milvus.data_type"
+  ) {
+    val schema = snapshotTableSchema(
+      StructType(
+        Seq(
+          StructField(
+            "binary_vec",
+            BinaryType,
+            nullable = true,
+            metadata = metadata("custom.flag" -> 7L)
+          )
+        )
+      ),
+      ""
+    )
+
+    assert(schema("binary_vec").metadata.getLong("custom.flag") == 7L)
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 100L
+    )
+  }
+
+  test("snapshot mode does not overwrite existing milvus.data_type") {
+    val schema = snapshotTableSchema(
+      StructType(
+        Seq(
+          StructField(
+            "binary_vec",
+            BinaryType,
+            nullable = true,
+            metadata = metadata(
+              ArrowConverter.MilvusDataTypeMetadataKey -> 999L,
+              "custom.flag" -> 7L
+            )
+          ),
+          StructField("legacy_bytes", ArrayType(ByteType), nullable = true)
+        )
+      ),
+      ""
+    )
+
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 999L
+    )
+    assert(schema("binary_vec").metadata.getLong("custom.flag") == 7L)
+    assert(
+      !schema("legacy_bytes").metadata.contains(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      )
+    )
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -679,6 +679,34 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test("snapshot mode fails loudly on malformed snapshot schema json") {
+    val err = intercept[IllegalArgumentException] {
+      snapshotTableSchema(
+        StructType(Seq(StructField("binary_vec", BinaryType, nullable = true))),
+        extraColumns = "",
+        snapshotSchemaJson = Some("not-json"),
+        snapshotSchemaBytes = None
+      )
+    }
+
+    assert(err.getMessage.contains(MilvusOption.SnapshotSchemaJson))
+    assert(err.getMessage.contains("Failed to parse"))
+  }
+
+  test("snapshot mode fails loudly on malformed snapshot schema bytes") {
+    val err = intercept[IllegalArgumentException] {
+      snapshotTableSchema(
+        StructType(Seq(StructField("binary_vec", BinaryType, nullable = true))),
+        extraColumns = "",
+        snapshotSchemaJson = None,
+        snapshotSchemaBytes = Some("not-base64%%")
+      )
+    }
+
+    assert(err.getMessage.contains(MilvusOption.SnapshotSchemaBytes))
+    assert(err.getMessage.contains("Failed to parse"))
+  }
+
   test(
     "client-derived schema allows user fields named legacy metadata aliases"
   ) {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -114,6 +114,19 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       }
     """
 
+  private val vectorSnapshotSchemaBytes =
+    java.util.Base64.getEncoder.encodeToString(
+      MilvusSnapshotReader
+        .toProtobufSchemaBytes(
+          MilvusSnapshotReader
+            .parseSnapshotMetadata(vectorSnapshotSchemaJson)
+            .toOption
+            .get
+            .collection
+            .schema
+        )
+    )
+
   private def metadata(
       entries: (String, Long)*
   ): org.apache.spark.sql.types.Metadata = {
@@ -125,17 +138,23 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   private def snapshotTableSchema(
       baseSchema: StructType,
       extraColumns: String,
-      snapshotSchemaJson: String = vectorSnapshotSchemaJson
+      snapshotSchemaJson: Option[String] = Some(vectorSnapshotSchemaJson),
+      snapshotSchemaBytes: Option[String] = None
   ): StructType = {
-    val options = Map(
+    val options = scala.collection.mutable.Map(
       MilvusOption.SnapshotMode -> "true",
       MilvusOption.SnapshotManifests -> "[]",
       MilvusOption.SnapshotCollectionId -> "10",
       MilvusOption.MilvusCollectionName -> "c",
-      MilvusOption.MilvusExtraColumns -> extraColumns,
-      MilvusOption.SnapshotSchemaJson -> snapshotSchemaJson
+      MilvusOption.MilvusExtraColumns -> extraColumns
     )
-    MilvusTable(MilvusOption(options), Some(baseSchema)).schema()
+    snapshotSchemaJson.foreach(json =>
+      options += MilvusOption.SnapshotSchemaJson -> json
+    )
+    snapshotSchemaBytes.foreach(bytes =>
+      options += MilvusOption.SnapshotSchemaBytes -> bytes
+    )
+    MilvusTable(MilvusOption(options.toMap), Some(baseSchema)).schema()
   }
 
   test(
@@ -592,6 +611,39 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       schema("binary_vec").metadata.getLong(
         ArrowConverter.MilvusDataTypeMetadataKey
       ) == 100L
+    )
+  }
+
+  test(
+    "snapshot mode injects milvus.data_type metadata from snapshot schema bytes"
+  ) {
+    val schema = snapshotTableSchema(
+      StructType(
+        Seq(
+          StructField("binary_vec", BinaryType, nullable = true),
+          StructField("float_vec", ArrayType(FloatType), nullable = true),
+          StructField("int8_vec", ArrayType(ShortType), nullable = true)
+        )
+      ),
+      extraColumns = "",
+      snapshotSchemaJson = None,
+      snapshotSchemaBytes = Some(vectorSnapshotSchemaBytes)
+    )
+
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 100L
+    )
+    assert(
+      schema("float_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 101L
+    )
+    assert(
+      schema("int8_vec").metadata.getLong(
+        ArrowConverter.MilvusDataTypeMetadataKey
+      ) == 105L
     )
   }
 

--- a/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
+++ b/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
@@ -1,6 +1,10 @@
 package com.zilliz.spark.connector.write
 
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.expressions.{
+  GenericInternalRow,
+  UnsafeProjection
+}
+import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.funsuite.AnyFunSuite
@@ -265,16 +269,18 @@ class MilvusInsertDataWriterRetryTest extends AnyFunSuite with Matchers {
     }
   }
 
-  test("addDataToBuffer reads BinaryVector from Spark BinaryType") {
-    val schema = CollectionSchema(
-      fields = Seq(
-        FieldSchema(
-          name = "binary_vec",
-          dataType = DataType.BinaryVector,
-          typeParams = Seq(io.milvus.grpc.common.KeyValuePair("dim", "16"))
-        )
+  private def binaryVectorSchema = CollectionSchema(
+    fields = Seq(
+      FieldSchema(
+        name = "binary_vec",
+        dataType = DataType.BinaryVector,
+        typeParams = Seq(io.milvus.grpc.common.KeyValuePair("dim", "16"))
       )
     )
+  )
+
+  test("addDataToBuffer reads BinaryVector from Spark BinaryType") {
+    val schema = binaryVectorSchema
     val fieldMap = MilvusInsertDataWriter.getFieldMap(schema)
     val buffer = MilvusInsertDataWriter.newDataBuffer(schema)
     val sparkSchema = org.apache.spark.sql.types.StructType(
@@ -287,6 +293,46 @@ class MilvusInsertDataWriterRetryTest extends AnyFunSuite with Matchers {
       new GenericInternalRow(Array[Any](Array[Byte](0x01.toByte, 0x23.toByte)))
 
     MilvusInsertDataWriter.addDataToBuffer(buffer, row, fieldMap, sparkSchema)
+
+    val values = buffer("binary_vec")
+      .asInstanceOf[scala.collection.mutable.ArrayBuffer[Array[Byte]]]
+      .toSeq
+
+    values should have size 1
+    values.head shouldBe Array[Byte](0x01.toByte, 0x23.toByte)
+  }
+
+  test(
+    "addDataToBuffer reads BinaryVector from legacy ArrayType(ByteType) UnsafeRow"
+  ) {
+    val schema = binaryVectorSchema
+    val fieldMap = MilvusInsertDataWriter.getFieldMap(schema)
+    val buffer = MilvusInsertDataWriter.newDataBuffer(schema)
+    val sparkSchema = org.apache.spark.sql.types.StructType(
+      Seq(
+        org.apache.spark.sql.types.StructField(
+          "binary_vec",
+          org.apache.spark.sql.types
+            .ArrayType(org.apache.spark.sql.types.ByteType)
+        )
+      )
+    )
+    val unsafeRow = UnsafeProjection
+      .create(sparkSchema)
+      .apply(
+        new GenericInternalRow(
+          Array[Any](
+            ArrayData.toArrayData(Array[Byte](0x01.toByte, 0x23.toByte))
+          )
+        )
+      )
+
+    MilvusInsertDataWriter.addDataToBuffer(
+      buffer,
+      unsafeRow,
+      fieldMap,
+      sparkSchema
+    )
 
     val values = buffer("binary_vec")
       .asInstanceOf[scala.collection.mutable.ArrayBuffer[Array[Byte]]]

--- a/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
+++ b/src/test/scala/write/MilvusInsertDataWriterRetryTest.scala
@@ -1,6 +1,10 @@
 package com.zilliz.spark.connector.write
 
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import com.zilliz.spark.connector.{MilvusRateLimitException, MilvusRpcException}
 import com.zilliz.spark.connector.write.MilvusInsertDataWriter.{
@@ -8,6 +12,7 @@ import com.zilliz.spark.connector.write.MilvusInsertDataWriter.{
   Abort,
   Retry
 }
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
 
 import io.grpc.StatusRuntimeException
 
@@ -22,7 +27,7 @@ import io.grpc.StatusRuntimeException
   *     paths
   *   - independent interaction of the two counters (retries / rateLimitRetries)
   */
-class MilvusInsertDataWriterRetryTest extends AnyFunSuite {
+class MilvusInsertDataWriterRetryTest extends AnyFunSuite with Matchers {
 
   private val retryInterval = 1000L
   private val initialDelay = 500L
@@ -258,5 +263,36 @@ class MilvusInsertDataWriterRetryTest extends AnyFunSuite {
       case Retry(2, 0, _, _, false) => succeed
       case other                    => fail(s"unexpected: $other")
     }
+  }
+
+  test("addDataToBuffer reads BinaryVector from Spark BinaryType") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(
+          name = "binary_vec",
+          dataType = DataType.BinaryVector,
+          typeParams = Seq(io.milvus.grpc.common.KeyValuePair("dim", "16"))
+        )
+      )
+    )
+    val fieldMap = MilvusInsertDataWriter.getFieldMap(schema)
+    val buffer = MilvusInsertDataWriter.newDataBuffer(schema)
+    val sparkSchema = org.apache.spark.sql.types.StructType(
+      Seq(
+        org.apache.spark.sql.types
+          .StructField("binary_vec", org.apache.spark.sql.types.BinaryType)
+      )
+    )
+    val row =
+      new GenericInternalRow(Array[Any](Array[Byte](0x01.toByte, 0x23.toByte)))
+
+    MilvusInsertDataWriter.addDataToBuffer(buffer, row, fieldMap, sparkSchema)
+
+    val values = buffer("binary_vec")
+      .asInstanceOf[scala.collection.mutable.ArrayBuffer[Array[Byte]]]
+      .toSeq
+
+    values should have size 1
+    values.head shouldBe Array[Byte](0x01.toByte, 0x23.toByte)
   }
 }


### PR DESCRIPTION
Use the existing `milvus.data_type` StructField metadata as the authoritative signal for FixedSizeBinary decoding so BinaryVector, Int8Vector, Float16Vector, and BFloat16Vector no longer depend on ambiguous Arrow physical shapes.

Align protobuf and snapshot schema mapping by exposing BinaryVector as Spark BinaryType and Int8Vector as Array[Short], then teach binary search and distance expressions to accept the new BinaryType contract without regressing legacy Array[Byte] callers.