### PR TITLE
enhance: Reject flags as backfill option values

### DIFF
--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -218,7 +218,11 @@ object BackfillApp {
             i += 1
           } else if (i + 1 < args.length) {
             val value = args(i + 1)
-            if (value.startsWith("--")) {
+            if (
+              value.startsWith("--") && KnownFlags.contains(
+                value.stripPrefix("--")
+              )
+            ) {
               throw new IllegalArgumentException(s"Missing value for $flag")
             }
             map += (key -> value)

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -217,7 +217,11 @@ object BackfillApp {
             map += (key -> "true")
             i += 1
           } else if (i + 1 < args.length) {
-            map += (key -> args(i + 1))
+            val value = args(i + 1)
+            if (value.startsWith("--")) {
+              throw new IllegalArgumentException(s"Missing value for $flag")
+            }
+            map += (key -> value)
             i += 2
           } else {
             throw new IllegalArgumentException(s"Missing value for $flag")

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -84,6 +84,22 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     }
   }
 
+  test("parseArgs throws when key/value flag is followed by another flag") {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseArgs(Array("--parquet", "--snapshot", "/tmp/snap.json"))
+    }
+    ex.getMessage should include("Missing value for --parquet")
+  }
+
+  test(
+    "parseArgs throws when source key/value flag is followed by another flag"
+  ) {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.parseArgs(Array("--source-s3-endpoint", "--source-use-iam"))
+    }
+    ex.getMessage should include("Missing value for --source-s3-endpoint")
+  }
+
   test("parseArgs throws on unexpected positional arg") {
     an[IllegalArgumentException] should be thrownBy {
       BackfillApp.parseArgs(Array("oops"))

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -100,6 +100,19 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     ex.getMessage should include("Missing value for --source-s3-endpoint")
   }
 
+  test("parseArgs allows non-flag values that begin with double dash") {
+    val parsed = BackfillApp.parseArgs(
+      Array(
+        "--s3-secret-key",
+        "--literal-secret",
+        "--parquet",
+        "/tmp/data.parquet"
+      )
+    )
+    parsed("s3-secret-key") shouldBe "--literal-secret"
+    parsed("parquet") shouldBe "/tmp/data.parquet"
+  }
+
   test("parseArgs throws on unexpected positional arg") {
     an[IllegalArgumentException] should be thrownBy {
       BackfillApp.parseArgs(Array("oops"))


### PR DESCRIPTION
Fail fast when a key/value backfill option is immediately followed by another flag. This reports a missing value at parse time instead of mis-parsing the next flag and failing later with a confusing positional-argument error.