### PR TITLE
enhance!: [storage] harden IAM storage option validation

### DIFF
--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -139,6 +139,7 @@ val s3Options = Map(
 | 参数名 | 类型 | 必需 | 默认值 | 描述 |
 |--------|------|------|--------|------|
 | `MilvusOption.MilvusInsertMaxBatchSize` | Int | 否 | 5000 | 单次插入的最大批次大小 |
+| `MilvusOption.WriterVariableWidthBytesPerValue` | Double | 否 | 32.0 | VARCHAR/JSON/binary 写入列的 Arrow 初始 buffer 密度；宽变长字段可调大。必须是有限正数。 |
 | `MilvusOption.MilvusRetryCount` | Int | 否 | 3 | 操作失败时的重试次数 |
 | `MilvusOption.MilvusRetryInterval` | Int | 否 | 1000 | 重试间隔时间（毫秒） |
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -139,6 +139,7 @@ val s3Options = Map(
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.MilvusInsertMaxBatchSize` | Int | No | 5000 | Maximum batch size for single insert operation |
+| `MilvusOption.WriterVariableWidthBytesPerValue` | Double | No | 32.0 | Initial Arrow buffer density for VARCHAR/JSON/binary writer columns; increase for wide variable-width values. Must be finite and positive. |
 | `MilvusOption.MilvusRetryCount` | Int | No | 3 | Number of retries on operation failure |
 | `MilvusOption.MilvusRetryInterval` | Int | No | 1000 | Retry interval in milliseconds |
 

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -127,6 +127,8 @@ object MilvusOption {
     "milvus.writer.commitType" // "addfield" for backfill, default "addfiles"
   val WriterFieldIds =
     "milvus.writer.fieldIds" // JSON map of field name -> field ID (e.g., "new_field:104,other_field:105")
+  val WriterVariableWidthBytesPerValue =
+    "milvus.writer.variableWidthBytesPerValue"
 
   // Backfill merge mode.
   //   replace   — file is source of truth for target columns: matched rows

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -13,6 +13,11 @@ object Properties {
       options: scala.collection.Map[String, String]
   ): Option[String] = options.get(FsConfig.FsUseIam).map(_.trim)
 
+  private[connector] def normalizedFsBucketNameValue(
+      options: scala.collection.Map[String, String]
+  ): Option[String] =
+    options.get(FsConfig.FsBucketName).map(_.trim).filter(_.nonEmpty)
+
   /** Filesystem configuration constants for Storage V2 (matching milvus-storage
     * C++ API)
     */
@@ -58,9 +63,7 @@ object Properties {
     // dev/test default when we are clearly *not* in IAM mode.
     val normalizedUseIamValue = normalizedFsUseIamValue(milvusOption.options)
     val useIamFlag = normalizedUseIamValue.exists(_.equalsIgnoreCase("true"))
-    val bucket = milvusOption.options
-      .get(FsConfig.FsBucketName)
-      .filter(_.trim.nonEmpty)
+    val bucket = normalizedFsBucketNameValue(milvusOption.options)
       .getOrElse {
         if (useIamFlag) {
           throw new IllegalArgumentException(

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -63,14 +63,25 @@ object Properties {
     // dev/test default when we are clearly *not* in IAM mode.
     val normalizedUseIamValue = normalizedFsUseIamValue(milvusOption.options)
     val useIamFlag = normalizedUseIamValue.exists(_.equalsIgnoreCase("true"))
+    val rawBucketValue = milvusOption.options.get(FsConfig.FsBucketName)
     val bucket = normalizedFsBucketNameValue(milvusOption.options)
       .getOrElse {
-        if (useIamFlag) {
-          throw new IllegalArgumentException(
-            s"${FsConfig.FsBucketName} must be set when ${FsConfig.FsUseIam}=true"
-          )
+        rawBucketValue match {
+          case Some(_) if useIamFlag =>
+            throw new IllegalArgumentException(
+              s"${FsConfig.FsBucketName} must not be blank when ${FsConfig.FsUseIam}=true"
+            )
+          case Some(_) =>
+            throw new IllegalArgumentException(
+              s"${FsConfig.FsBucketName} must not be blank"
+            )
+          case None if useIamFlag =>
+            throw new IllegalArgumentException(
+              s"${FsConfig.FsBucketName} must be set when ${FsConfig.FsUseIam}=true"
+            )
+          case None =>
+            "a-bucket"
         }
-        "a-bucket"
       }
     val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
     val accessKey =

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -42,15 +42,11 @@ object Properties {
     *   MilvusStorageProperties for milvus-storage native library
     */
   def fromMilvusOption(milvusOption: MilvusOption): MilvusStorageProperties = {
-    val props = new MilvusStorageProperties()
     val propsMap = new ju.HashMap[String, String]()
 
     // Extract filesystem configuration with defaults
     val endpoint =
       milvusOption.options.getOrElse(FsConfig.FsAddress, "localhost:9000")
-    val bucket =
-      milvusOption.options.getOrElse(FsConfig.FsBucketName, "a-bucket")
-    val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
     // When use_iam=true the FFI must consult the AWS default credentials
     // chain (env vars / web identity / instance profile). Falling back to
     // hard-coded "minioadmin" defaults under IRSA produces signed requests
@@ -59,6 +55,18 @@ object Properties {
     val useIamFlag = milvusOption.options
       .get(FsConfig.FsUseIam)
       .exists(_.equalsIgnoreCase("true"))
+    val bucket = milvusOption.options
+      .get(FsConfig.FsBucketName)
+      .filter(_.trim.nonEmpty)
+      .getOrElse {
+        if (useIamFlag) {
+          throw new IllegalArgumentException(
+            s"${FsConfig.FsBucketName} must be set when ${FsConfig.FsUseIam}=true"
+          )
+        }
+        "a-bucket"
+      }
+    val rootPath = milvusOption.options.getOrElse(FsConfig.FsRootPath, "files")
     val accessKey =
       milvusOption.options.getOrElse(
         FsConfig.FsAccessKeyId,
@@ -119,6 +127,7 @@ object Properties {
       .get(FsConfig.FsUseCustomPartUpload)
       .foreach(propsMap.put(FsConfig.FsUseCustomPartUpload, _))
 
+    val props = new MilvusStorageProperties()
     props.create(propsMap)
     if (!props.isValid) {
       throw new IllegalStateException(

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -9,6 +9,10 @@ import io.milvus.storage.MilvusStorageProperties
   */
 object Properties {
 
+  private[connector] def normalizedFsUseIamValue(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = options.get(FsConfig.FsUseIam).map(_.trim)
+
   /** Filesystem configuration constants for Storage V2 (matching milvus-storage
     * C++ API)
     */
@@ -52,9 +56,8 @@ object Properties {
     // hard-coded "minioadmin" defaults under IRSA produces signed requests
     // with bogus keys, which fail with InvalidAccessKeyId. Only inject the
     // dev/test default when we are clearly *not* in IAM mode.
-    val useIamFlag = milvusOption.options
-      .get(FsConfig.FsUseIam)
-      .exists(_.trim.equalsIgnoreCase("true"))
+    val normalizedUseIamValue = normalizedFsUseIamValue(milvusOption.options)
+    val useIamFlag = normalizedUseIamValue.exists(_.equalsIgnoreCase("true"))
     val bucket = milvusOption.options
       .get(FsConfig.FsBucketName)
       .filter(_.trim.nonEmpty)
@@ -108,9 +111,7 @@ object Properties {
     milvusOption.options
       .get(FsConfig.FsSslCaCert)
       .foreach(propsMap.put(FsConfig.FsSslCaCert, _))
-    milvusOption.options
-      .get(FsConfig.FsUseIam)
-      .foreach(propsMap.put(FsConfig.FsUseIam, _))
+    normalizedUseIamValue.foreach(propsMap.put(FsConfig.FsUseIam, _))
     milvusOption.options
       .get(FsConfig.FsUseVirtualHost)
       .foreach(propsMap.put(FsConfig.FsUseVirtualHost, _))

--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -54,7 +54,7 @@ object Properties {
     // dev/test default when we are clearly *not* in IAM mode.
     val useIamFlag = milvusOption.options
       .get(FsConfig.FsUseIam)
-      .exists(_.equalsIgnoreCase("true"))
+      .exists(_.trim.equalsIgnoreCase("true"))
     val bucket = milvusOption.options
       .get(FsConfig.FsBucketName)
       .filter(_.trim.nonEmpty)

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -176,6 +176,30 @@ object MilvusLoonPartitionWriter {
       doWrite
     }
   }
+
+  private[connector] def parsePositiveDoubleOption(
+      options: scala.collection.Map[String, String],
+      key: String,
+      defaultValue: Double
+  ): Double = {
+    options
+      .get(key.toLowerCase)
+      .filter(_.trim.nonEmpty)
+      .map { value =>
+        val parsed = Try(value.trim.toDouble).getOrElse {
+          throw new IllegalArgumentException(
+            s"$key must be a finite positive number, got '$value'"
+          )
+        }
+        if (!java.lang.Double.isFinite(parsed) || parsed <= 0.0) {
+          throw new IllegalArgumentException(
+            s"$key must be a finite positive number, got '$value'"
+          )
+        }
+        parsed
+      }
+      .getOrElse(defaultValue)
+  }
 }
 
 /** Partition writer using Storage V2 FFI
@@ -218,6 +242,12 @@ class MilvusLoonPartitionWriter(
 
   // Batch size configuration
   private val batchSize = milvusOption.insertMaxBatchSize
+  private val variableWidthBytesPerValue =
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      milvusOption.options,
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 32.0
+    )
   private var currentBatchSize = 0
   private var totalRecordCount = 0L
 
@@ -444,12 +474,18 @@ class MilvusLoonPartitionWriter(
           // Second arg is density (bytes per value), NOT total bytes. Arrow
           // computes the initial data buffer size as valueCount × density
           // internally. Passing `batchSize * 32` here gave batchSize² × 32 —
-          // a quadratic over-allocation (~32 MiB per column at batch=1024)
-          // that exploded into GiB-scale peaks and caused direct-memory OOM.
-          varCharVector.setInitialCapacity(batchSize, 32.0)
+          // a quadratic over-allocation. Use a bounded per-value default that
+          // can be raised for wide JSON/VARCHAR workloads.
+          varCharVector.setInitialCapacity(
+            batchSize,
+            variableWidthBytesPerValue
+          )
 
         case baseVarVector: BaseVariableWidthVector =>
-          baseVarVector.setInitialCapacity(batchSize, 32.0)
+          baseVarVector.setInitialCapacity(
+            batchSize,
+            variableWidthBytesPerValue
+          )
 
         case _ =>
           // For fixed-width vectors, just set row capacity
@@ -602,6 +638,8 @@ object MilvusLoonWriter extends Logging {
     *   - fs.root_path: Root path in bucket (default: "files")
     *   - milvus.collection.name: Collection name for path generation
     *   - vector.{field_name}.dim: Vector dimension for float array fields
+    *   - milvus.writer.variableWidthBytesPerValue: initial bytes per
+    *     variable-width value (default: 32.0)
     * @return
     *   Try containing manifest paths on success
     */

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -212,6 +212,16 @@ class MilvusLoonPartitionWriter(
 ) extends DataWriter[InternalRow]
     with Logging {
 
+  // Batch size configuration
+  private val batchSize = milvusOption.insertMaxBatchSize
+  private val variableWidthBytesPerValue =
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      milvusOption.options,
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 32.0
+    )
+  private val writerProperties = Properties.fromMilvusOption(milvusOption)
+
   private val allocator = new RootAllocator(Long.MaxValue)
 
   // Create Arrow schema from Spark schema
@@ -239,15 +249,6 @@ class MilvusLoonPartitionWriter(
   // alive until C++ drops its ref. This caps per-writer direct memory at
   // ~16 MB × numGroups instead of growing linearly with the segment's row count.
   private var root = VectorSchemaRoot.create(arrowSchema, allocator)
-
-  // Batch size configuration
-  private val batchSize = milvusOption.insertMaxBatchSize
-  private val variableWidthBytesPerValue =
-    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
-      milvusOption.options,
-      MilvusOption.WriterVariableWidthBytesPerValue,
-      defaultValue = 32.0
-    )
   private var currentBatchSize = 0
   private var totalRecordCount = 0L
 
@@ -268,25 +269,22 @@ class MilvusLoonPartitionWriter(
     }
   }
 
-  // Create Storage V2 writer
-  private val (writer, writerProperties, arrowSchemaC) = {
-    // Writer properties from MilvusOption
-    val props = Properties.fromMilvusOption(milvusOption)
+  private val arrowSchemaC = ArrowSchema.allocateNew(allocator)
 
-    // Create Storage V2 writer
-    val schemaC = ArrowSchema.allocateNew(allocator)
-    Data.exportSchema(allocator, arrowSchema, null, schemaC)
+  // Create Storage V2 writer
+  private val writer = {
+    Data.exportSchema(allocator, arrowSchema, null, arrowSchemaC)
 
     val w = new MilvusStorageWriter()
-    w.create(basePath, schemaC.memoryAddress(), props)
+    w.create(basePath, arrowSchemaC.memoryAddress(), writerProperties)
 
     if (!w.isValid) {
-      schemaC.close()
-      props.free()
+      arrowSchemaC.close()
+      writerProperties.free()
       throw new IllegalStateException("Failed to create MilvusStorageWriter")
     }
 
-    (w, props, schemaC)
+    w
   }
 
   logInfo(

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -89,6 +89,9 @@ class MilvusV2BinlogWriter(
       s"${newFieldNames.size} / ${newFieldIds.size} / ${targetSchema.fields.length}"
   )
 
+  private val variableWidthBytesPerValue: Double =
+    MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(milvusOption.options)
+
   // Storage root comes from the same FS config the V3 writer already consumes
   // — see com.zilliz.spark.connector.loon.Properties. Paths passed to the
   // native writer are bucket-relative keys: milvus-storage's FilesystemCache
@@ -185,8 +188,6 @@ class MilvusV2BinlogWriter(
   private val batchSize: Int =
     if (milvusOption.insertMaxBatchSize > 0) milvusOption.insertMaxBatchSize
     else 5000
-  private val variableWidthBytesPerValue: Double =
-    MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(milvusOption.options)
   private var root: VectorSchemaRoot =
     VectorSchemaRoot.create(arrowSchema, allocator)
   allocateVectors(root)

--- a/src/main/scala/write/MilvusV2BinlogWriter.scala
+++ b/src/main/scala/write/MilvusV2BinlogWriter.scala
@@ -39,6 +39,17 @@ case class V2BinlogFile(
     rowsWritten: Long
 )
 
+object MilvusV2BinlogWriter {
+  private[connector] def parseVariableWidthBytesPerValue(
+      options: scala.collection.Map[String, String]
+  ): Double =
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      options,
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 32.0
+    )
+}
+
 /** Writes StorageV2 per-field binlog parquet files for a single segment.
   *
   * Backfill always emits **single-field column groups**, so the writer creates
@@ -174,6 +185,8 @@ class MilvusV2BinlogWriter(
   private val batchSize: Int =
     if (milvusOption.insertMaxBatchSize > 0) milvusOption.insertMaxBatchSize
     else 5000
+  private val variableWidthBytesPerValue: Double =
+    MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(milvusOption.options)
   private var root: VectorSchemaRoot =
     VectorSchemaRoot.create(arrowSchema, allocator)
   allocateVectors(root)
@@ -295,9 +308,9 @@ class MilvusV2BinlogWriter(
         // give batchSize² × 32 bytes — a quadratic over-allocation that dwarfs
         // actual data (20-byte values) by ~1000× and made a single allocator
         // peak ~1 GiB for a 20k-row segment.
-        v.setInitialCapacity(batchSize, 32.0)
+        v.setInitialCapacity(batchSize, variableWidthBytesPerValue)
       case v: BaseVariableWidthVector =>
-        v.setInitialCapacity(batchSize, 32.0)
+        v.setInitialCapacity(batchSize, variableWidthBytesPerValue)
       case other =>
         other.setInitialCapacity(batchSize)
     }

--- a/src/test/scala/loon/MilvusLoonWriterTest.scala
+++ b/src/test/scala/loon/MilvusLoonWriterTest.scala
@@ -6,10 +6,35 @@ import org.apache.spark.sql.SparkSession
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import com.zilliz.spark.connector.write.MilvusLoonWriter
+import com.zilliz.spark.connector.write.{
+  MilvusLoonPartitionWriter,
+  MilvusLoonWriter
+}
 import com.zilliz.spark.connector.MilvusOption
 
 class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
+
+  test("parsePositiveDoubleOption rejects invalid values") {
+    Seq("0", "-1", "NaN", "Infinity", "-Infinity", "abc").foreach { value =>
+      an[IllegalArgumentException] should be thrownBy {
+        MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+          Map(
+            MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> value
+          ),
+          MilvusOption.WriterVariableWidthBytesPerValue,
+          defaultValue = 32.0
+        )
+      }
+    }
+  }
+
+  test("parsePositiveDoubleOption accepts finite positive values") {
+    MilvusLoonPartitionWriter.parsePositiveDoubleOption(
+      Map(MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> "64.5"),
+      MilvusOption.WriterVariableWidthBytesPerValue,
+      defaultValue = 32.0
+    ) shouldBe 64.5
+  }
 
   test("Write DataFrame using Loon Writer to Minio") {
     val spark = SparkSession

--- a/src/test/scala/loon/MilvusLoonWriterTest.scala
+++ b/src/test/scala/loon/MilvusLoonWriterTest.scala
@@ -36,6 +36,27 @@ class MilvusLoonWriterTest extends AnyFunSuite with Matchers {
     ) shouldBe 64.5
   }
 
+  test(
+    "constructor validates variable-width density before bucket validation"
+  ) {
+    val options = Map(
+      Properties.FsConfig.FsBucketName -> "   ",
+      MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> "NaN"
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      new MilvusLoonPartitionWriter(
+        partitionId = 1,
+        taskId = 1L,
+        sparkSchema = org.apache.spark.sql.types.StructType(Nil),
+        milvusOption = MilvusOption(options)
+      )
+    }
+
+    err.getMessage should include(MilvusOption.WriterVariableWidthBytesPerValue)
+    err.getMessage should not include (Properties.FsConfig.FsBucketName)
+  }
+
   test("Write DataFrame using Loon Writer to Minio") {
     val spark = SparkSession
       .builder()

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -230,4 +230,16 @@ class PropertiesTest extends AnyFunSuite with Matchers {
       Map(Properties.FsConfig.FsUseIam -> " true ")
     ) shouldBe Some("true")
   }
+
+  test("normalizedFsBucketNameValue trims whitespace before FFI forwarding") {
+    Properties.normalizedFsBucketNameValue(
+      Map(Properties.FsConfig.FsBucketName -> " my-bucket ")
+    ) shouldBe Some("my-bucket")
+  }
+
+  test("normalizedFsBucketNameValue drops blank bucket names") {
+    Properties.normalizedFsBucketNameValue(
+      Map(Properties.FsConfig.FsBucketName -> "   ")
+    ) shouldBe None
+  }
 }

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -224,4 +224,10 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     err.getMessage should include(Properties.FsConfig.FsBucketName)
     err.getMessage should include(Properties.FsConfig.FsUseIam)
   }
+
+  test("normalizedFsUseIamValue trims whitespace before FFI forwarding") {
+    Properties.normalizedFsUseIamValue(
+      Map(Properties.FsConfig.FsUseIam -> " true ")
+    ) shouldBe Some("true")
+  }
 }

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -210,4 +210,18 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     err.getMessage should include(Properties.FsConfig.FsBucketName)
     err.getMessage should include(Properties.FsConfig.FsUseIam)
   }
+
+  test("fromMilvusOption trims fs.use_iam before IAM-mode validation") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      Properties.FsConfig.FsUseIam -> " true "
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      Properties.fromMilvusOption(MilvusOption(options))
+    }
+
+    err.getMessage should include(Properties.FsConfig.FsBucketName)
+    err.getMessage should include(Properties.FsConfig.FsUseIam)
+  }
 }

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -209,6 +209,38 @@ class PropertiesTest extends AnyFunSuite with Matchers {
 
     err.getMessage should include(Properties.FsConfig.FsBucketName)
     err.getMessage should include(Properties.FsConfig.FsUseIam)
+    err.getMessage should include("must be set")
+  }
+
+  test("fromMilvusOption rejects blank bucket name in non-IAM mode") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      Properties.FsConfig.FsBucketName -> "   "
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      Properties.fromMilvusOption(MilvusOption(options))
+    }
+
+    err.getMessage should include(Properties.FsConfig.FsBucketName)
+    err.getMessage should include("must not be blank")
+    err.getMessage should not include (Properties.FsConfig.FsUseIam)
+  }
+
+  test("fromMilvusOption rejects blank bucket name in IAM mode") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      Properties.FsConfig.FsUseIam -> "true",
+      Properties.FsConfig.FsBucketName -> "   "
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      Properties.fromMilvusOption(MilvusOption(options))
+    }
+
+    err.getMessage should include(Properties.FsConfig.FsBucketName)
+    err.getMessage should include(Properties.FsConfig.FsUseIam)
+    err.getMessage should include("must not be blank")
   }
 
   test("fromMilvusOption trims fs.use_iam before IAM-mode validation") {

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -196,4 +196,18 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     Properties.FsConfig.FsUseSSL should not be empty
     Properties.FsConfig.FsRegion should not be empty
   }
+
+  test("fromMilvusOption requires bucket name in IAM mode") {
+    val options = Map(
+      MilvusOption.MilvusUri -> "http://localhost:19530",
+      Properties.FsConfig.FsUseIam -> "true"
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      Properties.fromMilvusOption(MilvusOption(options))
+    }
+
+    err.getMessage should include(Properties.FsConfig.FsBucketName)
+    err.getMessage should include(Properties.FsConfig.FsUseIam)
+  }
 }

--- a/src/test/scala/write/MilvusV2BinlogWriterTest.scala
+++ b/src/test/scala/write/MilvusV2BinlogWriterTest.scala
@@ -1,11 +1,19 @@
 package com.zilliz.spark.connector.write
 
+import java.nio.file.Files
+
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.MilvusOption
 
 class MilvusV2BinlogWriterTest extends AnyFunSuite with Matchers {
+
+  private val singleFieldSchema = StructType(
+    Seq(StructField("payload", StringType, nullable = true))
+  )
 
   test("parseVariableWidthBytesPerValue accepts finite positive values") {
     MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(
@@ -31,5 +39,32 @@ class MilvusV2BinlogWriterTest extends AnyFunSuite with Matchers {
         )
       }
     }
+  }
+
+  test(
+    "constructor validates variable-width density before IAM bucket validation"
+  ) {
+    val tempDir = Files.createTempDirectory("v2-binlog-writer-test-")
+    val options = Map(
+      Properties.FsConfig.FsUseIam -> "true",
+      Properties.FsConfig.FsRootPath -> tempDir.toString,
+      MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> "NaN"
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      new MilvusV2BinlogWriter(
+        collectionId = 1L,
+        partitionId = 2L,
+        segmentId = 3L,
+        newFieldNames = Seq("payload"),
+        newFieldIds = Seq(101L),
+        targetSchema = singleFieldSchema,
+        milvusOption = MilvusOption(options),
+        allocateLogId = () => 1L
+      )
+    }
+
+    err.getMessage should include(MilvusOption.WriterVariableWidthBytesPerValue)
+    err.getMessage should not include (Properties.FsConfig.FsBucketName)
   }
 }

--- a/src/test/scala/write/MilvusV2BinlogWriterTest.scala
+++ b/src/test/scala/write/MilvusV2BinlogWriterTest.scala
@@ -1,0 +1,35 @@
+package com.zilliz.spark.connector.write
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import com.zilliz.spark.connector.MilvusOption
+
+class MilvusV2BinlogWriterTest extends AnyFunSuite with Matchers {
+
+  test("parseVariableWidthBytesPerValue accepts finite positive values") {
+    MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(
+      Map(MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> "64.5")
+    ) shouldBe 64.5
+  }
+
+  test(
+    "parseVariableWidthBytesPerValue returns default when option is absent"
+  ) {
+    MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(
+      Map.empty
+    ) shouldBe 32.0
+  }
+
+  test("parseVariableWidthBytesPerValue rejects invalid values") {
+    Seq("0", "-1", "NaN", "Infinity", "-Infinity", "abc").foreach { value =>
+      an[IllegalArgumentException] should be thrownBy {
+        MilvusV2BinlogWriter.parseVariableWidthBytesPerValue(
+          Map(
+            MilvusOption.WriterVariableWidthBytesPerValue.toLowerCase -> value
+          )
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- require `fs.bucket_name` when `fs.use_iam=true` in the shared storage-property builder
- stop forwarding empty static AK/SK in IAM mode so the native layer can use the AWS default credentials chain
- normalize forwarded storage options such as `fs.use_iam` and `fs.bucket_name` before handing them to the FFI
- keep the configurable bytes-per-value override for variable-width Arrow columns

## Breaking change
- this change affects both write and read paths because they share `Properties.fromMilvusOption`
- when `fs.use_iam=true`, the connector now fails fast if `fs.bucket_name` is missing instead of silently falling back to `a-bucket`
- workloads that relied on that implicit fallback must set `fs.bucket_name` explicitly

## Test plan
- [x] `sbt "testOnly com.zilliz.spark.connector.loon.PropertiesTest -- -oD"`
- [x] existing writer/read tests for the touched code paths