### PR TITLE
enhance: [reader] add StorageV2 deltalog planning and delete-aware reads

### DIFF
--- a/src/main/resources/milvus-segment-manifest-v1.avsc
+++ b/src/main/resources/milvus-segment-manifest-v1.avsc
@@ -1,0 +1,178 @@
+{
+  "type": "record",
+  "name": "ManifestEntry",
+  "fields": [
+    {"name": "segment_id", "type": "long"},
+    {"name": "partition_id", "type": "long"},
+    {"name": "segment_level", "type": "long"},
+    {"name": "channel_name", "type": "string"},
+    {"name": "num_of_rows", "type": "long"},
+    {
+      "name": "start_position",
+      "type": {
+        "type": "record",
+        "name": "AvroMsgPosition",
+        "fields": [
+          {"name": "channel_name", "type": "string"},
+          {"name": "msg_id", "type": "bytes"},
+          {"name": "msg_group", "type": "string"},
+          {"name": "timestamp", "type": "long"}
+        ]
+      }
+    },
+    {
+      "name": "dml_position",
+      "type": "AvroMsgPosition"
+    },
+    {"name": "storage_version", "type": "long"},
+    {"name": "is_sorted", "type": "boolean"},
+    {
+      "name": "binlog_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroFieldBinlog",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "binlogs",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroBinlog",
+                  "fields": [
+                    {"name": "entries_num", "type": "long"},
+                    {"name": "timestamp_from", "type": "long"},
+                    {"name": "timestamp_to", "type": "long"},
+                    {"name": "log_path", "type": "string"},
+                    {"name": "log_size", "type": "long"},
+                    {"name": "log_id", "type": "long"},
+                    {"name": "memory_size", "type": "long"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "deltalog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "bm25_statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroIndexFilePathInfo",
+          "fields": [
+            {"name": "segment_id", "type": "long"},
+            {"name": "field_id", "type": "long"},
+            {"name": "index_id", "type": "long"},
+            {"name": "build_id", "type": "long"},
+            {"name": "index_name", "type": "string"},
+            {
+              "name": "index_params",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroKeyValuePair",
+                  "fields": [
+                    {"name": "key", "type": "string"},
+                    {"name": "value", "type": "string"}
+                  ]
+                }
+              }
+            },
+            {"name": "index_file_paths", "type": {"type": "array", "items": "string"}},
+            {"name": "serialized_size", "type": "long"},
+            {"name": "index_version", "type": "long"},
+            {"name": "num_rows", "type": "long"},
+            {"name": "current_index_version", "type": "int"},
+            {"name": "mem_size", "type": "long"},
+            {"name": "current_scalar_index_version", "type": "int", "default": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "text_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroTextIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroTextIndexStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "json_key_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroJsonKeyIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroJSONKeyStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"},
+                  {"name": "json_key_stats_data_format", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/milvus-segment-manifest-v2.avsc
+++ b/src/main/resources/milvus-segment-manifest-v2.avsc
@@ -1,0 +1,179 @@
+{
+  "type": "record",
+  "name": "ManifestEntry",
+  "fields": [
+    {"name": "segment_id", "type": "long"},
+    {"name": "partition_id", "type": "long"},
+    {"name": "segment_level", "type": "long"},
+    {"name": "channel_name", "type": "string"},
+    {"name": "num_of_rows", "type": "long"},
+    {
+      "name": "start_position",
+      "type": {
+        "type": "record",
+        "name": "AvroMsgPosition",
+        "fields": [
+          {"name": "channel_name", "type": "string"},
+          {"name": "msg_id", "type": "bytes"},
+          {"name": "msg_group", "type": "string"},
+          {"name": "timestamp", "type": "long"}
+        ]
+      }
+    },
+    {
+      "name": "dml_position",
+      "type": "AvroMsgPosition"
+    },
+    {"name": "storage_version", "type": "long"},
+    {"name": "is_sorted", "type": "boolean"},
+    {
+      "name": "binlog_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroFieldBinlog",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "binlogs",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroBinlog",
+                  "fields": [
+                    {"name": "entries_num", "type": "long"},
+                    {"name": "timestamp_from", "type": "long"},
+                    {"name": "timestamp_to", "type": "long"},
+                    {"name": "log_path", "type": "string"},
+                    {"name": "log_size", "type": "long"},
+                    {"name": "log_id", "type": "long"},
+                    {"name": "memory_size", "type": "long"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "deltalog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "bm25_statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroIndexFilePathInfo",
+          "fields": [
+            {"name": "segment_id", "type": "long"},
+            {"name": "field_id", "type": "long"},
+            {"name": "index_id", "type": "long"},
+            {"name": "build_id", "type": "long"},
+            {"name": "index_name", "type": "string"},
+            {
+              "name": "index_params",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroKeyValuePair",
+                  "fields": [
+                    {"name": "key", "type": "string"},
+                    {"name": "value", "type": "string"}
+                  ]
+                }
+              }
+            },
+            {"name": "index_file_paths", "type": {"type": "array", "items": "string"}},
+            {"name": "serialized_size", "type": "long"},
+            {"name": "index_version", "type": "long"},
+            {"name": "num_rows", "type": "long"},
+            {"name": "current_index_version", "type": "int"},
+            {"name": "mem_size", "type": "long"},
+            {"name": "current_scalar_index_version", "type": "int", "default": 0},
+            {"name": "index_store_path_version", "type": "int", "default": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "text_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroTextIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroTextIndexStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "json_key_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroJsonKeyIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroJSONKeyStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"},
+                  {"name": "json_key_stats_data_format", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/milvus-segment-manifest-v3.avsc
+++ b/src/main/resources/milvus-segment-manifest-v3.avsc
@@ -1,0 +1,180 @@
+{
+  "type": "record",
+  "name": "ManifestEntry",
+  "fields": [
+    {"name": "segment_id", "type": "long"},
+    {"name": "partition_id", "type": "long"},
+    {"name": "segment_level", "type": "long"},
+    {"name": "channel_name", "type": "string"},
+    {"name": "num_of_rows", "type": "long"},
+    {
+      "name": "start_position",
+      "type": {
+        "type": "record",
+        "name": "AvroMsgPosition",
+        "fields": [
+          {"name": "channel_name", "type": "string"},
+          {"name": "msg_id", "type": "bytes"},
+          {"name": "msg_group", "type": "string"},
+          {"name": "timestamp", "type": "long"}
+        ]
+      }
+    },
+    {
+      "name": "dml_position",
+      "type": "AvroMsgPosition"
+    },
+    {"name": "storage_version", "type": "long"},
+    {"name": "is_sorted", "type": "boolean"},
+    {"name": "commit_timestamp", "type": "long", "default": 0},
+    {
+      "name": "binlog_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroFieldBinlog",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "binlogs",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroBinlog",
+                  "fields": [
+                    {"name": "entries_num", "type": "long"},
+                    {"name": "timestamp_from", "type": "long"},
+                    {"name": "timestamp_to", "type": "long"},
+                    {"name": "log_path", "type": "string"},
+                    {"name": "log_size", "type": "long"},
+                    {"name": "log_id", "type": "long"},
+                    {"name": "memory_size", "type": "long"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "deltalog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "bm25_statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroIndexFilePathInfo",
+          "fields": [
+            {"name": "segment_id", "type": "long"},
+            {"name": "field_id", "type": "long"},
+            {"name": "index_id", "type": "long"},
+            {"name": "build_id", "type": "long"},
+            {"name": "index_name", "type": "string"},
+            {
+              "name": "index_params",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroKeyValuePair",
+                  "fields": [
+                    {"name": "key", "type": "string"},
+                    {"name": "value", "type": "string"}
+                  ]
+                }
+              }
+            },
+            {"name": "index_file_paths", "type": {"type": "array", "items": "string"}},
+            {"name": "serialized_size", "type": "long"},
+            {"name": "index_version", "type": "long"},
+            {"name": "num_rows", "type": "long"},
+            {"name": "current_index_version", "type": "int"},
+            {"name": "mem_size", "type": "long"},
+            {"name": "current_scalar_index_version", "type": "int", "default": 0},
+            {"name": "index_store_path_version", "type": "int", "default": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "text_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroTextIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroTextIndexStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "json_key_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroJsonKeyIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroJSONKeyStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"},
+                  {"name": "json_key_stats_data_format", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/milvus-segment-manifest-v4.avsc
+++ b/src/main/resources/milvus-segment-manifest-v4.avsc
@@ -1,0 +1,182 @@
+{
+  "type": "record",
+  "name": "ManifestEntry",
+  "fields": [
+    {"name": "segment_id", "type": "long"},
+    {"name": "partition_id", "type": "long"},
+    {"name": "segment_level", "type": "long"},
+    {"name": "channel_name", "type": "string"},
+    {"name": "num_of_rows", "type": "long"},
+    {
+      "name": "start_position",
+      "type": {
+        "type": "record",
+        "name": "AvroMsgPosition",
+        "fields": [
+          {"name": "channel_name", "type": "string"},
+          {"name": "msg_id", "type": "bytes"},
+          {"name": "msg_group", "type": "string"},
+          {"name": "timestamp", "type": "long"}
+        ]
+      }
+    },
+    {
+      "name": "dml_position",
+      "type": "AvroMsgPosition"
+    },
+    {"name": "storage_version", "type": "long"},
+    {"name": "is_sorted", "type": "boolean"},
+    {"name": "commit_timestamp", "type": "long", "default": 0},
+    {
+      "name": "binlog_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroFieldBinlog",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {"name": "child_fields", "type": {"type": "array", "items": "long"}, "default": []},
+            {"name": "format", "type": "string", "default": ""},
+            {
+              "name": "binlogs",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroBinlog",
+                  "fields": [
+                    {"name": "entries_num", "type": "long"},
+                    {"name": "timestamp_from", "type": "long"},
+                    {"name": "timestamp_to", "type": "long"},
+                    {"name": "log_path", "type": "string"},
+                    {"name": "log_size", "type": "long"},
+                    {"name": "log_id", "type": "long"},
+                    {"name": "memory_size", "type": "long"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "deltalog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "bm25_statslog_files",
+      "type": {
+        "type": "array",
+        "items": "AvroFieldBinlog"
+      }
+    },
+    {
+      "name": "index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroIndexFilePathInfo",
+          "fields": [
+            {"name": "segment_id", "type": "long"},
+            {"name": "field_id", "type": "long"},
+            {"name": "index_id", "type": "long"},
+            {"name": "build_id", "type": "long"},
+            {"name": "index_name", "type": "string"},
+            {
+              "name": "index_params",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "AvroKeyValuePair",
+                  "fields": [
+                    {"name": "key", "type": "string"},
+                    {"name": "value", "type": "string"}
+                  ]
+                }
+              }
+            },
+            {"name": "index_file_paths", "type": {"type": "array", "items": "string"}},
+            {"name": "serialized_size", "type": "long"},
+            {"name": "index_version", "type": "long"},
+            {"name": "num_rows", "type": "long"},
+            {"name": "current_index_version", "type": "int"},
+            {"name": "mem_size", "type": "long"},
+            {"name": "current_scalar_index_version", "type": "int", "default": 0},
+            {"name": "index_store_path_version", "type": "int", "default": 0}
+          ]
+        }
+      }
+    },
+    {
+      "name": "text_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroTextIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroTextIndexStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "json_key_index_files",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "AvroJsonKeyIndexEntry",
+          "fields": [
+            {"name": "field_id", "type": "long"},
+            {
+              "name": "stats",
+              "type": {
+                "type": "record",
+                "name": "AvroJSONKeyStats",
+                "fields": [
+                  {"name": "field_id", "type": "long"},
+                  {"name": "version", "type": "long"},
+                  {"name": "files", "type": {"type": "array", "items": "string"}},
+                  {"name": "log_size", "type": "long"},
+                  {"name": "memory_size", "type": "long"},
+                  {"name": "build_id", "type": "long"},
+                  {"name": "json_key_stats_data_format", "type": "long"}
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -165,10 +165,13 @@ object MilvusOption {
   val SnapshotSchemaBytes =
     "milvus.snapshot.schema.bytes" // Base64 encoded protobuf CollectionSchema bytes
   val SnapshotMaxJsonBytes = "milvus.snapshot.max.json.bytes"
+  val ReadApplyDeletes = "milvus.read.apply.deletes"
   val ClientSnapshotName = "milvus.client.snapshot.name"
   val ClientSnapshotDescription = "milvus.client.snapshot.description"
   val ClientSnapshotCompactionProtectionSeconds =
     "milvus.client.snapshot.compaction.protection.seconds"
+  val ClientSnapshotAutoCleanup =
+    "milvus.client.snapshot.auto.cleanup"
 
   private def nonEmptyOption(
       getOption: String => Option[String],
@@ -227,6 +230,54 @@ object MilvusOption {
 
   def validateSnapshotModeOptions(options: CaseInsensitiveStringMap): Unit = {
     validateSnapshotModeOptionsFrom(key => Option(options.get(key)))
+  }
+
+  private def readApplyDeletesFrom(
+      getOption: String => Option[String]
+  ): Boolean = {
+    getOption(ReadApplyDeletes)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(_.equalsIgnoreCase("true"))
+      .getOrElse(true)
+  }
+
+  def readApplyDeletes(options: Map[String, String]): Boolean = {
+    readApplyDeletesFrom { key =>
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) =>
+          value
+      }
+    }
+  }
+
+  def readApplyDeletes(options: CaseInsensitiveStringMap): Boolean = {
+    readApplyDeletesFrom(key => Option(options.get(key)))
+  }
+
+  private def clientSnapshotAutoCleanupFrom(
+      getOption: String => Option[String]
+  ): Boolean = {
+    getOption(ClientSnapshotAutoCleanup)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(_.equalsIgnoreCase("true"))
+      .getOrElse(true)
+  }
+
+  def clientSnapshotAutoCleanup(options: Map[String, String]): Boolean = {
+    clientSnapshotAutoCleanupFrom { key =>
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) =>
+          value
+      }
+    }
+  }
+
+  def clientSnapshotAutoCleanup(
+      options: CaseInsensitiveStringMap
+  ): Boolean = {
+    clientSnapshotAutoCleanupFrom(key => Option(options.get(key)))
   }
 
   // Create MilvusOption from a map

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -579,6 +579,7 @@ object MilvusBackfill {
       val allFieldIds = pkFieldId +: extraReadFields.map(_._2)
       options =
         options + (MilvusOption.ReaderFieldIDs -> allFieldIds.mkString(","))
+      options = options + (MilvusOption.ReadApplyDeletes -> "false")
 
       // If snapshot metadata is available, use snapshot-based reading (no client calls)
       snapshotMetadata.foreach { metadata =>
@@ -1352,7 +1353,9 @@ object MilvusBackfill {
         .loadV2Segments(
           metadata.manifestList,
           config.s3BucketName,
-          hadoopConf
+          hadoopConf,
+          manifestSchemaVersion = metadata.manifestSchemaVersion,
+          applyDeletes = false
         ) match {
         case Right(segs) =>
           // Workaround for Milvus snapshot not yet exposing FieldBinlog.child_fields:

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -29,7 +29,7 @@ class for running backfill as a Spark application:
 ```bash
 spark-submit \
   --class com.zilliz.spark.connector.operations.backfill.BackfillApp \
-  spark-connector-assembly.jar \
+  spark-connector-assembly-<branch>-amd64-SNAPSHOT.jar \
   --parquet      s3a://source-bucket/new_fields.parquet \
   --snapshot     s3a://milvus-bucket/snapshots/foo.json \
   --s3-endpoint  s3.us-west-2.amazonaws.com \

--- a/src/main/scala/read/MilvusDeletePlan.scala
+++ b/src/main/scala/read/MilvusDeletePlan.scala
@@ -1,27 +1,28 @@
 package com.zilliz.spark.connector.read
 
 sealed trait MilvusDeletePlan {
-  def containsLongPk(value: Long): Boolean
-  def containsStringPk(value: String): Boolean
+  def containsLongPk(value: Long, rowTs: Long): Boolean
+  def containsStringPk(value: String, rowTs: Long): Boolean
   def isEmpty: Boolean
 }
 
 object MilvusDeletePlan {
   val empty: MilvusDeletePlan = EmptyDeletePlan
 
-  def fromLongPks(values: Set[Long]): MilvusDeletePlan =
+  def fromLongPks(values: Map[Long, Long]): MilvusDeletePlan =
     if (values.isEmpty) empty else LongPkDeletePlan(values)
 
-  def fromStringPks(values: Set[String]): MilvusDeletePlan =
+  def fromStringPks(values: Map[String, Long]): MilvusDeletePlan =
     if (values.isEmpty) empty else StringPkDeletePlan(values)
 
   def union(left: MilvusDeletePlan, right: MilvusDeletePlan): MilvusDeletePlan =
     (left, right) match {
-      case (EmptyDeletePlan, other)                   => other
-      case (other, EmptyDeletePlan)                   => other
-      case (LongPkDeletePlan(a), LongPkDeletePlan(b)) => fromLongPks(a ++ b)
+      case (EmptyDeletePlan, other) => other
+      case (other, EmptyDeletePlan) => other
+      case (LongPkDeletePlan(a), LongPkDeletePlan(b)) =>
+        fromLongPks(mergeDeleteTimestamps(a, b))
       case (StringPkDeletePlan(a), StringPkDeletePlan(b)) =>
-        fromStringPks(a ++ b)
+        fromStringPks(mergeDeleteTimestamps(a, b))
       case _ =>
         throw new IllegalArgumentException(
           s"cannot union delete plans of different PK types: ${left.getClass.getSimpleName} vs ${right.getClass.getSimpleName}"
@@ -30,23 +31,37 @@ object MilvusDeletePlan {
 
   def union(plans: Iterable[MilvusDeletePlan]): MilvusDeletePlan =
     plans.foldLeft(empty)(union)
+
+  private def mergeDeleteTimestamps[K](
+      left: Map[K, Long],
+      right: Map[K, Long]
+  ): Map[K, Long] =
+    (left.keySet ++ right.keySet).iterator.map { key =>
+      key -> math.max(
+        left.getOrElse(key, Long.MinValue),
+        right.getOrElse(key, Long.MinValue)
+      )
+    }.toMap
 }
 
 case object EmptyDeletePlan extends MilvusDeletePlan {
-  override def containsLongPk(value: Long): Boolean = false
-  override def containsStringPk(value: String): Boolean = false
+  override def containsLongPk(value: Long, rowTs: Long): Boolean = false
+  override def containsStringPk(value: String, rowTs: Long): Boolean = false
   override val isEmpty: Boolean = true
 }
 
-final case class LongPkDeletePlan(values: Set[Long]) extends MilvusDeletePlan {
-  override def containsLongPk(value: Long): Boolean = values.contains(value)
-  override def containsStringPk(value: String): Boolean = false
+final case class LongPkDeletePlan(values: Map[Long, Long])
+    extends MilvusDeletePlan {
+  override def containsLongPk(value: Long, rowTs: Long): Boolean =
+    values.get(value).exists(_ >= rowTs)
+  override def containsStringPk(value: String, rowTs: Long): Boolean = false
   override def isEmpty: Boolean = values.isEmpty
 }
 
-final case class StringPkDeletePlan(values: Set[String])
+final case class StringPkDeletePlan(values: Map[String, Long])
     extends MilvusDeletePlan {
-  override def containsLongPk(value: Long): Boolean = false
-  override def containsStringPk(value: String): Boolean = values.contains(value)
+  override def containsLongPk(value: Long, rowTs: Long): Boolean = false
+  override def containsStringPk(value: String, rowTs: Long): Boolean =
+    values.get(value).exists(_ >= rowTs)
   override def isEmpty: Boolean = values.isEmpty
 }

--- a/src/main/scala/read/MilvusDeletePlan.scala
+++ b/src/main/scala/read/MilvusDeletePlan.scala
@@ -1,0 +1,52 @@
+package com.zilliz.spark.connector.read
+
+sealed trait MilvusDeletePlan {
+  def containsLongPk(value: Long): Boolean
+  def containsStringPk(value: String): Boolean
+  def isEmpty: Boolean
+}
+
+object MilvusDeletePlan {
+  val empty: MilvusDeletePlan = EmptyDeletePlan
+
+  def fromLongPks(values: Set[Long]): MilvusDeletePlan =
+    if (values.isEmpty) empty else LongPkDeletePlan(values)
+
+  def fromStringPks(values: Set[String]): MilvusDeletePlan =
+    if (values.isEmpty) empty else StringPkDeletePlan(values)
+
+  def union(left: MilvusDeletePlan, right: MilvusDeletePlan): MilvusDeletePlan =
+    (left, right) match {
+      case (EmptyDeletePlan, other)                   => other
+      case (other, EmptyDeletePlan)                   => other
+      case (LongPkDeletePlan(a), LongPkDeletePlan(b)) => fromLongPks(a ++ b)
+      case (StringPkDeletePlan(a), StringPkDeletePlan(b)) =>
+        fromStringPks(a ++ b)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"cannot union delete plans of different PK types: ${left.getClass.getSimpleName} vs ${right.getClass.getSimpleName}"
+        )
+    }
+
+  def union(plans: Iterable[MilvusDeletePlan]): MilvusDeletePlan =
+    plans.foldLeft(empty)(union)
+}
+
+case object EmptyDeletePlan extends MilvusDeletePlan {
+  override def containsLongPk(value: Long): Boolean = false
+  override def containsStringPk(value: String): Boolean = false
+  override val isEmpty: Boolean = true
+}
+
+final case class LongPkDeletePlan(values: Set[Long]) extends MilvusDeletePlan {
+  override def containsLongPk(value: Long): Boolean = values.contains(value)
+  override def containsStringPk(value: String): Boolean = false
+  override def isEmpty: Boolean = values.isEmpty
+}
+
+final case class StringPkDeletePlan(values: Set[String])
+    extends MilvusDeletePlan {
+  override def containsLongPk(value: Long): Boolean = false
+  override def containsStringPk(value: String): Boolean = values.contains(value)
+  override def isEmpty: Boolean = values.isEmpty
+}

--- a/src/main/scala/read/MilvusDeltaLogReader.scala
+++ b/src/main/scala/read/MilvusDeltaLogReader.scala
@@ -60,15 +60,17 @@ object MilvusDeltaLogReader extends Logging {
     )
   }
 
+  private val AllPartitionsId = -1L
+
   private[read] def mergeInheritedDeletePlans(
       dataSegments: Seq[V2SegmentInfo],
       inheritedPlansByPartition: Map[Long, MilvusDeletePlan],
       ownPlansBySegment: Map[Long, MilvusDeletePlan]
   ): Map[Long, MilvusDeletePlan] = {
     dataSegments.iterator.map { seg =>
-      val inheritedPlan = inheritedPlansByPartition.getOrElse(
+      val inheritedPlan = effectiveInheritedDeletePlan(
         seg.partitionId,
-        MilvusDeletePlan.empty
+        inheritedPlansByPartition
       )
       val ownPlan = ownPlansBySegment.getOrElse(
         seg.segmentId,
@@ -96,6 +98,31 @@ object MilvusDeltaLogReader extends Logging {
       }
     ).map(_.toMap)
   }
+
+  private[read] def effectiveInheritedDeletePlan(
+      partitionId: Long,
+      inheritedPlansByPartition: Map[Long, MilvusDeletePlan]
+  ): MilvusDeletePlan = {
+    val collectionWidePlan = inheritedPlansByPartition.getOrElse(
+      AllPartitionsId,
+      MilvusDeletePlan.empty
+    )
+    val partitionPlan = inheritedPlansByPartition.getOrElse(
+      partitionId,
+      MilvusDeletePlan.empty
+    )
+    MilvusDeletePlan.union(collectionWidePlan, partitionPlan)
+  }
+
+  private[read] def inheritedDeletePlanPartitionMarker(
+      partitionId: Long,
+      inheritedPlansByPartition: Map[Long, MilvusDeletePlan]
+  ): Option[Long] =
+    if (
+      inheritedPlansByPartition.contains(AllPartitionsId) ||
+      inheritedPlansByPartition.contains(partitionId)
+    ) Some(partitionId)
+    else None
 
   def loadDeletePlan(
       deltaLogs: Seq[V2DeltaLogFile],

--- a/src/main/scala/read/MilvusDeltaLogReader.scala
+++ b/src/main/scala/read/MilvusDeltaLogReader.scala
@@ -40,21 +40,61 @@ object MilvusDeltaLogReader extends Logging {
     val dataSegments = segments.filter(_.columnGroups.nonEmpty)
 
     for {
-      globalPlan <- loadDeletePlan(
-        deleteOnlySegments.flatMap(_.deltaLogs),
+      globalPlans <- loadPartitionScopedDeletePlans(
+        deleteOnlySegments,
         pkField,
         bucket,
         hadoopConf
       )
-      perSegment <- sequence(
+      ownPlans <- sequence(
         dataSegments.map { seg =>
           loadDeletePlan(seg.deltaLogs, pkField, bucket, hadoopConf).map {
-            ownPlan =>
-              seg.segmentId -> MilvusDeletePlan.union(globalPlan, ownPlan)
+            ownPlan => seg.segmentId -> ownPlan
           }
         }
       )
-    } yield perSegment.toMap
+    } yield mergeInheritedDeletePlans(
+      dataSegments,
+      globalPlans,
+      ownPlans.toMap
+    )
+  }
+
+  private[read] def mergeInheritedDeletePlans(
+      dataSegments: Seq[V2SegmentInfo],
+      inheritedPlansByPartition: Map[Long, MilvusDeletePlan],
+      ownPlansBySegment: Map[Long, MilvusDeletePlan]
+  ): Map[Long, MilvusDeletePlan] = {
+    dataSegments.iterator.map { seg =>
+      val inheritedPlan = inheritedPlansByPartition.getOrElse(
+        seg.partitionId,
+        MilvusDeletePlan.empty
+      )
+      val ownPlan = ownPlansBySegment.getOrElse(
+        seg.segmentId,
+        MilvusDeletePlan.empty
+      )
+      seg.segmentId -> MilvusDeletePlan.union(inheritedPlan, ownPlan)
+    }.toMap
+  }
+
+  private[connector] def loadPartitionScopedDeletePlans(
+      deleteOnlySegments: Seq[V2SegmentInfo],
+      pkField: FieldSchema,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Map[Long, MilvusDeletePlan]] = {
+    sequence(
+      deleteOnlySegments.groupBy(_.partitionId).toSeq.map {
+        case (partitionId, segments) =>
+          loadDeletePlan(
+            segments.flatMap(_.deltaLogs),
+            pkField,
+            bucket,
+            hadoopConf
+          ).map(partitionId -> _)
+      }
+    ).map(_.toMap)
   }
 
   def loadDeletePlan(
@@ -99,8 +139,8 @@ object MilvusDeltaLogReader extends Logging {
       pkField: FieldSchema,
       path: String
   ): MilvusDeletePlan = {
-    val longs = mutable.HashSet.empty[Long]
-    val strings = mutable.HashSet.empty[String]
+    val longs = mutable.HashMap.empty[Long, Long]
+    val strings = mutable.HashMap.empty[String, Long]
     val reader = newGroupReader(payload)
     try {
       var record = reader.read()
@@ -123,8 +163,8 @@ object MilvusDeltaLogReader extends Logging {
     }
 
     pkField.dataType match {
-      case DataType.Int64   => MilvusDeletePlan.fromLongPks(longs.toSet)
-      case DataType.VarChar => MilvusDeletePlan.fromStringPks(strings.toSet)
+      case DataType.Int64   => MilvusDeletePlan.fromLongPks(longs.toMap)
+      case DataType.VarChar => MilvusDeletePlan.fromStringPks(strings.toMap)
       case other =>
         throw new IllegalArgumentException(
           s"unsupported primary key type $other for delete logs"
@@ -136,8 +176,8 @@ object MilvusDeltaLogReader extends Logging {
       record: Group,
       pkField: FieldSchema,
       path: String,
-      longs: mutable.Set[Long],
-      strings: mutable.Set[String]
+      longs: mutable.Map[Long, Long],
+      strings: mutable.Map[String, Long]
   ): Unit = {
     val fieldCount = record.getType.getFieldCount
     if (fieldCount < 2) {
@@ -150,10 +190,23 @@ object MilvusDeltaLogReader extends Logging {
         s"multi-field delete log payload in $path is missing the pk value"
       )
     }
+    if (record.getFieldRepetitionCount(1) == 0) {
+      throw new IllegalStateException(
+        s"multi-field delete log payload in $path is missing the ts value"
+      )
+    }
+    val deleteTs = record.getLong(1, 0)
 
     pkField.dataType match {
-      case DataType.Int64   => longs += record.getLong(0, 0)
-      case DataType.VarChar => strings += record.getString(0, 0)
+      case DataType.Int64 =>
+        val pk = record.getLong(0, 0)
+        longs.update(pk, math.max(longs.getOrElse(pk, Long.MinValue), deleteTs))
+      case DataType.VarChar =>
+        val pk = record.getString(0, 0)
+        strings.update(
+          pk,
+          math.max(strings.getOrElse(pk, Long.MinValue), deleteTs)
+        )
       case other =>
         throw new IllegalArgumentException(
           s"unsupported primary key type $other for delete logs"
@@ -186,8 +239,8 @@ object MilvusDeltaLogReader extends Logging {
       raw: String,
       pkField: FieldSchema,
       path: String,
-      longs: mutable.Set[Long],
-      strings: mutable.Set[String]
+      longs: mutable.Map[Long, Long],
+      strings: mutable.Map[String, Long]
   ): Unit = {
     val trimmed = raw.trim
     if (trimmed.startsWith("{")) {
@@ -212,6 +265,13 @@ object MilvusDeltaLogReader extends Logging {
           s"delete log pkType $pkType in $path does not match collection PK type ${pkField.dataType.value}"
         )
       }
+      val tsNode = json.path("ts")
+      if (!tsNode.canConvertToLong) {
+        throw new IllegalStateException(
+          s"delete log ts in $path must be numeric: $trimmed"
+        )
+      }
+      val deleteTs = tsNode.longValue()
       pkField.dataType match {
         case DataType.Int64 =>
           if (!pkNode.isNumber) {
@@ -219,14 +279,22 @@ object MilvusDeltaLogReader extends Logging {
               s"delete log pk in $path must be numeric for Int64 PKs: $trimmed"
             )
           }
-          longs += pkNode.longValue()
+          val pk = pkNode.longValue()
+          longs.update(
+            pk,
+            math.max(longs.getOrElse(pk, Long.MinValue), deleteTs)
+          )
         case DataType.VarChar =>
           if (!pkNode.isTextual) {
             throw new IllegalStateException(
               s"delete log pk in $path must be textual for VarChar PKs: $trimmed"
             )
           }
-          strings += pkNode.textValue()
+          val pk = pkNode.textValue()
+          strings.update(
+            pk,
+            math.max(strings.getOrElse(pk, Long.MinValue), deleteTs)
+          )
         case _ =>
       }
     } else {
@@ -241,7 +309,9 @@ object MilvusDeltaLogReader extends Logging {
           s"legacy 'pk,ts' delete log payload in $path only supports Int64 PKs"
         )
       }
-      longs += parts(0).trim.toLong
+      val pk = parts(0).trim.toLong
+      val deleteTs = parts(1).trim.toLong
+      longs.update(pk, math.max(longs.getOrElse(pk, Long.MinValue), deleteTs))
     }
   }
 

--- a/src/main/scala/read/MilvusDeltaLogReader.scala
+++ b/src/main/scala/read/MilvusDeltaLogReader.scala
@@ -1,0 +1,475 @@
+package com.zilliz.spark.connector.read
+
+import java.io.EOFException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.example.data.Group
+import org.apache.parquet.hadoop.api.ReadSupport
+import org.apache.parquet.hadoop.example.GroupReadSupport
+import org.apache.parquet.hadoop.ParquetReader
+import org.apache.parquet.io.{InputFile, SeekableInputStream}
+import org.apache.spark.internal.Logging
+
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
+
+object MilvusDeltaLogReader extends Logging {
+  private val MagicNumber = 0xfffabc
+  private val DescriptorEventType: Byte = 0
+  private val DeleteEventType: Byte = 2
+  private val EventTypeCount = 8
+  private val BaseEventHeaderSize = 17
+  private val DescriptorEventDataFixPartSize = 52
+  private val DeleteEventDataFixPartSize = 16
+  private val MultiFieldVersion = "MULTI_FIELD"
+
+  private val mapper = new ObjectMapper()
+
+  def loadDeletePlansBySegment(
+      segments: Seq[V2SegmentInfo],
+      milvusSchema: CollectionSchema,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Map[Long, MilvusDeletePlan]] = {
+    val pkField = primaryKeyField(milvusSchema)
+    val deleteOnlySegments = segments.filter(_.columnGroups.isEmpty)
+    val dataSegments = segments.filter(_.columnGroups.nonEmpty)
+
+    for {
+      globalPlan <- loadDeletePlan(
+        deleteOnlySegments.flatMap(_.deltaLogs),
+        pkField,
+        bucket,
+        hadoopConf
+      )
+      perSegment <- sequence(
+        dataSegments.map { seg =>
+          loadDeletePlan(seg.deltaLogs, pkField, bucket, hadoopConf).map {
+            ownPlan =>
+              seg.segmentId -> MilvusDeletePlan.union(globalPlan, ownPlan)
+          }
+        }
+      )
+    } yield perSegment.toMap
+  }
+
+  def loadDeletePlan(
+      deltaLogs: Seq[V2DeltaLogFile],
+      pkField: FieldSchema,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, MilvusDeletePlan] = {
+    try {
+      validatePkType(pkField)
+      val plans = deltaLogs.map { log =>
+        val fullyQualifiedPath =
+          V2SegmentLoader.resolvePath(log.logPath, bucket)
+        val bytes = V2SegmentLoader.readAllBytes(hadoopConf, fullyQualifiedPath)
+        decodeDeletePlan(bytes, pkField, fullyQualifiedPath)
+      }
+      sequence(plans).map(MilvusDeletePlan.union)
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  private def decodeDeletePlan(
+      bytes: Array[Byte],
+      pkField: FieldSchema,
+      path: String
+  ): Either[Throwable, MilvusDeletePlan] = {
+    try {
+      val container = parseContainer(bytes, path)
+      val plans = container.payloads.map { payload =>
+        decodePayloadPlan(payload, container.multiField, pkField, path)
+      }
+      Right(MilvusDeletePlan.union(plans))
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  private def decodePayloadPlan(
+      payload: Array[Byte],
+      multiField: Boolean,
+      pkField: FieldSchema,
+      path: String
+  ): MilvusDeletePlan = {
+    val longs = mutable.HashSet.empty[Long]
+    val strings = mutable.HashSet.empty[String]
+    val reader = newGroupReader(payload)
+    try {
+      var record = reader.read()
+      while (record != null) {
+        if (multiField) {
+          appendMultiFieldDelete(record, pkField, path, longs, strings)
+        } else {
+          appendLegacyDelete(
+            extractLegacyDelete(record, path),
+            pkField,
+            path,
+            longs,
+            strings
+          )
+        }
+        record = reader.read()
+      }
+    } finally {
+      reader.close()
+    }
+
+    pkField.dataType match {
+      case DataType.Int64   => MilvusDeletePlan.fromLongPks(longs.toSet)
+      case DataType.VarChar => MilvusDeletePlan.fromStringPks(strings.toSet)
+      case other =>
+        throw new IllegalArgumentException(
+          s"unsupported primary key type $other for delete logs"
+        )
+    }
+  }
+
+  private def appendMultiFieldDelete(
+      record: Group,
+      pkField: FieldSchema,
+      path: String,
+      longs: mutable.Set[Long],
+      strings: mutable.Set[String]
+  ): Unit = {
+    val fieldCount = record.getType.getFieldCount
+    if (fieldCount < 2) {
+      throw new IllegalStateException(
+        s"multi-field delete log payload in $path must contain pk and ts columns, found $fieldCount columns"
+      )
+    }
+    if (record.getFieldRepetitionCount(0) == 0) {
+      throw new IllegalStateException(
+        s"multi-field delete log payload in $path is missing the pk value"
+      )
+    }
+
+    pkField.dataType match {
+      case DataType.Int64   => longs += record.getLong(0, 0)
+      case DataType.VarChar => strings += record.getString(0, 0)
+      case other =>
+        throw new IllegalArgumentException(
+          s"unsupported primary key type $other for delete logs"
+        )
+    }
+  }
+
+  private def extractLegacyDelete(record: Group, path: String): String = {
+    val fieldCount = record.getType.getFieldCount
+    if (fieldCount < 1) {
+      throw new IllegalStateException(
+        s"legacy delete log payload in $path is missing the delta column"
+      )
+    }
+    if (record.getFieldRepetitionCount(0) == 0) {
+      throw new IllegalStateException(
+        s"legacy delete log payload in $path has an empty delta value"
+      )
+    }
+    record.getString(0, 0)
+  }
+
+  private def newGroupReader(payload: Array[Byte]): ParquetReader[Group] =
+    new ParquetReader.Builder[Group](new InMemoryInputFile(payload)) {
+      override protected def getReadSupport(): ReadSupport[Group] =
+        new GroupReadSupport()
+    }.build()
+
+  private def appendLegacyDelete(
+      raw: String,
+      pkField: FieldSchema,
+      path: String,
+      longs: mutable.Set[Long],
+      strings: mutable.Set[String]
+  ): Unit = {
+    val trimmed = raw.trim
+    if (trimmed.startsWith("{")) {
+      val json = mapper.readTree(trimmed)
+      val pkType = json.path("pkType").asInt(Int.MinValue)
+      val pkNode = json.path("pk")
+      if (pkType == Int.MinValue || pkNode.isMissingNode) {
+        throw new IllegalStateException(
+          s"invalid legacy delete log JSON in $path: $trimmed"
+        )
+      }
+      val expectedPkType = pkField.dataType match {
+        case DataType.Int64   => DataType.Int64.value
+        case DataType.VarChar => DataType.VarChar.value
+        case other =>
+          throw new IllegalArgumentException(
+            s"unsupported primary key type $other for delete logs"
+          )
+      }
+      if (pkType != expectedPkType) {
+        throw new IllegalStateException(
+          s"delete log pkType $pkType in $path does not match collection PK type ${pkField.dataType.value}"
+        )
+      }
+      pkField.dataType match {
+        case DataType.Int64 =>
+          if (!pkNode.isNumber) {
+            throw new IllegalStateException(
+              s"delete log pk in $path must be numeric for Int64 PKs: $trimmed"
+            )
+          }
+          longs += pkNode.longValue()
+        case DataType.VarChar =>
+          if (!pkNode.isTextual) {
+            throw new IllegalStateException(
+              s"delete log pk in $path must be textual for VarChar PKs: $trimmed"
+            )
+          }
+          strings += pkNode.textValue()
+        case _ =>
+      }
+    } else {
+      val parts = trimmed.split(",", 2)
+      if (parts.length != 2) {
+        throw new IllegalStateException(
+          s"invalid legacy delete log payload in $path: $trimmed"
+        )
+      }
+      if (pkField.dataType != DataType.Int64) {
+        throw new IllegalStateException(
+          s"legacy 'pk,ts' delete log payload in $path only supports Int64 PKs"
+        )
+      }
+      longs += parts(0).trim.toLong
+    }
+  }
+
+  private def parseContainer(
+      bytes: Array[Byte],
+      path: String
+  ): ParsedContainer = {
+    val buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    val magic = buf.getInt()
+    if (magic != MagicNumber) {
+      throw new IllegalStateException(
+        f"invalid deltalog magic number in $path: expected 0x$MagicNumber%x got 0x$magic%x"
+      )
+    }
+
+    val descriptorHeader = readHeader(buf, s"descriptor header in $path")
+    if (descriptorHeader.typeCode != DescriptorEventType) {
+      throw new IllegalStateException(
+        s"expected descriptor event at start of $path, got type ${descriptorHeader.typeCode}"
+      )
+    }
+
+    skipFully(
+      buf,
+      DescriptorEventDataFixPartSize,
+      s"descriptor fix part in $path"
+    )
+    val postHeaderLengths = new Array[Int](EventTypeCount)
+    var idx = 0
+    while (idx < EventTypeCount) {
+      ensureRemaining(buf, 1, s"descriptor post-header lengths in $path")
+      postHeaderLengths(idx) = buf.get() & 0xff
+      idx += 1
+    }
+    ensureRemaining(buf, 4, s"descriptor extras length in $path")
+    val extraLength = buf.getInt()
+    if (extraLength < 0) {
+      throw new IllegalStateException(
+        s"negative descriptor extras length $extraLength in $path"
+      )
+    }
+    ensureRemaining(buf, extraLength, s"descriptor extras in $path")
+    val extraBytes = new Array[Byte](extraLength)
+    buf.get(extraBytes)
+    val extras =
+      if (extraBytes.isEmpty) mapper.createObjectNode()
+      else mapper.readTree(extraBytes)
+    val multiField =
+      Option(extras.get("version")).exists(_.asText() == MultiFieldVersion)
+
+    val payloads = mutable.ArrayBuffer.empty[Array[Byte]]
+    while (buf.hasRemaining) {
+      val header = readHeader(buf, s"event header in $path")
+      val fixPartSize =
+        if (header.typeCode >= 0 && header.typeCode < postHeaderLengths.length)
+          postHeaderLengths(header.typeCode)
+        else 0
+      if (fixPartSize < 0) {
+        throw new IllegalStateException(
+          s"negative event fix-part size $fixPartSize in $path"
+        )
+      }
+      ensureRemaining(buf, fixPartSize, s"event fix part in $path")
+      skipFully(buf, fixPartSize, s"event fix part in $path")
+      val payloadLength = header.eventLength - BaseEventHeaderSize - fixPartSize
+      if (payloadLength < 0) {
+        throw new IllegalStateException(
+          s"negative event payload length $payloadLength in $path"
+        )
+      }
+      ensureRemaining(buf, payloadLength, s"event payload in $path")
+      val payload = new Array[Byte](payloadLength)
+      buf.get(payload)
+      if (header.typeCode == DeleteEventType && payload.nonEmpty) {
+        payloads += payload
+      }
+    }
+
+    ParsedContainer(multiField = multiField, payloads = payloads.toSeq)
+  }
+
+  private def readHeader(buf: ByteBuffer, context: String): ParsedHeader = {
+    ensureRemaining(buf, BaseEventHeaderSize, context)
+    buf.getLong()
+    val typeCode = buf.get()
+    val eventLength = buf.getInt()
+    buf.getInt()
+    ParsedHeader(typeCode, eventLength)
+  }
+
+  private def primaryKeyField(milvusSchema: CollectionSchema): FieldSchema = {
+    val pkField = milvusSchema.fields.find(_.isPrimaryKey).getOrElse {
+      throw new IllegalArgumentException("No primary key field found in schema")
+    }
+    validatePkType(pkField)
+    pkField
+  }
+
+  private def validatePkType(pkField: FieldSchema): Unit = {
+    pkField.dataType match {
+      case DataType.Int64 | DataType.VarChar =>
+      case other =>
+        throw new IllegalArgumentException(
+          s"StorageV2 delete logs only support Int64/VarChar PKs, got $other"
+        )
+    }
+  }
+
+  private def asLong(value: Any, context: String): Long = value match {
+    case n: java.lang.Long    => n.longValue()
+    case n: java.lang.Integer => n.longValue()
+    case n: java.lang.Short   => n.longValue()
+    case n: java.lang.Byte    => n.longValue()
+    case n: java.lang.Number  => n.longValue()
+    case other =>
+      throw new IllegalStateException(s"expected numeric $context, got $other")
+  }
+
+  private def ensureRemaining(
+      buf: ByteBuffer,
+      needed: Int,
+      context: String
+  ): Unit = {
+    if (buf.remaining() < needed) {
+      throw new EOFException(
+        s"unexpected EOF while reading $context: need $needed bytes, only ${buf.remaining()} remain"
+      )
+    }
+  }
+
+  private def skipFully(buf: ByteBuffer, length: Int, context: String): Unit = {
+    ensureRemaining(buf, length, context)
+    buf.position(buf.position() + length)
+  }
+
+  private def sequence[A](
+      items: Seq[Either[Throwable, A]]
+  ): Either[Throwable, Seq[A]] = {
+    val out = mutable.ArrayBuffer.empty[A]
+    items.foreach {
+      case Right(value) => out += value
+      case Left(err)    => return Left(err)
+    }
+    Right(out.toSeq)
+  }
+
+  private final case class ParsedHeader(typeCode: Byte, eventLength: Int)
+  private final case class ParsedContainer(
+      multiField: Boolean,
+      payloads: Seq[Array[Byte]]
+  )
+
+  private final class InMemoryInputFile(bytes: Array[Byte]) extends InputFile {
+    override def getLength: Long = bytes.length.toLong
+
+    override def newStream(): SeekableInputStream =
+      new SeekableInputStream {
+        private var pos = 0
+
+        override def getPos: Long = pos.toLong
+
+        override def seek(newPos: Long): Unit = {
+          if (newPos < 0 || newPos > bytes.length) {
+            throw new EOFException(
+              s"invalid seek position $newPos for in-memory parquet payload of ${bytes.length} bytes"
+            )
+          }
+          pos = newPos.toInt
+        }
+
+        override def read(): Int = {
+          if (pos >= bytes.length) -1
+          else {
+            val value = bytes(pos) & 0xff
+            pos += 1
+            value
+          }
+        }
+
+        override def read(b: Array[Byte], off: Int, len: Int): Int = {
+          if (pos >= bytes.length) {
+            -1
+          } else {
+            val toRead = math.min(len, bytes.length - pos)
+            System.arraycopy(bytes, pos, b, off, toRead)
+            pos += toRead
+            toRead
+          }
+        }
+
+        override def readFully(target: Array[Byte]): Unit =
+          readFully(target, 0, target.length)
+
+        override def read(target: ByteBuffer): Int = {
+          if (pos >= bytes.length) {
+            -1
+          } else {
+            val toRead = math.min(target.remaining(), bytes.length - pos)
+            target.put(bytes, pos, toRead)
+            pos += toRead
+            toRead
+          }
+        }
+
+        override def readFully(target: ByteBuffer): Unit = {
+          val len = target.remaining()
+          ensureAvailable(len)
+          target.put(bytes, pos, len)
+          pos += len
+        }
+
+        override def readFully(
+            target: Array[Byte],
+            start: Int,
+            len: Int
+        ): Unit = {
+          ensureAvailable(len)
+          System.arraycopy(bytes, pos, target, start, len)
+          pos += len
+        }
+
+        private def ensureAvailable(len: Int): Unit = {
+          if (pos + len > bytes.length) {
+            throw new EOFException(
+              s"unexpected EOF while reading in-memory parquet payload: need $len bytes at offset $pos, payload size=${bytes.length}"
+            )
+          }
+        }
+      }
+  }
+}

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -27,7 +27,9 @@ case class MilvusStorageV3InputPartition(
     vectorColumn: Option[String] = None,
     segmentID: Long = -1L,
     readVersion: Long =
-      -1L // -1 = LATEST, >0 = specific manifest version from snapshot
+      -1L, // -1 = LATEST, >0 = specific manifest version from snapshot
+    applyDeletes: Boolean = true,
+    deletePlan: MilvusDeletePlan = MilvusDeletePlan.empty
 ) extends InputPartition
 
 /** InputPartition for milvus-segment-info `storage_version = 2` — the
@@ -51,5 +53,7 @@ case class MilvusPackedV2InputPartition(
     columnGroups: Seq[V2ColumnGroup],
     milvusSchemaBytes: Array[Byte],
     milvusOption: MilvusOption,
-    neededColumnFieldIds: Seq[Long] = Seq.empty
+    neededColumnFieldIds: Seq[Long] = Seq.empty,
+    applyDeletes: Boolean = true,
+    deletePlan: MilvusDeletePlan = MilvusDeletePlan.empty
 ) extends InputPartition

--- a/src/main/scala/read/MilvusInputPartition.scala
+++ b/src/main/scala/read/MilvusInputPartition.scala
@@ -55,5 +55,15 @@ case class MilvusPackedV2InputPartition(
     milvusOption: MilvusOption,
     neededColumnFieldIds: Seq[Long] = Seq.empty,
     applyDeletes: Boolean = true,
-    deletePlan: MilvusDeletePlan = MilvusDeletePlan.empty
+    deletePlan: MilvusDeletePlan = MilvusDeletePlan.empty,
+    inheritedDeletePlanPartitionId: Option[Long] = None
 ) extends InputPartition
+
+case class MilvusPackedV2DeleteContext(
+    inheritedPlansByPartition: Map[Long, MilvusDeletePlan]
+)
+
+object MilvusPackedV2DeleteContext {
+  val empty: MilvusPackedV2DeleteContext =
+    MilvusPackedV2DeleteContext(Map.empty)
+}

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -6,16 +6,22 @@ import org.apache.arrow.c.{
   CDataDictionaryProvider,
   Data
 }
-import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.{
+  BigIntVector,
+  VarBinaryVector,
+  VarCharVector,
+  VectorSchemaRoot
+}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.unsafe.types.UTF8String
 
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
 import com.zilliz.spark.connector.MilvusOption
-import io.milvus.grpc.schema.CollectionSchema
+import io.milvus.grpc.schema.{CollectionSchema, DataType}
 import io.milvus.storage.{
   ArrowUtils,
   MilvusStorageColumnGroups,
@@ -67,6 +73,25 @@ object MilvusPackedV2PartitionReader {
     )
   }
 
+  private[read] def projectedFieldIds(
+      sourceSchema: StructType,
+      fieldMappings: FieldMappings,
+      neededColumnFieldIds: Seq[Long],
+      applyDeletes: Boolean,
+      deletePlan: MilvusDeletePlan,
+      pkFieldId: Long
+  ): Seq[Long] = {
+    if (!applyDeletes || deletePlan.isEmpty) {
+      neededColumnFieldIds
+    } else if (neededColumnFieldIds.nonEmpty) {
+      (neededColumnFieldIds :+ pkFieldId).distinct
+    } else {
+      (sourceSchema.fieldNames.toSeq.flatMap(
+        fieldMappings.fieldNameToId.get
+      ) :+ pkFieldId).distinct
+    }
+  }
+
   private[read] def resolveNeededColumns(
       sourceSchema: StructType,
       columnGroups: Seq[V2ColumnGroup],
@@ -103,6 +128,7 @@ object MilvusPackedV2PartitionReader {
         }
         sourceSchema.fieldNames.toSeq.flatMap(fieldMappings.fieldNameToId.get)
       }
+
     val missingFieldIds = requestedFieldIds.filterNot(declaredFieldIds.contains)
     if (missingFieldIds.nonEmpty) {
       val missingColumns = missingFieldIds
@@ -118,32 +144,19 @@ object MilvusPackedV2PartitionReader {
           s"; declared columns=${declaredColumns.mkString(",")}"
       )
     }
+
     requestedFieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
   }
 }
 
-/** Spark partition reader for milvus-segment-info `storage_version = 2`
-  * (StorageV2, non-manifest packed parquet) segments.
-  *
-  * Unlike [[MilvusLoonPartitionReader]] (which handles StorageV3: manifest
-  * based, resolves a milvus-storage `.milvus_manifest` file via
-  * `MilvusStorageManifest.getColumnGroupsScala`), this reader is handed a
-  * pre-materialized set of [[V2ColumnGroup]]s recovered from the snapshot AVRO
-  * (slot -> file paths) + one parquet footer's `group_field_id_list`
-  * kv-metadata (slot -> real field IDs). The packed reader then opens only the
-  * files for the requested columns.
-  *
-  * The reader iterates the Arrow stream sequentially (no vector search, no
-  * filter pushdown). Backfill only needs the PK column plus positional row
-  * metadata added by [[MilvusPartitionReaderFactory]], so the minimal shape
-  * fits well.
-  */
 class MilvusPackedV2PartitionReader(
     schema: StructType,
     columnGroups: Seq[V2ColumnGroup],
     milvusSchema: CollectionSchema,
     milvusOption: MilvusOption,
-    neededColumnFieldIds: Seq[Long]
+    neededColumnFieldIds: Seq[Long],
+    applyDeletes: Boolean,
+    deletePlan: MilvusDeletePlan
 ) extends PartitionReader[InternalRow]
     with Logging {
 
@@ -151,47 +164,39 @@ class MilvusPackedV2PartitionReader(
 
   private val allocator = ArrowUtils.getAllocator
   private val sourceSchema = schema
-
+  private val pkField = milvusSchema.fields.find(_.isPrimaryKey).getOrElse {
+    throw new IllegalArgumentException("No primary key field found in schema")
+  }
   private val fieldMappings =
     MilvusPackedV2PartitionReader.buildFieldMappings(milvusSchema)
   private val fieldNameToArrowColumn = fieldMappings.fieldNameToArrowColumn
-
-  // Which column names to ask the packed reader for. Prefer explicit
-  // projection from neededColumnFieldIds; fall back to sourceSchema's Spark
-  // field names. In both cases we coerce to logical names that the parquet
-  // actually carries.
+  private val effectiveNeededColumnFieldIds =
+    MilvusPackedV2PartitionReader.projectedFieldIds(
+      sourceSchema,
+      fieldMappings,
+      neededColumnFieldIds,
+      applyDeletes,
+      deletePlan,
+      pkField.fieldID
+    )
   private val neededColumns: Array[String] =
     MilvusPackedV2PartitionReader.resolveNeededColumns(
       sourceSchema,
       columnGroups,
       fieldMappings,
-      neededColumnFieldIds
+      effectiveNeededColumnFieldIds
     )
+  private val pkColumnName =
+    fieldMappings.fieldIdToName.getOrElse(pkField.fieldID, pkField.name)
 
-  // V2 packed parquet uses logical names (e.g. "ID"). When callers request
-  // aliases such as row_id/timestamp, ArrowConverter must look up the canonical
-  // packed column names RowID/Timestamp instead.
-
-  // Native resource handles. Initialized to safe defaults so a partial-init
-  // failure can roll back whatever was allocated so far. Spark only calls
-  // close() on a fully-constructed reader; any throw from the init block
-  // below has to release its own resources before bubbling out.
   private var arrowSchemaObj: ArrowSchema = null
   private var readerProperties: MilvusStorageProperties = null
   private var columnGroupsPtr: Long = 0L
   private var reader: MilvusStorageReader = null
-  // Per-batch record batch reader handle (see milvus-storage
-  // loon_record_batch_reader_*). We deliberately avoid the ArrowArrayStream
-  // path because Arrow Java's `ArrowReader.loadNextBatch` shares one
-  // VectorSchemaRoot across batches and ignores the ArrowArray `offset`
-  // field — when the underlying C++ reader emits `RecordBatch::Slice`
-  // results, every batch after the first would show the same data.
   private var rbrHandle: Long = 0L
   private var dictProvider: CDataDictionaryProvider = null
 
   try {
-    // Arrow schema for the read: columns named by their logical names so the
-    // packed reader can find them by name in the on-disk parquet.
     val arrowSchema =
       com.zilliz.spark.connector.MilvusSchemaUtil.convertToArrowSchema(
         milvusSchema
@@ -201,11 +206,6 @@ class MilvusPackedV2PartitionReader(
 
     readerProperties = Properties.fromMilvusOption(milvusOption)
 
-    // Build LoonColumnGroups directly from the materialized v2 layout. Each
-    // group's `columns` is the LOGICAL names of its fields (matching what
-    // milvus segcore wrote into the parquet). Row counts (per file) come
-    // from the AVRO's AvroBinlog.entries_num — required because the packed
-    // reader rejects negative end indices.
     val cols = columnGroups.map { cg =>
       cg.fieldIds.flatMap(fieldMappings.fieldIdToName.get).toArray
     }.toArray
@@ -242,20 +242,15 @@ class MilvusPackedV2PartitionReader(
       throw e
   }
 
-  // Per-batch state: each loadNextBatch() imports a FRESH RecordBatch
-  // into a NEW VectorSchemaRoot. The previous root (if any) is closed
-  // before the next import so buffers are correctly reclaimed. This
-  // intentionally does not reuse a single root across batches — Arrow
-  // Java's shared-root import drops the per-batch `offset`.
-  //
-  // Initialized inside its own try/catch: Spark only calls close() on
-  // a fully-constructed reader, so a throw from the first loadNextBatch
-  // (e.g. a malformed parquet chunk) would otherwise leak every native
-  // handle allocated in the main init block above.
-  private var _currentBatch: VectorSchemaRoot = null
-  private var _currentRowIndex: Int = 0
+  private var currentBatch: VectorSchemaRoot = null
+  private var currentRowIndex: Int = 0
+  private var currentBatchStartRowOffset: Long = 0L
+  private var _lastReturnedRowOffset: Long = -1L
+
+  def lastReturnedRowOffset: Long = _lastReturnedRowOffset
+
   try {
-    _currentBatch = loadNextBatch()
+    currentBatch = loadNextBatch()
   } catch {
     case e: Throwable =>
       releaseAll()
@@ -277,18 +272,9 @@ class MilvusPackedV2PartitionReader(
       if (!gotBatch) {
         null
       } else {
-        // Import the ArrowArray+ArrowSchema as a RecordBatch-backed
-        // VectorSchemaRoot. Import takes ownership of the release
-        // callbacks (moves them out), so the subsequent `.close()` on
-        // cArr / cSchema is a no-op w.r.t. the live buffers; closing
-        // the returned root (in close()/loadNextBatch) is what releases
-        // them.
         Data.importVectorSchemaRoot(allocator, cArr, cSchema, dictProvider)
       }
     } finally {
-      // Always close the C-struct wrappers: after a successful import
-      // their release callback has been moved into the root and this is
-      // a no-op; on failure we need to release them to avoid leaks.
       try cArr.close()
       catch { case e: Throwable => logWarning("close cArr failed", e) }
       try cSchema.close()
@@ -297,47 +283,91 @@ class MilvusPackedV2PartitionReader(
   }
 
   override def next(): Boolean = {
-    // Advance past exhausted batches; close the previous root before
-    // loading the next so we bound JVM direct memory to one live batch.
-    while (
-      _currentBatch != null && _currentRowIndex >= _currentBatch.getRowCount
-    ) {
-      val exhausted = _currentBatch
-      _currentBatch = null
-      try exhausted.close()
-      catch {
-        case e: Throwable => logWarning("close exhausted batch failed", e)
+    while (true) {
+      while (
+        currentBatch != null && currentRowIndex >= currentBatch.getRowCount
+      ) {
+        val exhausted = currentBatch
+        currentBatch = null
+        currentBatchStartRowOffset += exhausted.getRowCount.toLong
+        try exhausted.close()
+        catch {
+          case e: Throwable => logWarning("close exhausted batch failed", e)
+        }
+        currentBatch = loadNextBatch()
+        currentRowIndex = 0
       }
-      _currentBatch = loadNextBatch()
-      _currentRowIndex = 0
+
+      if (currentBatch == null) {
+        return false
+      }
+
+      if (applyDeletes && !deletePlan.isEmpty && isDeleted(currentRowIndex)) {
+        currentRowIndex += 1
+      } else {
+        return true
+      }
     }
-    _currentBatch != null && _currentRowIndex < _currentBatch.getRowCount
+    false
   }
 
   override def get(): InternalRow = {
-    if (_currentBatch == null) {
+    if (currentBatch == null) {
       throw new IllegalStateException("No batch loaded")
     }
+    _lastReturnedRowOffset = currentBatchStartRowOffset + currentRowIndex
     val row = ArrowConverter.arrowToInternalRow(
-      _currentBatch,
-      _currentRowIndex,
+      currentBatch,
+      currentRowIndex,
       sourceSchema,
       fieldNameToArrowColumn
     )
-    _currentRowIndex += 1
+    currentRowIndex += 1
     row
   }
 
   override def close(): Unit = releaseAll()
 
-  // Each native resource is released in its own try-catch so one failing
-  // release doesn't strand the rest. Also reused by the constructor's
-  // failure path to roll back a partial init.
+  private def isDeleted(rowIndex: Int): Boolean = {
+    val vector = currentBatch.getVector(pkColumnName)
+    if (vector == null) {
+      throw new IllegalStateException(
+        s"Packed V2 delete filtering requires PK column $pkColumnName to be loaded"
+      )
+    }
+    if (vector.isNull(rowIndex)) {
+      false
+    } else {
+      pkField.dataType match {
+        case DataType.Int64 =>
+          deletePlan.containsLongPk(
+            vector.asInstanceOf[BigIntVector].get(rowIndex)
+          )
+        case DataType.VarChar =>
+          val value = vector match {
+            case v: VarCharVector =>
+              UTF8String.fromBytes(v.get(rowIndex)).toString
+            case v: VarBinaryVector =>
+              UTF8String.fromBytes(v.get(rowIndex)).toString
+            case other =>
+              throw new IllegalStateException(
+                s"Packed V2 delete filtering expected VarChar/VarBinary PK vector for $pkColumnName, got ${other.getClass.getSimpleName}"
+              )
+          }
+          deletePlan.containsStringPk(value)
+        case other =>
+          throw new IllegalArgumentException(
+            s"Packed V2 delete filtering only supports Int64/VarChar PKs, got $other"
+          )
+      }
+    }
+  }
+
   private def releaseAll(): Unit = {
-    if (_currentBatch != null) {
-      try _currentBatch.close()
+    if (currentBatch != null) {
+      try currentBatch.close()
       catch { case e: Throwable => logWarning("close currentBatch failed", e) }
-      _currentBatch = null
+      currentBatch = null
     }
     if (rbrHandle != 0L) {
       try reader.destroyRecordBatchReaderScala(rbrHandle)

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -21,7 +21,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
 import com.zilliz.spark.connector.MilvusOption
-import io.milvus.grpc.schema.{CollectionSchema, DataType}
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
 import io.milvus.storage.{
   ArrowUtils,
   MilvusStorageColumnGroups,
@@ -79,16 +79,55 @@ object MilvusPackedV2PartitionReader {
       neededColumnFieldIds: Seq[Long],
       applyDeletes: Boolean,
       deletePlan: MilvusDeletePlan,
-      pkFieldId: Long
+      pkFieldId: Long,
+      tsFieldId: Long = 1L
   ): Seq[Long] = {
     if (!applyDeletes || deletePlan.isEmpty) {
       neededColumnFieldIds
     } else if (neededColumnFieldIds.nonEmpty) {
-      (neededColumnFieldIds :+ pkFieldId).distinct
+      (neededColumnFieldIds ++ Seq(pkFieldId, tsFieldId)).distinct
     } else {
       (sourceSchema.fieldNames.toSeq.flatMap(
         fieldMappings.fieldNameToId.get
-      ) :+ pkFieldId).distinct
+      ) ++ Seq(pkFieldId, tsFieldId)).distinct
+    }
+  }
+
+  private[read] def rowDeleted(
+      deletePlan: MilvusDeletePlan,
+      pkField: FieldSchema,
+      pkVector: org.apache.arrow.vector.ValueVector,
+      tsVector: BigIntVector,
+      rowIndex: Int,
+      pkColumnName: String
+  ): Boolean = {
+    if (pkVector.isNull(rowIndex) || tsVector.isNull(rowIndex)) {
+      false
+    } else {
+      val rowTs = tsVector.get(rowIndex)
+      pkField.dataType match {
+        case DataType.Int64 =>
+          deletePlan.containsLongPk(
+            pkVector.asInstanceOf[BigIntVector].get(rowIndex),
+            rowTs
+          )
+        case DataType.VarChar =>
+          val value = pkVector match {
+            case v: VarCharVector =>
+              UTF8String.fromBytes(v.get(rowIndex)).toString
+            case v: VarBinaryVector =>
+              UTF8String.fromBytes(v.get(rowIndex)).toString
+            case other =>
+              throw new IllegalStateException(
+                s"Packed V2 delete filtering expected VarChar/VarBinary PK vector for $pkColumnName, got ${other.getClass.getSimpleName}"
+              )
+          }
+          deletePlan.containsStringPk(value, rowTs)
+        case other =>
+          throw new IllegalArgumentException(
+            s"Packed V2 delete filtering only supports Int64/VarChar PKs, got $other"
+          )
+      }
     }
   }
 
@@ -177,7 +216,8 @@ class MilvusPackedV2PartitionReader(
       neededColumnFieldIds,
       applyDeletes,
       deletePlan,
-      pkField.fieldID
+      pkField.fieldID,
+      tsFieldId = 1L
     )
   private val neededColumns: Array[String] =
     MilvusPackedV2PartitionReader.resolveNeededColumns(
@@ -329,38 +369,26 @@ class MilvusPackedV2PartitionReader(
   override def close(): Unit = releaseAll()
 
   private def isDeleted(rowIndex: Int): Boolean = {
-    val vector = currentBatch.getVector(pkColumnName)
-    if (vector == null) {
+    val pkVector = currentBatch.getVector(pkColumnName)
+    if (pkVector == null) {
       throw new IllegalStateException(
         s"Packed V2 delete filtering requires PK column $pkColumnName to be loaded"
       )
     }
-    if (vector.isNull(rowIndex)) {
-      false
-    } else {
-      pkField.dataType match {
-        case DataType.Int64 =>
-          deletePlan.containsLongPk(
-            vector.asInstanceOf[BigIntVector].get(rowIndex)
-          )
-        case DataType.VarChar =>
-          val value = vector match {
-            case v: VarCharVector =>
-              UTF8String.fromBytes(v.get(rowIndex)).toString
-            case v: VarBinaryVector =>
-              UTF8String.fromBytes(v.get(rowIndex)).toString
-            case other =>
-              throw new IllegalStateException(
-                s"Packed V2 delete filtering expected VarChar/VarBinary PK vector for $pkColumnName, got ${other.getClass.getSimpleName}"
-              )
-          }
-          deletePlan.containsStringPk(value)
-        case other =>
-          throw new IllegalArgumentException(
-            s"Packed V2 delete filtering only supports Int64/VarChar PKs, got $other"
-          )
-      }
+    val rawTsVector = currentBatch.getVector("Timestamp")
+    if (rawTsVector == null) {
+      throw new IllegalStateException(
+        "Packed V2 delete filtering requires Timestamp column to be loaded"
+      )
     }
+    MilvusPackedV2PartitionReader.rowDeleted(
+      deletePlan,
+      pkField,
+      pkVector,
+      rawTsVector.asInstanceOf[BigIntVector],
+      rowIndex,
+      pkColumnName
+    )
   }
 
   private def releaseAll(): Unit = {

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -46,7 +46,9 @@ object MilvusPartitionReaderFactory {
 class MilvusPartitionReaderFactory(
     schema: StructType,
     optionsMap: Map[String, String],
-    pushedFilters: Array[Filter] = Array.empty[Filter]
+    pushedFilters: Array[Filter] = Array.empty[Filter],
+    packedV2DeleteContext: MilvusPackedV2DeleteContext =
+      MilvusPackedV2DeleteContext.empty
 ) extends PartitionReaderFactory
     with Logging {
 
@@ -140,6 +142,14 @@ class MilvusPartitionReaderFactory(
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
 
+        val effectiveDeletePlan = MilvusDeletePlan.union(
+          packedV2DeleteContext.inheritedPlansByPartition.getOrElse(
+            p.inheritedDeletePlanPartitionId.getOrElse(Long.MinValue),
+            MilvusDeletePlan.empty
+          ),
+          p.deletePlan
+        )
+
         val underlying = new MilvusPackedV2PartitionReader(
           innerSchema,
           p.columnGroups,
@@ -147,7 +157,7 @@ class MilvusPartitionReaderFactory(
           p.milvusOption,
           p.neededColumnFieldIds,
           p.applyDeletes,
-          p.deletePlan
+          effectiveDeletePlan
         )
 
         val hasMetadataExtraFields = schema.fieldNames.exists { name =>

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -145,7 +145,9 @@ class MilvusPartitionReaderFactory(
           p.columnGroups,
           milvusSchema,
           p.milvusOption,
-          p.neededColumnFieldIds
+          p.neededColumnFieldIds,
+          p.applyDeletes,
+          p.deletePlan
         )
 
         val hasMetadataExtraFields = schema.fieldNames.exists { name =>
@@ -154,8 +156,6 @@ class MilvusPartitionReaderFactory(
 
         if (hasMetadataExtraFields) {
           new PartitionReader[InternalRow] {
-            private var rowOffset: Long = 0L
-
             override def next(): Boolean = underlying.next()
 
             override def get(): InternalRow = {
@@ -172,13 +172,12 @@ class MilvusPartitionReaderFactory(
                   case MilvusOption.MilvusExtraColumnSegmentID =>
                     out(writeIdx) = p.segmentID
                   case MilvusOption.MilvusExtraColumnRowOffset =>
-                    out(writeIdx) = rowOffset
+                    out(writeIdx) = underlying.lastReturnedRowOffset
                   case _ =>
                     out(writeIdx) = row.get(readIdx, field.dataType)
                     readIdx += 1
                 }
               }
-              rowOffset += 1
 
               InternalRow.fromSeq(out.toSeq)
             }

--- a/src/main/scala/read/MilvusSegmentManifestReader.scala
+++ b/src/main/scala/read/MilvusSegmentManifestReader.scala
@@ -36,9 +36,11 @@ private[read] case class AvroBinlogEntry(
 private[read] case class AvroManifestEntry(
     segmentId: Long,
     partitionId: Long,
+    segmentLevel: Long,
     numOfRows: Long,
     storageVersion: Long,
-    binlogFiles: Seq[AvroFieldBinlogEntry]
+    binlogFiles: Seq[AvroFieldBinlogEntry],
+    deltaLogFiles: Seq[AvroFieldBinlogEntry]
 )
 
 /** Decoder for per-segment manifest AVRO files written by milvus-datacoord.
@@ -60,33 +62,28 @@ private[read] case class AvroManifestEntry(
   */
 object MilvusSegmentManifestReader extends Logging {
 
-  /** Classpath path of the bundled AVSC (same content as milvus's
-    * `getProperAvroSchema()`).
-    */
-  private val SchemaResource = "/milvus-segment-manifest.avsc"
+  private val LastNeededField = "deltalog_files"
 
-  /** The last field we read from each AVRO record. Avro binary is positional
-    * and has no container header here, so the reader schema must match the
-    * writer schema exactly for whatever it parses. By stopping at
-    * `binlog_files` (the last field backfill actually uses) we make all
-    * trailing fields — present or absent — effectively optional: extra bytes
-    * after this field are simply ignored, and writers that emit fewer trailing
-    * fields still decode because the prefix they share with us is identical.
-    * Update this if backfill starts consuming a later field.
-    */
-  private val LastNeededField = "binlog_files"
+  private val SchemaResources: Map[Int, String] = Map(
+    1 -> "/milvus-segment-manifest-v1.avsc",
+    2 -> "/milvus-segment-manifest-v2.avsc",
+    3 -> "/milvus-segment-manifest-v3.avsc",
+    4 -> "/milvus-segment-manifest-v4.avsc"
+  )
 
-  /** Parsed lazily once. `Schema.Parser` is not thread-safe but the parsed
-    * `Schema` is immutable, so lazy val is fine. We truncate the bundled schema
-    * to the prefix ending at `LastNeededField` so trailing fields are treated
-    * as optional across milvus versions.
-    */
-  private lazy val schema: Schema = truncatedSchema(fullSchema, LastNeededField)
+  private lazy val schemas: Map[Int, Schema] = SchemaResources.map {
+    case (version, resource) =>
+      version -> truncatedSchema(
+        loadSchema(resource),
+        LastNeededField,
+        resource
+      )
+  }
 
-  private lazy val fullSchema: Schema = {
-    val in = Option(getClass.getResourceAsStream(SchemaResource)).getOrElse {
+  private def loadSchema(resource: String): Schema = {
+    val in = Option(getClass.getResourceAsStream(resource)).getOrElse {
       throw new IllegalStateException(
-        s"bundled AVSC resource $SchemaResource not found on classpath"
+        s"bundled AVSC resource $resource not found on classpath"
       )
     }
     try {
@@ -98,15 +95,27 @@ object MilvusSegmentManifestReader extends Logging {
     }
   }
 
+  private def schemaFor(version: Int): Schema =
+    schemas.getOrElse(
+      version,
+      throw new IllegalArgumentException(
+        s"Unsupported Milvus manifest schema version $version"
+      )
+    )
+
   /** Build a record schema containing only the prefix of `full`'s fields up to
     * and including `lastField`. Field objects are reconstructed so the new
     * record owns them (avro forbids a field being attached to two records).
     */
-  private def truncatedSchema(full: Schema, lastField: String): Schema = {
+  private def truncatedSchema(
+      full: Schema,
+      lastField: String,
+      resource: String
+  ): Schema = {
     val idx = full.getFields.asScala.indexWhere(_.name == lastField)
     if (idx < 0) {
       throw new IllegalStateException(
-        s"bundled AVSC $SchemaResource is missing required field '$lastField'"
+        s"bundled AVSC $resource is missing required field '$lastField'"
       )
     }
     val truncated = Schema.createRecord(
@@ -128,9 +137,15 @@ object MilvusSegmentManifestReader extends Logging {
     * @return
     *   `Right(entry)` on success, or `Left(throwable)` on any parse error.
     */
-  def parse(avroBytes: Array[Byte]): Either[Throwable, AvroManifestEntry] = {
+  def parse(
+      avroBytes: Array[Byte],
+      manifestSchemaVersion: Int = 1
+  ): Either[Throwable, AvroManifestEntry] = {
     try {
-      val reader = new GenericDatumReader[GenericRecord](schema)
+      val reader =
+        new GenericDatumReader[GenericRecord](
+          schemaFor(manifestSchemaVersion)
+        )
       val decoder =
         DecoderFactory
           .get()
@@ -141,6 +156,8 @@ object MilvusSegmentManifestReader extends Logging {
       case e: Throwable => Left(e)
     }
   }
+
+  def supportedSchemaVersions: Seq[Int] = SchemaResources.keys.toSeq.sorted
 
   /** Join an AVRO entry with the segment's `group_field_id_list` kv-metadata
     * (read from any one of the segment's parquet files) to produce the runtime
@@ -172,7 +189,17 @@ object MilvusSegmentManifestReader extends Logging {
           partitionId = entry.partitionId,
           numOfRows = entry.numOfRows,
           storageVersion = entry.storageVersion,
-          columnGroups = Seq.empty
+          columnGroups = Seq.empty,
+          deltaLogs = entry.deltaLogFiles
+            .flatMap(_.binlogs)
+            .sortBy(_.logId)
+            .map(log =>
+              V2DeltaLogFile(
+                logId = log.logId,
+                logPath = log.logPath,
+                entriesNum = log.entriesNum
+              )
+            )
         )
       )
     } else if (entry.binlogFiles.size != groupFieldIdList.size) {
@@ -200,13 +227,24 @@ object MilvusSegmentManifestReader extends Logging {
             slotFieldId = afb.slotFieldId
           )
         }
+      val deltaLogs = entry.deltaLogFiles
+        .flatMap(_.binlogs)
+        .sortBy(_.logId)
+        .map(log =>
+          V2DeltaLogFile(
+            logId = log.logId,
+            logPath = log.logPath,
+            entriesNum = log.entriesNum
+          )
+        )
       Right(
         V2SegmentInfo(
           segmentId = entry.segmentId,
           partitionId = entry.partitionId,
           numOfRows = entry.numOfRows,
           storageVersion = entry.storageVersion,
-          columnGroups = cgs
+          columnGroups = cgs,
+          deltaLogs = deltaLogs
         )
       )
     }
@@ -251,9 +289,11 @@ object MilvusSegmentManifestReader extends Logging {
     AvroManifestEntry(
       segmentId = asLong(rec.get("segment_id")),
       partitionId = asLong(rec.get("partition_id")),
+      segmentLevel = asLong(rec.get("segment_level")),
       numOfRows = asLong(rec.get("num_of_rows")),
       storageVersion = asLong(rec.get("storage_version")),
-      binlogFiles = projectFieldBinlogs(rec.get("binlog_files"))
+      binlogFiles = projectFieldBinlogs(rec.get("binlog_files")),
+      deltaLogFiles = projectFieldBinlogs(rec.get("deltalog_files"))
     )
   }
 

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -357,13 +357,24 @@ case class V2ColumnGroupDTO(
     @JsonProperty("file_row_counts") fileRowCounts: Seq[JsonNode] = Seq.empty
 )
 
+case class V2DeltaLogFileDTO(
+    @JsonProperty("log_id") rawLogId: Option[JsonNode] = None,
+    @JsonProperty("log_path") logPath: String = "",
+    @JsonProperty("entries_num") rawEntriesNum: Option[JsonNode] = None
+) {
+  def logId: Long = rawLogId.map(JsonTypeConverter.toLong).getOrElse(0L)
+  def entriesNum: Long =
+    rawEntriesNum.map(JsonTypeConverter.toLong).getOrElse(0L)
+}
+
 case class V2SegmentInfoDTO(
     @JsonProperty("segment_id") rawSegmentId: Option[JsonNode] = None,
     @JsonProperty("partition_id") rawPartitionId: Option[JsonNode] = None,
     @JsonProperty("num_of_rows") rawNumOfRows: Option[JsonNode] = None,
     @JsonProperty("storage_version") rawStorageVersion: Option[JsonNode] = None,
     @JsonProperty("column_groups") columnGroups: Seq[V2ColumnGroupDTO] =
-      Seq.empty
+      Seq.empty,
+    @JsonProperty("delta_logs") deltaLogs: Seq[V2DeltaLogFileDTO] = Seq.empty
 ) {
   def segmentId: Long = rawSegmentId.map(JsonTypeConverter.toLong).getOrElse(0L)
   def partitionId: Long =
@@ -405,14 +416,54 @@ case class V2ColumnGroup(
     slotFieldId: Long = -1L
 )
 
+case class V2DeltaLogFile(
+    logId: Long,
+    logPath: String,
+    entriesNum: Long
+)
+
 /** One StorageV2 segment's manifest information needed by backfill. */
 case class V2SegmentInfo(
     segmentId: Long,
     partitionId: Long,
     numOfRows: Long,
     storageVersion: Long, // always 2L for StorageV2
-    columnGroups: Seq[V2ColumnGroup]
+    columnGroups: Seq[V2ColumnGroup],
+    deltaLogs: Seq[V2DeltaLogFile] = Seq.empty
 )
+
+case class SnapshotBinlogEntry(
+    @JsonProperty("entries_num") rawEntriesNum: Option[JsonNode] = None,
+    @JsonProperty("log_path") logPath: String = "",
+    @JsonProperty("log_id") rawLogId: Option[JsonNode] = None
+) {
+  def entriesNum: Long =
+    rawEntriesNum.map(JsonTypeConverter.toLong).getOrElse(0L)
+  def logId: Long = rawLogId.map(JsonTypeConverter.toLong).getOrElse(0L)
+}
+
+case class SnapshotFieldBinlog(
+    @JsonProperty("field_id") rawFieldId: Option[JsonNode] = None,
+    @JsonProperty("binlogs") binlogs: Seq[SnapshotBinlogEntry] = Seq.empty
+) {
+  def fieldId: Long = rawFieldId.map(JsonTypeConverter.toLong).getOrElse(0L)
+}
+
+case class SnapshotSegmentInfo(
+    @JsonProperty("segment_id") rawSegmentId: Option[JsonNode] = None,
+    @JsonProperty("partition_id") rawPartitionId: Option[JsonNode] = None,
+    @JsonProperty("segment_level") rawSegmentLevel: Option[JsonNode] = None,
+    @JsonProperty("storage_version") rawStorageVersion: Option[JsonNode] = None,
+    @JsonProperty("deltalog_files") deltaLogFiles: Seq[SnapshotFieldBinlog] =
+      Seq.empty
+) {
+  def segmentId: Long = rawSegmentId.map(JsonTypeConverter.toLong).getOrElse(0L)
+  def partitionId: Long =
+    rawPartitionId.map(JsonTypeConverter.toLong).getOrElse(0L)
+  def segmentLevel: Option[Long] = rawSegmentLevel.map(JsonTypeConverter.toLong)
+  def storageVersion: Long =
+    rawStorageVersion.map(JsonTypeConverter.toLong).getOrElse(0L)
+}
 
 /** Complete snapshot metadata
   */
@@ -428,8 +479,78 @@ case class SnapshotMetadata(
     ) manifestList: Seq[String] = Seq.empty,
     @JsonProperty("storagev2_manifest_list") @JsonAlias(
       Array("storagev2-manifest-list")
-    ) storageV2ManifestList: Option[Seq[StorageV2ManifestItem]] = None
-)
+    ) storageV2ManifestList: Option[Seq[StorageV2ManifestItem]] = None,
+    @JsonProperty("segments") segments: Seq[SnapshotSegmentInfo] = Seq.empty,
+    @JsonProperty("segment_infos") @JsonAlias(
+      Array("segment-infos", "segmentInfos")
+    ) segmentInfos: Seq[SnapshotSegmentInfo] = Seq.empty
+) {
+  def allSegments: Seq[SnapshotSegmentInfo] =
+    if (segments.nonEmpty) segments else segmentInfos
+
+  def manifestSchemaVersion: Int = formatVersion match {
+    case Some(v) if v >= 2 => v
+    case _                 => 1
+  }
+}
+
+object SnapshotMetadata {
+  def fromAvroEntries(
+      snapshotInfo: SnapshotInfo,
+      collection: Collection,
+      manifestList: Seq[String],
+      storageV2ManifestList: Option[Seq[StorageV2ManifestItem]],
+      entries: Seq[AvroManifestEntry]
+  ): SnapshotMetadata = {
+    SnapshotMetadata(
+      snapshotInfo = snapshotInfo,
+      collection = collection,
+      manifestList = manifestList,
+      storageV2ManifestList = storageV2ManifestList,
+      segments = entries.map(entry =>
+        SnapshotSegmentInfo(
+          rawSegmentId = Some(
+            com.fasterxml.jackson.databind.node.LongNode
+              .valueOf(entry.segmentId)
+          ),
+          rawPartitionId = Some(
+            com.fasterxml.jackson.databind.node.LongNode
+              .valueOf(entry.partitionId)
+          ),
+          rawSegmentLevel = Some(
+            com.fasterxml.jackson.databind.node.LongNode
+              .valueOf(entry.segmentLevel)
+          ),
+          rawStorageVersion = Some(
+            com.fasterxml.jackson.databind.node.LongNode
+              .valueOf(entry.storageVersion)
+          ),
+          deltaLogFiles = entry.deltaLogFiles.map(group =>
+            SnapshotFieldBinlog(
+              rawFieldId = Some(
+                com.fasterxml.jackson.databind.node.LongNode
+                  .valueOf(group.slotFieldId)
+              ),
+              binlogs = group.binlogs.map(log =>
+                SnapshotBinlogEntry(
+                  rawEntriesNum = Some(
+                    com.fasterxml.jackson.databind.node.LongNode
+                      .valueOf(log.entriesNum)
+                  ),
+                  logPath = log.logPath,
+                  rawLogId = Some(
+                    com.fasterxml.jackson.databind.node.LongNode
+                      .valueOf(log.logId)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+}
 
 /** Reader for Milvus snapshot metadata JSON files
   */
@@ -898,6 +1019,13 @@ object MilvusSnapshotReader {
             fileRowCounts =
               cg.fileRowCounts.map(n => LongNode.valueOf(n): JsonNode)
           )
+        ),
+        deltaLogs = s.deltaLogs.map(log =>
+          V2DeltaLogFileDTO(
+            rawLogId = Some(LongNode.valueOf(log.logId)),
+            logPath = log.logPath,
+            rawEntriesNum = Some(LongNode.valueOf(log.entriesNum))
+          )
         )
       )
     }
@@ -930,6 +1058,13 @@ object MilvusSnapshotReader {
               filePaths = cg.filePaths,
               fileRowCounts =
                 cg.fileRowCounts.map(v => JsonTypeConverter.toLong(v))
+            )
+          ),
+          deltaLogs = d.deltaLogs.map(log =>
+            V2DeltaLogFile(
+              logId = log.logId,
+              logPath = log.logPath,
+              entriesNum = log.entriesNum
             )
           )
         )

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -50,22 +50,31 @@ object V2SegmentLoader extends Logging {
   def loadV2Segments(
       manifestPaths: Seq[String],
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      manifestSchemaVersion: Int = 1,
+      applyDeletes: Boolean = true
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
     try {
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
       manifestPaths.foreach { rawPath =>
         val avroPath = resolvePath(rawPath, bucket)
         val avroBytes = readAllBytes(hadoopConf, avroPath)
-        val entry = MilvusSegmentManifestReader.parse(avroBytes) match {
-          case Right(e) => e
-          case Left(err) =>
-            throw new RuntimeException(
-              s"failed to decode segment manifest $avroPath: ${err.getMessage}",
-              err
-            )
-        }
-        buildV2SegmentInfoFromEntry(entry, bucket, hadoopConf) match {
+        val entry =
+          MilvusSegmentManifestReader
+            .parse(avroBytes, manifestSchemaVersion) match {
+            case Right(e) => e
+            case Left(err) =>
+              throw new RuntimeException(
+                s"failed to decode segment manifest $avroPath: ${err.getMessage}",
+                err
+              )
+          }
+        buildV2SegmentInfoFromEntry(
+          entry,
+          bucket,
+          hadoopConf,
+          applyDeletes
+        ) match {
           case Right(Some(seg)) => out += seg
           case Right(None)      => // skipped (storage version != 2)
           case Left(err)        => throw err
@@ -91,12 +100,21 @@ object V2SegmentLoader extends Logging {
   private[read] def buildV2SegmentInfoFromEntry(
       entry: AvroManifestEntry,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      applyDeletes: Boolean = true
   ): Either[Throwable, Option[V2SegmentInfo]] = {
+    val isL0 = entry.segmentLevel == 0L
+    val hasDeltaLogs = entry.deltaLogFiles.exists(_.binlogs.nonEmpty)
+
     if (entry.storageVersion != 2L) {
       logInfo(
         s"skipping segment ${entry.segmentId}: storage_version=${entry.storageVersion} " +
           s"(!= 2); V2SegmentLoader only handles StorageV2"
+      )
+      Right(None)
+    } else if (isL0 && !applyDeletes) {
+      logInfo(
+        s"skipping StorageV2 L0 delete-only segment ${entry.segmentId} because applyDeletes=false"
       )
       Right(None)
     } else if (
@@ -114,7 +132,17 @@ object V2SegmentLoader extends Logging {
             partitionId = entry.partitionId,
             numOfRows = entry.numOfRows,
             storageVersion = entry.storageVersion,
-            columnGroups = Seq.empty
+            columnGroups = Seq.empty,
+            deltaLogs = entry.deltaLogFiles
+              .flatMap(_.binlogs)
+              .sortBy(_.logId)
+              .map(log =>
+                V2DeltaLogFile(
+                  logId = log.logId,
+                  logPath = log.logPath,
+                  entriesNum = log.entriesNum
+                )
+              )
           )
         )
       )

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -103,7 +103,7 @@ object V2SegmentLoader extends Logging {
       hadoopConf: Configuration,
       applyDeletes: Boolean = true
   ): Either[Throwable, Option[V2SegmentInfo]] = {
-    val isL0 = entry.segmentLevel == 0L
+    val isL0 = entry.segmentLevel == 1L
     val hasDeltaLogs = entry.deltaLogFiles.exists(_.binlogs.nonEmpty)
 
     if (entry.storageVersion != 2L) {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -59,6 +59,7 @@ import com.zilliz.spark.connector.{
 }
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
+  MilvusDeltaLogReader,
   MilvusPackedV2InputPartition,
   MilvusPartitionReaderFactory,
   MilvusSnapshotReader,
@@ -884,9 +885,13 @@ object MilvusScan extends Logging {
   private[sources] def connectorS3BucketOption(
       options: scala.collection.Map[String, String]
   ): Option[String] = {
-    optionValue(options, Properties.FsConfig.FsBucketName)
-      .map(_.trim)
-      .filter(_.nonEmpty)
+    Seq(
+      Properties.FsConfig.FsBucketName,
+      MilvusOption.FsBucketName,
+      MilvusOption.S3BucketName
+    ).view
+      .flatMap(key => optionValue(options, key).map(_.trim).filter(_.nonEmpty))
+      .headOption
   }
 
   private[sources] def resolveConnectorS3Bucket(
@@ -1179,43 +1184,51 @@ object MilvusScan extends Logging {
       baseOptions: Map[String, String],
       databaseName: String,
       collectionName: String,
-      snapshotName: String
+      snapshotName: String,
+      autoCleanup: Boolean = true
   ): Boolean = {
     val cleanupTriggered = new AtomicBoolean(false)
     val session = registration.session
     val executionId = registration.executionId
 
-    def submitCleanup(reason: String): Unit = {
-      submitClientSnapshotCleanup(
-        baseOptions,
-        databaseName,
-        collectionName,
-        snapshotName,
-        reason
+    if (!autoCleanup) {
+      logWarning(
+        s"Client read snapshot $snapshotName will be preserved after Spark SQL execution ends because ${MilvusOption.ClientSnapshotAutoCleanup}=false"
       )
-    }
+      true
+    } else {
+      def submitCleanup(reason: String): Unit = {
+        submitClientSnapshotCleanup(
+          baseOptions,
+          databaseName,
+          collectionName,
+          snapshotName,
+          reason
+        )
+      }
 
-    val listener = new SparkListener {
-      override def onOtherEvent(event: SparkListenerEvent): Unit = {
-        event match {
-          case e: SparkListenerSQLExecutionEnd
-              if e.executionId == executionId && cleanupTriggered
-                .compareAndSet(false, true) =>
-            try submitCleanup(s"Spark SQL execution $executionId ended")
-            finally session.sparkContext.removeSparkListener(this)
-          case _ =>
+      val listener = new SparkListener {
+        override def onOtherEvent(event: SparkListenerEvent): Unit = {
+          event match {
+            case e: SparkListenerSQLExecutionEnd
+                if e.executionId == executionId && cleanupTriggered
+                  .compareAndSet(false, true) =>
+              try submitCleanup(s"Spark SQL execution $executionId ended")
+              finally session.sparkContext.removeSparkListener(this)
+            case _ =>
+          }
         }
       }
-    }
 
-    Try(session.sparkContext.addSparkListener(listener)) match {
-      case Success(_) => true
-      case Failure(e) =>
-        logError(
-          s"Failed to register cleanup listener for client read snapshot $snapshotName",
-          e
-        )
-        false
+      Try(session.sparkContext.addSparkListener(listener)) match {
+        case Success(_) => true
+        case Failure(e) =>
+          logError(
+            s"Failed to register cleanup listener for client read snapshot $snapshotName",
+            e
+          )
+          false
+      }
     }
   }
 
@@ -1288,6 +1301,7 @@ object MilvusScan extends Logging {
     }
     metadata
   }
+
 }
 
 class MilvusScan(
@@ -1324,7 +1338,8 @@ class MilvusScan(
   }
 
   private[sources] def shouldCacheInputPartitions: Boolean =
-    MilvusOption.isSnapshotMode(options)
+    MilvusOption.isSnapshotMode(options) ||
+      MilvusScan.canUseClientSnapshotFastPath(milvusOption)
 
   private def computeInputPartitions(): Array[InputPartition] = {
     if (MilvusOption.isSnapshotMode(options)) {
@@ -1425,13 +1440,16 @@ class MilvusScan(
             options.asScala.toMap,
             milvusOption.databaseName,
             milvusOption.collectionName,
-            snapshot.name
+            snapshot.name,
+            autoCleanup = MilvusOption.clientSnapshotAutoCleanup(options)
           )
         ) {
-          logWarning(
-            s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
-              "an unclean driver exit can leave it behind and require manual cleanup."
-          )
+          if (MilvusOption.clientSnapshotAutoCleanup(options)) {
+            logWarning(
+              s"Client read snapshot ${snapshot.name} will be dropped when the Spark SQL execution ends; " +
+                "an unclean driver exit can leave it behind and require manual cleanup."
+            )
+          }
           val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
             snapshot.s3Location,
             connectorBucket.getOrElse("")
@@ -1485,12 +1503,15 @@ class MilvusScan(
       snapshotPath,
       milvusOption.options
     )
+    val applyDeletes = MilvusOption.readApplyDeletes(options)
     val v2Segments =
       if (metadata.manifestList.nonEmpty) {
         V2SegmentLoader.loadV2Segments(
           metadata.manifestList,
           snapshotBucket.getOrElse(""),
-          hadoopConf
+          hadoopConf,
+          manifestSchemaVersion = metadata.manifestSchemaVersion,
+          applyDeletes = applyDeletes
         ) match {
           case Right(segs) => segs
           case Left(err) =>
@@ -1517,26 +1538,24 @@ class MilvusScan(
     val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
       metadata.collection.schema
     )
-    val snapshotOptions = MilvusScan.buildClientSnapshotOptions(
-      options.asScala.toMap,
-      collectionName = metadata.collection.schema.name,
-      collectionId = metadata.snapshotInfo.collectionId,
-      partitionIds = metadata.snapshotInfo.partitionIds,
-      schemaBytesBase64 = Base64.getEncoder.encodeToString(schemaBytes),
-      manifestList = storageV2ManifestList,
-      v2Segments = v2Segments,
-      snapshotBucketForRelativePaths = snapshotBucket
-    )
-    require(
-      MilvusOption.isSnapshotMode(snapshotOptions),
-      "Client-created snapshot options must enable snapshot mode"
-    )
+    val v2DeletePlans =
+      loadV2DeletePlans(
+        v2Segments,
+        schemaBytes,
+        snapshotBucket,
+        hadoopConf,
+        errorContext = "client-created snapshot"
+      )
 
-    new MilvusScan(
-      schema,
-      new CaseInsensitiveStringMap(snapshotOptions.asJava),
-      pushedFilters
-    ).planInputPartitions()
+    buildSnapshotPartitions(
+      manifestList = storageV2ManifestList,
+      defaultPartitionId = metadata.snapshotInfo.partitionIds.headOption
+        .map(_.toString)
+        .getOrElse("0"),
+      schemaBytes = schemaBytes,
+      v2Segments = v2Segments,
+      v2DeletePlans = v2DeletePlans
+    )
   }
 
   private def planInputPartitionsFromLegacyClient(
@@ -1594,10 +1613,21 @@ class MilvusScan(
       )
     }
 
+    val storageV2Segments = allPackedSegments.filter(_.storageVersion == 2)
+    if (storageV2Segments.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"Legacy GetPersistentSegmentInfo read path cannot safely read StorageV2 segments for collection " +
+          s"${milvusOption.collectionName}. Use snapshot mode or the client snapshot fast path instead. " +
+          s"Offending segment IDs: ${storageV2Segments.map(_.segmentID).sorted.mkString(",")}"
+      )
+    }
+
+    val storageV3Segments = allPackedSegments.filter(_.storageVersion >= 3)
+
     val partitions =
       if (partition.nonEmpty && segment.nonEmpty) {
         val segmentInfo =
-          allPackedSegments.find(_.segmentID.toString == segment)
+          storageV3Segments.find(_.segmentID.toString == segment)
         segmentInfo match {
           case Some(seg) =>
             if (seg.partitionID.toString != partition) {
@@ -1613,12 +1643,12 @@ class MilvusScan(
             )
         }
       } else if (partition.nonEmpty) {
-        allPackedSegments
+        storageV3Segments
           .filter(_.partitionID.toString == partition)
           .map(seg => createPartition(seg.segmentID.toString, partition))
           .toArray
       } else {
-        allPackedSegments.map { seg =>
+        storageV3Segments.map { seg =>
           createPartition(seg.segmentID.toString, seg.partitionID.toString)
         }.toArray
       }
@@ -1735,6 +1765,125 @@ class MilvusScan(
     }
   }
 
+  private def loadV2DeletePlans(
+      v2Segments: Seq[V2SegmentInfo],
+      schemaBytes: Array[Byte],
+      snapshotBucket: Option[String],
+      hadoopConf: Configuration,
+      errorContext: String
+  ): Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
+    val applyDeletes = MilvusOption.readApplyDeletes(options)
+    val hasAnyDeltaLogs = v2Segments.exists(_.deltaLogs.nonEmpty)
+    if (!applyDeletes || v2Segments.isEmpty || !hasAnyDeltaLogs) {
+      Map.empty
+    } else {
+      val milvusSchema = CollectionSchema.parseFrom(schemaBytes)
+      MilvusDeltaLogReader.loadDeletePlansBySegment(
+        v2Segments,
+        milvusSchema,
+        snapshotBucket.getOrElse(""),
+        hadoopConf
+      ) match {
+        case Right(plans) => plans
+        case Left(err) =>
+          throw new IllegalStateException(
+            s"Failed to load StorageV2 delete logs from $errorContext: ${err.getMessage}",
+            err
+          )
+      }
+    }
+  }
+
+  private def buildSnapshotPartitions(
+      manifestList: Seq[StorageV2ManifestItem],
+      defaultPartitionId: String,
+      schemaBytes: Array[Byte],
+      v2Segments: Seq[V2SegmentInfo],
+      v2DeletePlans: Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+  ): Array[InputPartition] = {
+    val v3Partitions = manifestList.map { item =>
+      val (basePath, readVersion) =
+        MilvusSnapshotReader.parseManifestContent(item.manifest) match {
+          case Right(content) => (content.basePath, content.ver.toLong)
+          case Left(_)        => (item.manifest, -1L)
+        }
+
+      val pathParts = basePath.split("/").filter(_.nonEmpty)
+      val segmentID =
+        if (item.segmentID != 0L) {
+          item.segmentID
+        } else if (pathParts.nonEmpty) {
+          try pathParts.last.toLong
+          catch { case _: NumberFormatException => 0L }
+        } else 0L
+      val insertLogIdx = pathParts.lastIndexOf("insert_log")
+      val partitionId =
+        if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
+          pathParts(insertLogIdx + 2)
+        } else {
+          logWarning(
+            s"Manifest path '$basePath' does not match expected insert_log/{collectionID}/{partitionID}/{segmentID} layout; using fallback partitionID=$defaultPartitionId"
+          )
+          defaultPartitionId
+        }
+      logInfo(
+        s"Creating partition with manifestPath=$basePath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
+      )
+      MilvusStorageV3InputPartition(
+        basePath,
+        schemaBytes,
+        partitionId,
+        milvusOption,
+        vectorSearchConfig.map(_.topK),
+        vectorSearchConfig.map(_.queryVector),
+        vectorSearchConfig.map(_.metricType),
+        vectorSearchConfig.map(_.vectorColumn),
+        segmentID,
+        readVersion
+      ): InputPartition
+    }
+
+    if (v3Partitions.nonEmpty) {
+      logInfo(
+        s"Created ${v3Partitions.size} V3 partitions from snapshot manifests"
+      )
+    }
+
+    val packedV2Partitions = v2Segments
+      .filter(_.columnGroups.nonEmpty)
+      .map { seg =>
+        MilvusPackedV2InputPartition(
+          segmentID = seg.segmentId,
+          partitionID = seg.partitionId,
+          columnGroups = seg.columnGroups,
+          milvusSchemaBytes = schemaBytes,
+          milvusOption = milvusOption,
+          neededColumnFieldIds = Seq.empty,
+          applyDeletes = MilvusOption.readApplyDeletes(options),
+          deletePlan = v2DeletePlans.getOrElse(
+            seg.segmentId,
+            com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+          )
+        ): InputPartition
+      }
+
+    val skippedDeleteOnlySegments =
+      v2Segments.count(_.columnGroups.isEmpty)
+    if (skippedDeleteOnlySegments > 0) {
+      logInfo(
+        s"Skipped $skippedDeleteOnlySegments StorageV2 delete-only segment(s) during snapshot partition planning"
+      )
+    }
+
+    if (packedV2Partitions.nonEmpty) {
+      logInfo(
+        s"Created ${packedV2Partitions.size} packed-V2 partition(s) from snapshot metadata"
+      )
+    }
+
+    (v3Partitions ++ packedV2Partitions).toArray
+  }
+
   /** Plan input partitions from snapshot manifests (offline mode - no client
     * connection) This enables reading Milvus data purely from snapshot metadata
     * without any client calls.
@@ -1761,9 +1910,6 @@ class MilvusScan(
       "Using snapshot mode for partition planning (no Milvus client connection)"
     )
 
-    // Parse manifest list from JSON. Empty or null means no V3 manifests
-    // were supplied (pure V2-packed snapshot) — fall through to the
-    // packed-V2 branch below without erroring out.
     val manifestList: Seq[StorageV2ManifestItem] =
       if (manifestsJson == null || manifestsJson.isEmpty) Seq.empty
       else
@@ -1776,15 +1922,11 @@ class MilvusScan(
             )
         }
 
-    // Get partition IDs from options (comma-separated)
     val partitionIds = Option(options.get(MilvusOption.SnapshotPartitionIds))
       .map(_.split(",").map(_.trim).filter(_.nonEmpty))
       .getOrElse(Array.empty[String])
-
-    // Use first partition ID as default, or "0" if none provided
     val defaultPartitionId = partitionIds.headOption.getOrElse("0")
 
-    // Get schema bytes from options (Base64 encoded)
     val schemaBytes = Option(options.get(MilvusOption.SnapshotSchemaBytes))
       .map(base64 => java.util.Base64.getDecoder.decode(base64))
       .getOrElse {
@@ -1798,95 +1940,39 @@ class MilvusScan(
       s"Using schema bytes (${schemaBytes.length} bytes) for V2 partitions"
     )
 
-    // Create V2 input partitions from snapshot manifests
-    val v2Partitions = manifestList.map { item =>
-      // Try to parse manifest as JSON to extract basePath and ver (version)
-      // If parsing fails, treat the manifest string as a plain basePath (backward compatible)
-      val (basePath, readVersion) =
-        MilvusSnapshotReader.parseManifestContent(item.manifest) match {
-          case Right(content) => (content.basePath, content.ver.toLong)
-          case Left(_) =>
-            (
-              item.manifest,
-              -1L
-            ) // Backward compatible: plain basePath, latest version
+    val v2Segments = Option(options.get(MilvusOption.SnapshotV2Segments))
+      .filter(_.nonEmpty)
+      .map { json =>
+        MilvusSnapshotReader.deserializeV2Segments(json) match {
+          case Right(segs) => segs
+          case Left(e) =>
+            throw new Exception(
+              s"Failed to parse SnapshotV2Segments: ${e.getMessage}",
+              e
+            )
         }
+      }
+      .getOrElse(Seq.empty)
 
-      // Extract segmentID and partitionID from manifest path if needed
-      // Path format: files/insert_log/{collectionID}/{partitionID}/{segmentID}
-      val pathParts = basePath.split("/").filter(_.nonEmpty)
-      val segmentID = if (item.segmentID != 0L) {
-        item.segmentID
-      } else if (pathParts.nonEmpty) {
-        try {
-          pathParts.last.toLong
-        } catch {
-          case _: NumberFormatException => 0L
-        }
-      } else 0L
-      val insertLogIdx = pathParts.lastIndexOf("insert_log")
-      val partitionId =
-        if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
-          pathParts(insertLogIdx + 2)
-        } else {
-          logWarning(
-            s"Manifest path '$basePath' does not match expected insert_log/{collectionID}/{partitionID}/{segmentID} layout; using fallback partitionID=$defaultPartitionId"
-          )
-          defaultPartitionId
-        }
-      logInfo(
-        s"Creating partition with manifestPath=$basePath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
+    val snapshotBucketForRelativePaths =
+      MilvusScan.connectorS3BucketOption(options.asScala.toMap)
+
+    val v2DeletePlans =
+      loadV2DeletePlans(
+        v2Segments,
+        schemaBytes,
+        snapshotBucket = snapshotBucketForRelativePaths,
+        hadoopConf = buildSnapshotHadoopConf(""),
+        errorContext = "snapshot metadata"
       )
-      MilvusStorageV3InputPartition(
-        basePath, // The basePath extracted from manifest JSON
-        schemaBytes, // Protobuf CollectionSchema bytes from snapshot
-        partitionId, // Partition name/ID
-        milvusOption,
-        vectorSearchConfig.map(_.topK),
-        vectorSearchConfig.map(_.queryVector),
-        vectorSearchConfig.map(_.metricType),
-        vectorSearchConfig.map(_.vectorColumn),
-        segmentID, // Segment ID extracted from path or from item
-        readVersion // Manifest version from snapshot (-1 = latest)
-      ): InputPartition
-    }
 
-    logInfo(
-      s"Created ${v2Partitions.size} V2 partitions from snapshot manifests"
+    buildSnapshotPartitions(
+      manifestList = manifestList,
+      defaultPartitionId = defaultPartitionId,
+      schemaBytes = schemaBytes,
+      v2Segments = v2Segments,
+      v2DeletePlans = v2DeletePlans
     )
-
-    // Additional partitions from pre-materialized packed-V2 segments (if any).
-    val packedV2Partitions: Seq[InputPartition] =
-      Option(options.get(MilvusOption.SnapshotV2Segments))
-        .filter(_.nonEmpty)
-        .map { json =>
-          MilvusSnapshotReader.deserializeV2Segments(json) match {
-            case Right(segs) if segs.nonEmpty =>
-              logInfo(
-                s"Creating ${segs.size} packed-V2 partition(s) from " +
-                  s"SnapshotV2Segments option"
-              )
-              segs.map { seg =>
-                MilvusPackedV2InputPartition(
-                  segmentID = seg.segmentId,
-                  partitionID = seg.partitionId,
-                  columnGroups = seg.columnGroups,
-                  milvusSchemaBytes = schemaBytes,
-                  milvusOption = milvusOption,
-                  neededColumnFieldIds = Seq.empty
-                ): InputPartition
-              }
-            case Right(_) => Seq.empty[InputPartition]
-            case Left(e) =>
-              throw new Exception(
-                s"Failed to parse SnapshotV2Segments: ${e.getMessage}",
-                e
-              )
-          }
-        }
-        .getOrElse(Seq.empty[InputPartition])
-
-    (v2Partitions ++ packedV2Partitions).toArray
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1455,7 +1455,12 @@ class MilvusScan(
             snapshot.s3Location,
             connectorBucket.getOrElse("")
           )
-          Some(planInputPartitionsFromClientSnapshotPath(snapshotPath))
+          Some(
+            planInputPartitionsFromClientSnapshotPath(
+              snapshotPath,
+              forceCanonicalBucket = connectorBucket
+            )
+          )
         } else {
           MilvusScan.submitClientSnapshotCleanup(
             options.asScala.toMap,
@@ -1483,7 +1488,8 @@ class MilvusScan(
   }
 
   private def planInputPartitionsFromClientSnapshotPath(
-      snapshotPath: String
+      snapshotPath: String,
+      forceCanonicalBucket: Option[String] = None
   ): Array[InputPartition] = {
     val hadoopConf = buildSnapshotHadoopConf(snapshotPath)
     val snapshotJson = readAllBytes(hadoopConf, snapshotPath)
@@ -1500,10 +1506,13 @@ class MilvusScan(
         snapshotPath
       )
 
-    val snapshotBucket = MilvusScan.snapshotS3BucketForRelativePaths(
-      snapshotPath,
-      milvusOption.options
-    )
+    val snapshotBucket = forceCanonicalBucket
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .orElse(
+        MilvusScan
+          .snapshotS3BucketForRelativePaths(snapshotPath, milvusOption.options)
+      )
     val applyDeletes = MilvusOption.readApplyDeletes(options)
     val v2Segments =
       if (metadata.manifestList.nonEmpty) {
@@ -1856,8 +1865,20 @@ class MilvusScan(
       inheritedDeletePlansByPartition: Map[
         Long,
         com.zilliz.spark.connector.read.MilvusDeletePlan
-      ] = Map.empty
+      ] = Map.empty,
+      forceCanonicalBucket: Option[String] = None
   ): Array[InputPartition] = {
+    val canonicalMilvusOption = forceCanonicalBucket
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(bucket =>
+        milvusOption.copy(
+          options = milvusOption.options +
+            (Properties.FsConfig.FsBucketName -> bucket)
+        )
+      )
+      .getOrElse(milvusOption)
+
     val v3Partitions = manifestList.map { item =>
       val (basePath, readVersion) =
         MilvusSnapshotReader.parseManifestContent(item.manifest) match {
@@ -1914,7 +1935,7 @@ class MilvusScan(
           partitionID = seg.partitionId,
           columnGroups = seg.columnGroups,
           milvusSchemaBytes = schemaBytes,
-          milvusOption = milvusOption,
+          milvusOption = canonicalMilvusOption,
           neededColumnFieldIds = Seq.empty,
           applyDeletes = MilvusOption.readApplyDeletes(options),
           deletePlan = v2DeletePlans.getOrElse(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -60,6 +60,7 @@ import com.zilliz.spark.connector.{
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   MilvusDeltaLogReader,
+  MilvusPackedV2DeleteContext,
   MilvusPackedV2InputPartition,
   MilvusPartitionReaderFactory,
   MilvusSnapshotReader,
@@ -1547,6 +1548,42 @@ class MilvusScan(
         errorContext = "client-created snapshot"
       )
 
+    val inheritedDeleteSegments =
+      v2Segments.filter(seg =>
+        seg.columnGroups.isEmpty && seg.deltaLogs.nonEmpty
+      )
+    val inheritedDeletePlansByPartition =
+      if (
+        !MilvusOption.readApplyDeletes(
+          options
+        ) || inheritedDeleteSegments.isEmpty
+      ) {
+        Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+      } else {
+        val pkField = CollectionSchema
+          .parseFrom(schemaBytes)
+          .fields
+          .find(_.isPrimaryKey)
+          .getOrElse {
+            throw new IllegalArgumentException(
+              "No primary key field found in schema"
+            )
+          }
+        MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
+          inheritedDeleteSegments,
+          pkField,
+          snapshotBucket.getOrElse(""),
+          hadoopConf
+        ) match {
+          case Right(plans) => plans
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Failed to load inherited StorageV2 delete logs from client-created snapshot: ${err.getMessage}",
+              err
+            )
+        }
+      }
+
     buildSnapshotPartitions(
       manifestList = storageV2ManifestList,
       defaultPartitionId = metadata.snapshotInfo.partitionIds.headOption
@@ -1554,7 +1591,8 @@ class MilvusScan(
         .getOrElse("0"),
       schemaBytes = schemaBytes,
       v2Segments = v2Segments,
-      v2DeletePlans = v2DeletePlans
+      v2DeletePlans = v2DeletePlans,
+      inheritedDeletePlansByPartition = inheritedDeletePlansByPartition
     )
   }
 
@@ -1773,24 +1811,36 @@ class MilvusScan(
       errorContext: String
   ): Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
     val applyDeletes = MilvusOption.readApplyDeletes(options)
-    val hasAnyDeltaLogs = v2Segments.exists(_.deltaLogs.nonEmpty)
-    if (!applyDeletes || v2Segments.isEmpty || !hasAnyDeltaLogs) {
+    val dataSegments = v2Segments.filter(seg =>
+      seg.columnGroups.nonEmpty && seg.deltaLogs.nonEmpty
+    )
+    if (!applyDeletes || dataSegments.isEmpty) {
       Map.empty
     } else {
-      val milvusSchema = CollectionSchema.parseFrom(schemaBytes)
-      MilvusDeltaLogReader.loadDeletePlansBySegment(
-        v2Segments,
-        milvusSchema,
-        snapshotBucket.getOrElse(""),
-        hadoopConf
-      ) match {
-        case Right(plans) => plans
-        case Left(err) =>
-          throw new IllegalStateException(
-            s"Failed to load StorageV2 delete logs from $errorContext: ${err.getMessage}",
-            err
+      val pkField = CollectionSchema
+        .parseFrom(schemaBytes)
+        .fields
+        .find(_.isPrimaryKey)
+        .getOrElse {
+          throw new IllegalArgumentException(
+            "No primary key field found in schema"
           )
-      }
+        }
+      dataSegments.map { seg =>
+        MilvusDeltaLogReader.loadDeletePlan(
+          seg.deltaLogs,
+          pkField,
+          snapshotBucket.getOrElse(""),
+          hadoopConf
+        ) match {
+          case Right(plan) => seg.segmentId -> plan
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Failed to load StorageV2 delete logs from $errorContext for segment ${seg.segmentId}: ${err.getMessage}",
+              err
+            )
+        }
+      }.toMap
     }
   }
 
@@ -1799,7 +1849,14 @@ class MilvusScan(
       defaultPartitionId: String,
       schemaBytes: Array[Byte],
       v2Segments: Seq[V2SegmentInfo],
-      v2DeletePlans: Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+      v2DeletePlans: Map[
+        Long,
+        com.zilliz.spark.connector.read.MilvusDeletePlan
+      ],
+      inheritedDeletePlansByPartition: Map[
+        Long,
+        com.zilliz.spark.connector.read.MilvusDeletePlan
+      ] = Map.empty
   ): Array[InputPartition] = {
     val v3Partitions = manifestList.map { item =>
       val (basePath, readVersion) =
@@ -1863,7 +1920,11 @@ class MilvusScan(
           deletePlan = v2DeletePlans.getOrElse(
             seg.segmentId,
             com.zilliz.spark.connector.read.MilvusDeletePlan.empty
-          )
+          ),
+          inheritedDeletePlanPartitionId =
+            if (inheritedDeletePlansByPartition.contains(seg.partitionId))
+              Some(seg.partitionId)
+            else None
         ): InputPartition
       }
 
@@ -1966,18 +2027,114 @@ class MilvusScan(
         errorContext = "snapshot metadata"
       )
 
+    val inheritedDeleteSegments =
+      v2Segments.filter(seg =>
+        seg.columnGroups.isEmpty && seg.deltaLogs.nonEmpty
+      )
+    val inheritedDeletePlansByPartition =
+      if (
+        !MilvusOption.readApplyDeletes(
+          options
+        ) || inheritedDeleteSegments.isEmpty
+      ) {
+        Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+      } else {
+        val pkField = CollectionSchema
+          .parseFrom(schemaBytes)
+          .fields
+          .find(_.isPrimaryKey)
+          .getOrElse {
+            throw new IllegalArgumentException(
+              "No primary key field found in schema"
+            )
+          }
+        MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
+          inheritedDeleteSegments,
+          pkField,
+          snapshotBucketForRelativePaths.getOrElse(""),
+          buildSnapshotHadoopConf("")
+        ) match {
+          case Right(plans) => plans
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Failed to load inherited StorageV2 delete logs from snapshot metadata: ${err.getMessage}",
+              err
+            )
+        }
+      }
+
     buildSnapshotPartitions(
       manifestList = manifestList,
       defaultPartitionId = defaultPartitionId,
       schemaBytes = schemaBytes,
       v2Segments = v2Segments,
-      v2DeletePlans = v2DeletePlans
+      v2DeletePlans = v2DeletePlans,
+      inheritedDeletePlansByPartition = inheritedDeletePlansByPartition
     )
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {
-    // Convert CaseInsensitiveStringMap to regular Map for serialization
     val optionsMap = options.asScala.toMap
-    new MilvusPartitionReaderFactory(schema, optionsMap, pushedFilters)
+    val inheritedPlansByPartition =
+      if (
+        MilvusOption
+          .isSnapshotMode(options) && MilvusOption.readApplyDeletes(options)
+      ) {
+        val schemaBytes = Option(options.get(MilvusOption.SnapshotSchemaBytes))
+          .map(base64 => java.util.Base64.getDecoder.decode(base64))
+          .getOrElse(Array.emptyByteArray)
+        val v2Segments = Option(options.get(MilvusOption.SnapshotV2Segments))
+          .filter(_.nonEmpty)
+          .map(json =>
+            MilvusSnapshotReader.deserializeV2Segments(json) match {
+              case Right(segs) => segs
+              case Left(err) =>
+                throw new IllegalStateException(
+                  s"Failed to parse SnapshotV2Segments in reader factory: ${err.getMessage}",
+                  err
+                )
+            }
+          )
+          .getOrElse(Seq.empty)
+        val inheritedDeleteSegments =
+          v2Segments.filter(seg =>
+            seg.columnGroups.isEmpty && seg.deltaLogs.nonEmpty
+          )
+        if (schemaBytes.isEmpty || inheritedDeleteSegments.isEmpty) {
+          Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+        } else {
+          val pkField = CollectionSchema
+            .parseFrom(schemaBytes)
+            .fields
+            .find(_.isPrimaryKey)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                "No primary key field found in schema"
+              )
+            )
+          MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
+            inheritedDeleteSegments,
+            pkField,
+            MilvusScan.connectorS3BucketOption(optionsMap).getOrElse(""),
+            buildSnapshotHadoopConf("")
+          ) match {
+            case Right(plans) => plans
+            case Left(err) =>
+              throw new IllegalStateException(
+                s"Failed to load inherited StorageV2 delete logs for reader factory: ${err.getMessage}",
+                err
+              )
+          }
+        }
+      } else {
+        Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+      }
+
+    new MilvusPartitionReaderFactory(
+      schema,
+      optionsMap,
+      pushedFilters,
+      MilvusPackedV2DeleteContext(inheritedPlansByPartition)
+    )
   }
 }

--- a/src/main/scala/tools/ListV2SegmentsApp.scala
+++ b/src/main/scala/tools/ListV2SegmentsApp.scala
@@ -104,7 +104,8 @@ object ListV2SegmentsApp {
           processOneSegment(
             hadoopConf,
             resolvePath(manifestPath, s3Bucket),
-            s3Bucket
+            s3Bucket,
+            metadata.manifestSchemaVersion
           )
         }
       }
@@ -120,13 +121,15 @@ object ListV2SegmentsApp {
   private def processOneSegment(
       hadoopConf: Configuration,
       manifestPath: String,
-      bucket: String
+      bucket: String,
+      manifestSchemaVersion: Int
   ): Unit = {
     println(s"\n  AVRO: $manifestPath")
     val avroBytes = readAllBytes(hadoopConf, manifestPath)
     println(s"    size: ${avroBytes.length} bytes")
 
-    MilvusSegmentManifestReader.parse(avroBytes) match {
+    MilvusSegmentManifestReader
+      .parse(avroBytes, manifestSchemaVersion) match {
       case Left(err) =>
         println(s"    ERROR decoding AVRO: ${err.getMessage}")
 

--- a/src/main/scala/tools/ReadSourceOnlyApp.scala
+++ b/src/main/scala/tools/ReadSourceOnlyApp.scala
@@ -1,0 +1,306 @@
+package com.zilliz.spark.connector.tools
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.SparkSession
+
+import com.zilliz.spark.connector.read.{
+  MilvusParquetFooterReader,
+  MilvusSegmentManifestReader,
+  MilvusSnapshotReader,
+  V2SegmentInfo,
+  V2SegmentLoader
+}
+import com.zilliz.spark.connector.MilvusOption
+
+/** Standalone reader-only verification app.
+  *
+  * Loads a Milvus snapshot and reads the PK column via the V2 packed reader —
+  * but WITHOUT running any join / shuffle / write. Then it diagnoses the raw
+  * output:
+  *   - total row count
+  *   - distinct PK count
+  *   - specific `row_offset → pk` samples
+  *   - (optional) IDs at boundary positions
+  *
+  * If distinct PK count != total row count (but pyarrow says they are equal at
+  * the parquet level), the V2 reader has a read-side duplication bug.
+  *
+  * Usage:
+  * {{{
+  *   spark-submit --class com.zilliz.spark.connector.tools.ReadSourceOnlyApp \
+  *     <jar> \
+  *     --snapshot s3://.../metadata.json \
+  *     --s3-endpoint 127.0.0.1:9000 \
+  *     --s3-bucket a-bucket \
+  *     --s3-access-key minioadmin \
+  *     --s3-secret-key minioadmin \
+  *     --s3-root-path files
+  * }}}
+  */
+object ReadSourceOnlyApp {
+
+  def main(args: Array[String]): Unit = {
+    val parsed = parseArgs(args)
+    val snapshotPath = required(parsed, "snapshot")
+    val s3Endpoint = parsed.getOrElse("s3-endpoint", "")
+    val s3Bucket = required(parsed, "s3-bucket")
+    val s3AccessKey = parsed.getOrElse("s3-access-key", "")
+    val s3SecretKey = parsed.getOrElse("s3-secret-key", "")
+    val s3Region = parsed.getOrElse("s3-region", "us-east-1")
+    val s3RootPath = parsed.getOrElse("s3-root-path", "files")
+
+    val spark = SparkSession.builder
+      .appName("ReadSourceOnly")
+      .getOrCreate()
+
+    try {
+      val hadoopConf = spark.sparkContext.hadoopConfiguration
+      configureBucket(
+        hadoopConf,
+        s3Bucket,
+        s3Endpoint,
+        s3AccessKey,
+        s3SecretKey,
+        s3Region
+      )
+
+      // 1. Read snapshot metadata
+      val snapshotJson = new String(
+        readAllBytes(hadoopConf, normalizeS3(snapshotPath)),
+        "UTF-8"
+      )
+      val metadata =
+        MilvusSnapshotReader.parseSnapshotMetadata(snapshotJson) match {
+          case Right(m) => m
+          case Left(e) =>
+            throw new RuntimeException(
+              s"failed to parse snapshot metadata: ${e.getMessage}"
+            )
+        }
+
+      println(s"snapshot.id = ${metadata.snapshotInfo.id}")
+      println(s"collection  = ${metadata.collection.schema.name}")
+
+      // 2. Load V2 segments (same path MilvusBackfill uses)
+      val v2Segments: Seq[V2SegmentInfo] =
+        V2SegmentLoader.loadV2Segments(
+          metadata.manifestList,
+          s3Bucket,
+          hadoopConf,
+          manifestSchemaVersion = metadata.manifestSchemaVersion
+        ) match {
+          case Right(segs) => segs
+          case Left(err) =>
+            throw new RuntimeException(
+              s"failed to load v2 segments: ${err.getMessage}"
+            )
+        }
+
+      println(s"v2 segments: ${v2Segments.size}")
+      v2Segments.foreach { seg =>
+        println(
+          s"  segment=${seg.segmentId}, numOfRows=${seg.numOfRows}, " +
+            s"columnGroups=${seg.columnGroups.size}"
+        )
+      }
+
+      // 3. Pick PK field id from schema
+      val pkField = metadata.collection.schema.fields
+        .find(_.isPrimaryKey.getOrElse(false))
+        .getOrElse(throw new RuntimeException("no PK field in schema"))
+      val pkFieldId = pkField.getFieldIDAsLong
+      val pkName = pkField.name
+      println(s"pk field: $pkName (id=$pkFieldId)")
+
+      // 4. Build MilvusDataSource read options (matches MilvusBackfill's
+      //    readCollectionWithMetadata path — snapshot mode, PK + extras only).
+      var options = Map[String, String](
+        MilvusOption.SnapshotMode -> "true",
+        "milvus.uri" -> "dummy://snapshot-mode",
+        "milvus.collection.name" -> metadata.collection.schema.name,
+        MilvusOption.SnapshotCollectionId -> metadata.snapshotInfo.collectionId.toString,
+        MilvusOption.SnapshotPartitionIds -> metadata.snapshotInfo.partitionIds
+          .mkString(","),
+        MilvusOption.ReaderFieldIDs -> pkFieldId.toString,
+        "milvus.s3.endpoint" -> s3Endpoint,
+        "milvus.s3.bucketName" -> s3Bucket,
+        "milvus.s3.accessKey" -> s3AccessKey,
+        "milvus.s3.secretKey" -> s3SecretKey,
+        "milvus.s3.region" -> s3Region,
+        "milvus.s3.rootPath" -> s3RootPath
+      )
+
+      val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
+        metadata.collection.schema
+      )
+      options = options + (MilvusOption.SnapshotSchemaBytes ->
+        java.util.Base64.getEncoder.encodeToString(schemaBytes))
+
+      metadata.storageV2ManifestList.foreach { manifestList =>
+        if (manifestList.nonEmpty) {
+          options = options + (MilvusOption.SnapshotManifests ->
+            MilvusSnapshotReader.serializeManifestList(manifestList))
+        }
+      }
+
+      if (v2Segments.nonEmpty) {
+        options = options + (MilvusOption.SnapshotV2Segments ->
+          MilvusSnapshotReader.serializeV2Segments(v2Segments))
+      }
+
+      // 5. Build the read schema: PK field + segment metadata columns
+      import org.apache.spark.sql.types._
+      val segmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
+      val rowOffsetCol = MilvusOption.MilvusExtraColumnRowOffset
+      val pkStructField = MilvusSnapshotReader.fieldToStructField(pkField)
+      val readSchema = StructType(
+        Seq(
+          pkStructField,
+          StructField(segmentIdCol, LongType, false),
+          StructField(rowOffsetCol, LongType, false)
+        )
+      )
+
+      val df = spark.read
+        .schema(readSchema)
+        .format("com.zilliz.spark.connector.sources.MilvusDataSource")
+        .options(options)
+        .load()
+
+      // ---- Diagnose ----
+
+      println("\n=== Raw source DataFrame ===")
+      val total = df.count()
+      val distinctPk = df.select(col(pkName)).distinct().count()
+      println(s"total rows:   $total")
+      println(s"distinct $pkName: $distinctPk")
+
+      if (total != distinctPk) {
+        println(
+          s"\n⚠️  DUPLICATION DETECTED: total($total) != distinct($distinctPk)"
+        )
+        println("=> V2 packed reader is producing repeated data.")
+
+        // Show PK frequency — which pks appear more than once?
+        println("\nTop duplicated PKs (appear count > 1):")
+        df.groupBy(col(pkName))
+          .count()
+          .filter(col("count") > 1)
+          .orderBy(col("count").desc)
+          .show(20, truncate = false)
+      }
+
+      // ---- Boundary samples: first/last of each 8192-row block ----
+      val probeOffsets = Seq(
+        0L, 1L, 8191L, 8192L, 8193L, 10000L, 16383L, 16384L, 16385L, 20479L
+      )
+      println(
+        s"\n=== Boundary samples ($rowOffsetCol, $pkName, $segmentIdCol) ==="
+      )
+      df.filter(
+        col(rowOffsetCol).isin(probeOffsets.map(java.lang.Long.valueOf): _*)
+      ).orderBy(segmentIdCol, rowOffsetCol)
+        .show(100, truncate = false)
+
+      // ---- Per-segment stats ----
+      println("\n=== Per-segment stats ===")
+      df.groupBy(col(segmentIdCol))
+        .agg(
+          count(lit(1)).as("rows"),
+          countDistinct(col(pkName)).as(s"distinct_$pkName"),
+          min(col(rowOffsetCol)).as("min_ro"),
+          max(col(rowOffsetCol)).as("max_ro")
+        )
+        .show(50, truncate = false)
+
+    } finally {
+      spark.stop()
+    }
+  }
+
+  // ------------------------------------------------------------------
+
+  private def required(
+      parsed: Map[String, String],
+      key: String
+  ): String =
+    parsed.getOrElse(
+      key,
+      throw new IllegalArgumentException(s"--$key is required")
+    )
+
+  private def parseArgs(args: Array[String]): Map[String, String] = {
+    val m = scala.collection.mutable.Map.empty[String, String]
+    var i = 0
+    while (i < args.length) {
+      val a = args(i)
+      if (a.startsWith("--")) {
+        val key = a.stripPrefix("--")
+        if (i + 1 < args.length && !args(i + 1).startsWith("--")) {
+          m(key) = args(i + 1)
+          i += 2
+        } else {
+          m(key) = "true"
+          i += 1
+        }
+      } else {
+        i += 1
+      }
+    }
+    m.toMap
+  }
+
+  private def configureBucket(
+      hadoopConf: Configuration,
+      bucket: String,
+      endpoint: String,
+      accessKey: String,
+      secretKey: String,
+      region: String
+  ): Unit = {
+    val prefix = s"fs.s3a.bucket.$bucket"
+    if (endpoint.nonEmpty) hadoopConf.set(s"$prefix.endpoint", endpoint)
+    if (region.nonEmpty) {
+      hadoopConf.set(s"$prefix.endpoint.region", region)
+      hadoopConf.set(s"$prefix.region", region)
+    }
+    hadoopConf.set(s"$prefix.path.style.access", "true")
+    hadoopConf.set(s"$prefix.connection.ssl.enabled", "false")
+    if (accessKey.nonEmpty) {
+      hadoopConf.set(s"$prefix.access.key", accessKey)
+      hadoopConf.set(s"$prefix.secret.key", secretKey)
+      hadoopConf.set(
+        s"$prefix.aws.credentials.provider",
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      )
+    }
+  }
+
+  private def normalizeS3(path: String): String =
+    if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://") else path
+
+  private def readAllBytes(
+      conf: Configuration,
+      path: String
+  ): Array[Byte] = {
+    import java.net.URI
+    import org.apache.hadoop.fs.{FileSystem, Path => HPath}
+    import java.io.ByteArrayOutputStream
+    val uri = new URI(path)
+    val fs = FileSystem.get(uri, conf)
+    val in = fs.open(new HPath(uri))
+    try {
+      val out = new ByteArrayOutputStream()
+      val buf = new Array[Byte](8192)
+      var n = in.read(buf)
+      while (n >= 0) {
+        out.write(buf, 0, n)
+        n = in.read(buf)
+      }
+      out.toByteArray
+    } finally {
+      in.close()
+    }
+  }
+}

--- a/src/main/scala/tools/ReadSourceOnlyApp.scala
+++ b/src/main/scala/tools/ReadSourceOnlyApp.scala
@@ -5,8 +5,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.SparkSession
 
 import com.zilliz.spark.connector.read.{
-  MilvusParquetFooterReader,
-  MilvusSegmentManifestReader,
   MilvusSnapshotReader,
   V2SegmentInfo,
   V2SegmentLoader
@@ -65,7 +63,6 @@ object ReadSourceOnlyApp {
         s3Region
       )
 
-      // 1. Read snapshot metadata
       val snapshotJson = new String(
         readAllBytes(hadoopConf, normalizeS3(snapshotPath)),
         "UTF-8"
@@ -82,7 +79,6 @@ object ReadSourceOnlyApp {
       println(s"snapshot.id = ${metadata.snapshotInfo.id}")
       println(s"collection  = ${metadata.collection.schema.name}")
 
-      // 2. Load V2 segments (same path MilvusBackfill uses)
       val v2Segments: Seq[V2SegmentInfo] =
         V2SegmentLoader.loadV2Segments(
           metadata.manifestList,
@@ -105,7 +101,6 @@ object ReadSourceOnlyApp {
         )
       }
 
-      // 3. Pick PK field id from schema
       val pkField = metadata.collection.schema.fields
         .find(_.isPrimaryKey.getOrElse(false))
         .getOrElse(throw new RuntimeException("no PK field in schema"))
@@ -113,8 +108,8 @@ object ReadSourceOnlyApp {
       val pkName = pkField.name
       println(s"pk field: $pkName (id=$pkFieldId)")
 
-      // 4. Build MilvusDataSource read options (matches MilvusBackfill's
-      //    readCollectionWithMetadata path — snapshot mode, PK + extras only).
+      val segmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
+      val rowOffsetCol = MilvusOption.MilvusExtraColumnRowOffset
       var options = Map[String, String](
         MilvusOption.SnapshotMode -> "true",
         "milvus.uri" -> "dummy://snapshot-mode",
@@ -123,6 +118,7 @@ object ReadSourceOnlyApp {
         MilvusOption.SnapshotPartitionIds -> metadata.snapshotInfo.partitionIds
           .mkString(","),
         MilvusOption.ReaderFieldIDs -> pkFieldId.toString,
+        MilvusOption.MilvusExtraColumns -> s"$segmentIdCol,$rowOffsetCol",
         "milvus.s3.endpoint" -> s3Endpoint,
         "milvus.s3.bucketName" -> s3Bucket,
         "milvus.s3.accessKey" -> s3AccessKey,
@@ -149,10 +145,7 @@ object ReadSourceOnlyApp {
           MilvusSnapshotReader.serializeV2Segments(v2Segments))
       }
 
-      // 5. Build the read schema: PK field + segment metadata columns
       import org.apache.spark.sql.types._
-      val segmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
-      val rowOffsetCol = MilvusOption.MilvusExtraColumnRowOffset
       val pkStructField = MilvusSnapshotReader.fieldToStructField(pkField)
       val readSchema = StructType(
         Seq(
@@ -168,8 +161,6 @@ object ReadSourceOnlyApp {
         .options(options)
         .load()
 
-      // ---- Diagnose ----
-
       println("\n=== Raw source DataFrame ===")
       val total = df.count()
       val distinctPk = df.select(col(pkName)).distinct().count()
@@ -182,7 +173,6 @@ object ReadSourceOnlyApp {
         )
         println("=> V2 packed reader is producing repeated data.")
 
-        // Show PK frequency — which pks appear more than once?
         println("\nTop duplicated PKs (appear count > 1):")
         df.groupBy(col(pkName))
           .count()
@@ -191,7 +181,6 @@ object ReadSourceOnlyApp {
           .show(20, truncate = false)
       }
 
-      // ---- Boundary samples: first/last of each 8192-row block ----
       val probeOffsets = Seq(
         0L, 1L, 8191L, 8192L, 8193L, 10000L, 16383L, 16384L, 16385L, 20479L
       )
@@ -203,23 +192,25 @@ object ReadSourceOnlyApp {
       ).orderBy(segmentIdCol, rowOffsetCol)
         .show(100, truncate = false)
 
-      // ---- Per-segment stats ----
       println("\n=== Per-segment stats ===")
       df.groupBy(col(segmentIdCol))
         .agg(
           count(lit(1)).as("rows"),
-          countDistinct(col(pkName)).as(s"distinct_$pkName"),
-          min(col(rowOffsetCol)).as("min_ro"),
-          max(col(rowOffsetCol)).as("max_ro")
+          countDistinct(col(pkName)).as("distinct_pk"),
+          min(col(rowOffsetCol)).as("min_row_offset"),
+          max(col(rowOffsetCol)).as("max_row_offset")
         )
-        .show(50, truncate = false)
+        .orderBy(col(segmentIdCol))
+        .show(100, truncate = false)
 
+      println("\n=== Done ===")
+      println(s"snapshot=$snapshotPath")
+      println(s"pk=$pkName")
+      println(s"segments=${v2Segments.map(_.segmentId).mkString(",")}")
     } finally {
       spark.stop()
     }
   }
-
-  // ------------------------------------------------------------------
 
   private def required(
       parsed: Map[String, String],
@@ -284,9 +275,11 @@ object ReadSourceOnlyApp {
       conf: Configuration,
       path: String
   ): Array[Byte] = {
-    import java.net.URI
-    import org.apache.hadoop.fs.{FileSystem, Path => HPath}
     import java.io.ByteArrayOutputStream
+    import java.net.URI
+
+    import org.apache.hadoop.fs.{FileSystem, Path => HPath}
+
     val uri = new URI(path)
     val fs = FileSystem.get(uri, conf)
     val in = fs.open(new HPath(uri))

--- a/src/test/scala/read/MilvusDeltaLogReaderTest.scala
+++ b/src/test/scala/read/MilvusDeltaLogReaderTest.scala
@@ -1,0 +1,58 @@
+package com.zilliz.spark.connector.read
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MilvusDeltaLogReaderTest extends AnyFunSuite with Matchers {
+  test("mergeInheritedDeletePlans keeps L0 deletes within the same partition") {
+    val dataSegments = Seq(
+      V2SegmentInfo(
+        segmentId = 2L,
+        partitionId = 10L,
+        numOfRows = 100L,
+        storageVersion = 2L,
+        columnGroups = Seq(
+          V2ColumnGroup(Seq(100L, 1L), Seq("s3a://bucket/data-p10"), Seq(100L))
+        )
+      ),
+      V2SegmentInfo(
+        segmentId = 3L,
+        partitionId = 11L,
+        numOfRows = 100L,
+        storageVersion = 2L,
+        columnGroups = Seq(
+          V2ColumnGroup(Seq(100L, 1L), Seq("s3a://bucket/data-p11"), Seq(100L))
+        )
+      )
+    )
+
+    val inheritedPlansByPartition = Map(
+      10L -> MilvusDeletePlan.fromLongPks(Map(7L -> 100L))
+    )
+    val ownPlansBySegment = Map(
+      2L -> MilvusDeletePlan.fromLongPks(Map(9L -> 200L)),
+      3L -> MilvusDeletePlan.empty
+    )
+
+    val merged = MilvusDeltaLogReader.mergeInheritedDeletePlans(
+      dataSegments,
+      inheritedPlansByPartition,
+      ownPlansBySegment
+    )
+
+    merged(2L).containsLongPk(7L, 50L) shouldBe true
+    merged(2L).containsLongPk(9L, 150L) shouldBe true
+    merged(3L).containsLongPk(7L, 50L) shouldBe false
+  }
+
+  test("delete plan union keeps the latest delete timestamp per PK") {
+    val merged = MilvusDeletePlan.union(
+      MilvusDeletePlan.fromLongPks(Map(7L -> 100L)),
+      MilvusDeletePlan.fromLongPks(Map(7L -> 200L, 8L -> 150L))
+    )
+
+    merged.containsLongPk(7L, 150L) shouldBe true
+    merged.containsLongPk(7L, 250L) shouldBe false
+    merged.containsLongPk(8L, 140L) shouldBe true
+  }
+}

--- a/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.read
 
+import org.apache.arrow.vector.BigIntVector
 import org.apache.spark.sql.types.{
   LongType,
   StringType,
@@ -196,11 +197,11 @@ class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
       mappings,
       neededColumnFieldIds = Seq(101L),
       applyDeletes = true,
-      deletePlan = MilvusDeletePlan.fromLongPks(Set(1L)),
+      deletePlan = MilvusDeletePlan.fromLongPks(Map(1L -> 100L)),
       pkFieldId = 100L
     )
 
-    assert(projected == Seq(101L, 100L))
+    assert(projected == Seq(101L, 100L, 1L))
   }
 
   test(
@@ -230,5 +231,53 @@ class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
     )
 
     assert(projected == Seq(101L))
+  }
+
+  test("rowDeleted respects delete timestamp ordering") {
+    val pkField = FieldSchema(
+      name = "pk",
+      fieldID = 100,
+      dataType = DataType.Int64,
+      isPrimaryKey = true
+    )
+    val allocator = new org.apache.arrow.memory.RootAllocator(Long.MaxValue)
+    val pkVector = new BigIntVector("pk", allocator)
+    val tsVector = new BigIntVector("Timestamp", allocator)
+    try {
+      pkVector.allocateNew(1)
+      pkVector.set(0, 1L)
+      pkVector.setValueCount(1)
+      tsVector.allocateNew(1)
+      tsVector.set(0, 200L)
+      tsVector.setValueCount(1)
+
+      val deletePlan = MilvusDeletePlan.fromLongPks(Map(1L -> 150L))
+      assert(
+        !MilvusPackedV2PartitionReader.rowDeleted(
+          deletePlan,
+          pkField,
+          pkVector,
+          tsVector,
+          rowIndex = 0,
+          pkColumnName = "pk"
+        )
+      )
+
+      val laterDeletePlan = MilvusDeletePlan.fromLongPks(Map(1L -> 250L))
+      assert(
+        MilvusPackedV2PartitionReader.rowDeleted(
+          laterDeletePlan,
+          pkField,
+          pkVector,
+          tsVector,
+          rowIndex = 0,
+          pkColumnName = "pk"
+        )
+      )
+    } finally {
+      pkVector.close()
+      tsVector.close()
+      allocator.close()
+    }
   }
 }

--- a/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusPackedV2PartitionReaderTest.scala
@@ -1,0 +1,234 @@
+package com.zilliz.spark.connector.read
+
+import org.apache.spark.sql.types.{
+  LongType,
+  StringType,
+  StructField,
+  StructType
+}
+import org.scalatest.funsuite.AnyFunSuite
+
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
+
+class MilvusPackedV2PartitionReaderTest extends AnyFunSuite {
+  test(
+    "lowercase system aliases are omitted when user fields use those names"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "row_id", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        )
+      )
+    )
+
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+
+    assert(mappings.fieldNameToId("row_id") == 100L)
+    assert(mappings.fieldNameToId("timestamp") == 101L)
+    assert(!mappings.fieldNameToArrowColumn.contains("row_id"))
+    assert(!mappings.fieldNameToArrowColumn.contains("timestamp"))
+    assert(mappings.fieldNameToArrowColumn("RowID") == "RowID")
+    assert(mappings.fieldNameToArrowColumn("Timestamp") == "Timestamp")
+  }
+
+  test("system aliases are omitted when user fields use canonical names") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(
+          name = "Timestamp",
+          fieldID = 101,
+          dataType = DataType.Int64
+        ),
+        FieldSchema(name = "rowid", fieldID = 102, dataType = DataType.Int64)
+      )
+    )
+
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+
+    assert(mappings.fieldNameToId("RowID") == 100L)
+    assert(mappings.fieldNameToId("Timestamp") == 101L)
+    assert(mappings.fieldNameToId("rowid") == 102L)
+    assert(mappings.fieldNameToId("row_id") == 0L)
+    assert(mappings.fieldNameToId("timestamp") == 1L)
+    assert(!mappings.fieldNameToArrowColumn.contains("RowID"))
+    assert(!mappings.fieldNameToArrowColumn.contains("Timestamp"))
+    assert(!mappings.fieldNameToArrowColumn.contains("rowid"))
+    assert(mappings.fieldNameToArrowColumn("row_id") == "RowID")
+    assert(mappings.fieldNameToArrowColumn("timestamp") == "Timestamp")
+  }
+
+  test("resolveNeededColumns uses exact user names before system aliases") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "RowID", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(Seq(StructField("RowID", LongType)))
+    val columnGroups = Seq(
+      V2ColumnGroup(
+        fieldIds = Seq(100L),
+        filePaths = Seq("s3a://bucket/files/insert_log/1/2/3/100/1"),
+        fileRowCounts = Seq(1L)
+      )
+    )
+
+    val columns = MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups,
+      mappings,
+      neededColumnFieldIds = Seq.empty
+    )
+
+    assert(columns.toSeq == Seq("RowID"))
+  }
+
+  test(
+    "resolveNeededColumns returns empty for V2 segments without column groups"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(Seq(StructField("pk", LongType)))
+
+    val columns = MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups = Seq.empty,
+      mappings,
+      neededColumnFieldIds = Seq.empty
+    )
+
+    assert(columns.isEmpty)
+  }
+
+  test(
+    "resolveNeededColumns fails when requested field is absent from V2 column groups"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64),
+        FieldSchema(name = "value", fieldID = 101, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(
+      Seq(
+        StructField("pk", LongType),
+        StructField("value", LongType)
+      )
+    )
+    val columnGroups = Seq(
+      V2ColumnGroup(
+        fieldIds = Seq(100L),
+        filePaths = Seq("s3a://bucket/files/insert_log/1/2/3/100/1"),
+        fileRowCounts = Seq(1L)
+      )
+    )
+
+    val err = intercept[IllegalArgumentException] {
+      MilvusPackedV2PartitionReader.resolveNeededColumns(
+        sourceSchema,
+        columnGroups,
+        mappings,
+        neededColumnFieldIds = Seq(100L, 101L)
+      )
+    }
+
+    assert(err.getMessage.contains("do not contain requested columns: value"))
+  }
+
+  test("resolveNeededColumns tolerates synthetic $meta column") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(name = "pk", fieldID = 100, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(
+      Seq(
+        StructField("pk", LongType),
+        StructField("$meta", StringType)
+      )
+    )
+    val columnGroups = Seq(
+      V2ColumnGroup(
+        fieldIds = Seq(100L),
+        filePaths = Seq("s3a://bucket/files/insert_log/1/2/3/100/1"),
+        fileRowCounts = Seq(1L)
+      )
+    )
+
+    val columns = MilvusPackedV2PartitionReader.resolveNeededColumns(
+      sourceSchema,
+      columnGroups,
+      mappings,
+      neededColumnFieldIds = Seq.empty
+    )
+
+    assert(columns.toSeq == Seq("pk"))
+  }
+
+  test("projectedFieldIds forces PK when delete filtering is enabled") {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(
+          name = "pk",
+          fieldID = 100,
+          dataType = DataType.Int64,
+          isPrimaryKey = true
+        ),
+        FieldSchema(name = "value", fieldID = 101, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(Seq(StructField("value", LongType)))
+
+    val projected = MilvusPackedV2PartitionReader.projectedFieldIds(
+      sourceSchema,
+      mappings,
+      neededColumnFieldIds = Seq(101L),
+      applyDeletes = true,
+      deletePlan = MilvusDeletePlan.fromLongPks(Set(1L)),
+      pkFieldId = 100L
+    )
+
+    assert(projected == Seq(101L, 100L))
+  }
+
+  test(
+    "projectedFieldIds keeps projection unchanged when delete plan is empty"
+  ) {
+    val schema = CollectionSchema(
+      fields = Seq(
+        FieldSchema(
+          name = "pk",
+          fieldID = 100,
+          dataType = DataType.Int64,
+          isPrimaryKey = true
+        ),
+        FieldSchema(name = "value", fieldID = 101, dataType = DataType.Int64)
+      )
+    )
+    val mappings = MilvusPackedV2PartitionReader.buildFieldMappings(schema)
+    val sourceSchema = StructType(Seq(StructField("value", LongType)))
+
+    val projected = MilvusPackedV2PartitionReader.projectedFieldIds(
+      sourceSchema,
+      mappings,
+      neededColumnFieldIds = Seq(101L),
+      applyDeletes = true,
+      deletePlan = MilvusDeletePlan.empty,
+      pkFieldId = 100L
+    )
+
+    assert(projected == Seq(101L))
+  }
+}

--- a/src/test/scala/read/MilvusPartitionReaderFactoryTest.scala
+++ b/src/test/scala/read/MilvusPartitionReaderFactoryTest.scala
@@ -1,0 +1,47 @@
+package com.zilliz.spark.connector.read
+
+import org.apache.spark.unsafe.types.UTF8String
+import org.scalatest.funsuite.AnyFunSuite
+
+import com.zilliz.spark.connector.MilvusOption
+
+class MilvusPartitionReaderFactoryTest extends AnyFunSuite {
+  test("requestedExtraColumns normalizes legacy aliases") {
+    val requested = MilvusPartitionReaderFactory.requestedExtraColumns(
+      Map(MilvusOption.MilvusExtraColumns -> "partition,segment_id,row_offset")
+    )
+
+    assert(
+      requested == Set(
+        MilvusOption.MilvusExtraColumnPartition,
+        MilvusOption.MilvusExtraColumnSegmentID,
+        MilvusOption.MilvusExtraColumnRowOffset
+      )
+    )
+  }
+
+  test("metadata classification is limited to requested extra columns") {
+    val requested = Set(MilvusOption.MilvusExtraColumnSegmentID)
+
+    assert(
+      !MilvusPartitionReaderFactory.isMetadataExtraField(
+        MilvusOption.MilvusExtraColumnPartition,
+        requested
+      )
+    )
+    assert(
+      MilvusPartitionReaderFactory.isMetadataExtraField(
+        MilvusOption.MilvusExtraColumnSegmentID,
+        requested
+      )
+    )
+  }
+
+  test("partition metadata values use Spark UTF8String representation") {
+    assert(
+      MilvusPartitionReaderFactory.stringValue("20") == UTF8String.fromString(
+        "20"
+      )
+    )
+  }
+}

--- a/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
@@ -101,6 +101,47 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
     // multi-group fieldID conflicts. Slots match the per-group directory
     // names {0, 1, 102} for this fixture.
     seg.columnGroups.map(_.slotFieldId) shouldBe Seq(0L, 1L, 102L)
+    seg.deltaLogs shouldBe empty
+  }
+
+  test("toV2SegmentInfo flattens and sorts delta logs by logId") {
+    val entry = AvroManifestEntry(
+      segmentId = 123L,
+      partitionId = 456L,
+      segmentLevel = 1L,
+      numOfRows = 789L,
+      storageVersion = 2L,
+      binlogFiles = Seq(
+        AvroFieldBinlogEntry(
+          slotFieldId = 100L,
+          binlogs = Seq(AvroBinlogEntry(1L, "files/insert_log/.../1", 10L))
+        )
+      ),
+      deltaLogFiles = Seq(
+        AvroFieldBinlogEntry(
+          slotFieldId = 100L,
+          binlogs = Seq(
+            AvroBinlogEntry(9L, "files/delete_log/.../9", 1L),
+            AvroBinlogEntry(7L, "files/delete_log/.../7", 3L)
+          )
+        ),
+        AvroFieldBinlogEntry(
+          slotFieldId = 101L,
+          binlogs = Seq(AvroBinlogEntry(8L, "files/delete_log/.../8", 2L))
+        )
+      )
+    )
+
+    val result =
+      MilvusSegmentManifestReader.toV2SegmentInfo(entry, Seq(Seq(100L)))
+
+    result shouldBe a[Right[_, _]]
+    val seg = result.toOption.get
+    seg.deltaLogs shouldBe Seq(
+      V2DeltaLogFile(7L, "files/delete_log/.../7", 3L),
+      V2DeltaLogFile(8L, "files/delete_log/.../8", 2L),
+      V2DeltaLogFile(9L, "files/delete_log/.../9", 1L)
+    )
   }
 
   test("toV2SegmentInfo rejects non-StorageV2 entries") {
@@ -135,6 +176,18 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
           filePaths = Seq("p/103"),
           fileRowCounts = Seq(20480L)
         )
+      ),
+      deltaLogs = Seq(
+        V2DeltaLogFile(
+          logId = 7L,
+          logPath = "files/delete_log/.../7",
+          entriesNum = 3L
+        ),
+        V2DeltaLogFile(
+          logId = 9L,
+          logPath = "files/delete_log/.../9",
+          entriesNum = 1L
+        )
       )
     )
     val json = MilvusSnapshotReader.serializeV2Segments(Seq(seg))
@@ -145,12 +198,15 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
     got.segmentId shouldBe seg.segmentId
     got.columnGroups(0).fieldIds shouldBe Seq(100L, 0L, 1L)
     got.columnGroups(0).fileRowCounts shouldBe Seq(20480L)
+    got.deltaLogs shouldBe seg.deltaLogs
     // Exercise the exact pattern that failed at runtime — mapping over the
     // rehydrated Seq[Long]. Must not throw ClassCastException.
     val asStrings = got.columnGroups(0).fieldIds.map(_.toString)
     asStrings shouldBe Seq("100", "0", "1")
     val rcStrings = got.columnGroups(0).fileRowCounts.map(_.toString)
     rcStrings shouldBe Seq("20480")
+    val deltaStrings = got.deltaLogs.map(_.logId.toString)
+    deltaStrings shouldBe Seq("7", "9")
   }
 
   test("toV2SegmentInfo fails when group count disagrees with AVRO") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -45,6 +45,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     result shouldBe a[Right[_, _]]
     val metadata = result.toOption.get
 
+    metadata.allSegments shouldBe empty
+
     // Verify snapshot info
     metadata.snapshotInfo.name shouldBe "backfill_snapshot"
     metadata.snapshotInfo.id shouldBe 462324574599774209L
@@ -262,6 +264,299 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     result.toOption.get.snapshotInfo.name shouldBe "test"
   }
 
+  test("manifestSchemaVersion defaults legacy snapshots to v1") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(json).toOption.get
+
+    metadata.manifestSchemaVersion shouldBe 1
+  }
+
+  test("manifestSchemaVersion uses snapshot format_version when present") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "format_version": 4,
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(json).toOption.get
+
+    metadata.manifestSchemaVersion shouldBe 4
+  }
+
+  test("manifestSchemaVersion treats version 0 metadata as v1 manifests") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "format_version": 0,
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(json).toOption.get
+
+    metadata.manifestSchemaVersion shouldBe 1
+  }
+
+  test("manifestSchemaVersion preserves v2 and v3 metadata versions") {
+    val jsonV2 = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "format_version": 2,
+      "indexes": [],
+      "manifest-list": []
+    }
+    """
+    val jsonV3 =
+      jsonV2.replace("\"format_version\": 2", "\"format_version\": 3")
+
+    MilvusSnapshotReader
+      .parseSnapshotMetadata(jsonV2)
+      .toOption
+      .get
+      .manifestSchemaVersion shouldBe 2
+    MilvusSnapshotReader
+      .parseSnapshotMetadata(jsonV3)
+      .toOption
+      .get
+      .manifestSchemaVersion shouldBe 3
+  }
+
+  test(
+    "Parse snapshot segment delete metadata from segments and segment_infos"
+  ) {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": [],
+      "segments": [
+        {
+          "segment_id": 10,
+          "partition_id": 20,
+          "segment_level": 1,
+          "storage_version": 2,
+          "deltalog_files": [
+            {
+              "field_id": 100,
+              "binlogs": [
+                {
+                  "entries_num": 3,
+                  "log_path": "files/delete-a",
+                  "log_id": 7
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "segment_infos": [
+        {
+          "segment_id": 11,
+          "partition_id": 21,
+          "segment_level": 0,
+          "storage_version": 2,
+          "deltalog_files": [
+            {
+              "field_id": 100,
+              "binlogs": [
+                {
+                  "entries_num": 1,
+                  "log_path": "files/delete-b",
+                  "log_id": 8
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    val result = MilvusSnapshotReader.parseSnapshotMetadata(json)
+
+    result shouldBe a[Right[_, _]]
+    val metadata = result.toOption.get
+    metadata.allSegments should have size 1
+    metadata.allSegments.head.segmentId shouldBe 10L
+    metadata.allSegments.head.partitionId shouldBe 20L
+    metadata.allSegments.head.segmentLevel shouldBe Some(1L)
+    metadata.allSegments.head.storageVersion shouldBe 2L
+    metadata.allSegments.head.deltaLogFiles should have size 1
+    metadata.allSegments.head.deltaLogFiles.head.fieldId shouldBe 100L
+    metadata.allSegments.head.deltaLogFiles.head.binlogs.head.entriesNum shouldBe 3L
+    metadata.allSegments.head.deltaLogFiles.head.binlogs.head.logPath shouldBe "files/delete-a"
+    metadata.allSegments.head.deltaLogFiles.head.binlogs.head.logId shouldBe 7L
+  }
+
+  test("allSegments falls back to segment_infos when segments is empty") {
+    val json = """
+    {
+      "snapshot-info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "fields": [
+            {
+              "fieldID": 100,
+              "name": "id",
+              "data_type": 5,
+              "is_primary_key": true
+            }
+          ]
+        }
+      },
+      "indexes": [],
+      "manifest-list": [],
+      "segment_infos": [
+        {
+          "segment_id": 11,
+          "partition_id": 21,
+          "segment_level": 0,
+          "storage_version": 2,
+          "deltalog_files": [
+            {
+              "field_id": 100,
+              "binlogs": [
+                {
+                  "entries_num": 1,
+                  "log_path": "files/delete-b",
+                  "log_id": 8
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    val result = MilvusSnapshotReader.parseSnapshotMetadata(json)
+
+    result shouldBe a[Right[_, _]]
+    val metadata = result.toOption.get
+    metadata.segments shouldBe empty
+    metadata.segmentInfos should have size 1
+    metadata.allSegments should have size 1
+    metadata.allSegments.head.segmentId shouldBe 11L
+    metadata.allSegments.head.segmentLevel shouldBe Some(0L)
+    metadata.allSegments.head.deltaLogFiles.head.binlogs.head.logPath shouldBe "files/delete-b"
+  }
+
   test("Get Storage V2 manifest map from snapshot file") {
     val result = MilvusSnapshotReader.getStorageV2ManifestMap(snapshotFilePath)
 
@@ -398,6 +693,46 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     deserializedList should have size originalManifestList.size
     deserializedList.head.segmentID shouldBe originalManifestList.head.segmentID
     deserializedList.head.manifest shouldBe originalManifestList.head.manifest
+  }
+
+  test("serialize and deserialize V2 segments keeps delta logs") {
+    val segments = Seq(
+      V2SegmentInfo(
+        segmentId = 10L,
+        partitionId = 20L,
+        numOfRows = 30L,
+        storageVersion = 2L,
+        columnGroups = Seq(
+          V2ColumnGroup(
+            fieldIds = Seq(100L, 0L, 1L),
+            filePaths = Seq("files/insert_log/.../0/1"),
+            fileRowCounts = Seq(30L)
+          )
+        ),
+        deltaLogs = Seq(
+          V2DeltaLogFile(
+            logId = 9L,
+            logPath = "files/delete_log/.../9",
+            entriesNum = 2L
+          ),
+          V2DeltaLogFile(
+            logId = 11L,
+            logPath = "files/delete_log/.../11",
+            entriesNum = 1L
+          )
+        )
+      )
+    )
+
+    val json = MilvusSnapshotReader.serializeV2Segments(segments)
+    json should not be empty
+
+    val result = MilvusSnapshotReader.deserializeV2Segments(json)
+    result shouldBe a[Right[_, _]]
+    val roundTripped = result.toOption.get
+
+    roundTripped should have size 1
+    roundTripped.head shouldBe segments.head
   }
 
   test("Parse data_type as string format (e.g., 'Int64' instead of 5)") {

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -115,11 +115,12 @@ class V2SegmentLoaderTest
       binlogs: Seq[AvroFieldBinlogEntry],
       storageVersion: Long = 2L,
       segmentLevel: Long = 1L,
+      partitionId: Long = 10L,
       deltaLogFiles: Seq[AvroFieldBinlogEntry] = Seq.empty
   ): AvroManifestEntry =
     AvroManifestEntry(
       segmentId = segmentId,
-      partitionId = 10L,
+      partitionId = partitionId,
       segmentLevel = segmentLevel,
       numOfRows = 100L,
       storageVersion = storageVersion,

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -113,14 +113,18 @@ class V2SegmentLoaderTest
   private def entry(
       segmentId: Long,
       binlogs: Seq[AvroFieldBinlogEntry],
-      storageVersion: Long = 2L
+      storageVersion: Long = 2L,
+      segmentLevel: Long = 1L,
+      deltaLogFiles: Seq[AvroFieldBinlogEntry] = Seq.empty
   ): AvroManifestEntry =
     AvroManifestEntry(
       segmentId = segmentId,
       partitionId = 10L,
+      segmentLevel = segmentLevel,
       numOfRows = 100L,
       storageVersion = storageVersion,
-      binlogFiles = binlogs
+      binlogFiles = binlogs,
+      deltaLogFiles = deltaLogFiles
     )
 
   test(
@@ -265,9 +269,110 @@ class V2SegmentLoaderTest
     seg.columnGroups shouldBe empty
   }
 
+  test(
+    "StorageV2 entry with delete metadata keeps segment info when applyDeletes=true"
+  ) {
+    val pq0 = mkTempParquet("v2loader-delete-meta-")
+    try {
+      writeSingleFieldParquet(pq0, "pk", fieldId = 100)
+
+      val manifest = entry(
+        segmentId = 5005L,
+        binlogs = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq0.toUri.toString, 10L))
+          )
+        ),
+        deltaLogFiles = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(9L, "s3a://bucket/delete-1", 1L))
+          )
+        )
+      )
+
+      val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+        manifest,
+        bucket = "",
+        new Configuration(),
+        applyDeletes = true
+      )
+
+      result shouldBe a[Right[_, _]]
+      val Some(seg) = result.toOption.get
+      seg.segmentId shouldBe 5005L
+      seg.columnGroups.map(_.fieldIds) shouldBe Seq(Seq(100L))
+      seg.deltaLogs shouldBe Seq(
+        V2DeltaLogFile(9L, "s3a://bucket/delete-1", 1L)
+      )
+    } finally {
+      Files.deleteIfExists(pq0)
+    }
+  }
+
+  test("StorageV2 L0 segment is skipped when applyDeletes=false") {
+    val manifest = entry(
+      segmentId = 5006L,
+      binlogs = Seq(
+        AvroFieldBinlogEntry(slotFieldId = 100L, binlogs = Seq.empty)
+      ),
+      segmentLevel = 0L
+    )
+
+    val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+      manifest,
+      bucket = "",
+      new Configuration(),
+      applyDeletes = false
+    )
+
+    result shouldBe Right(None)
+  }
+
+  test("StorageV2 data segment keeps reading when applyDeletes=false") {
+    val pq0 = mkTempParquet("v2loader-ignore-delete-")
+    try {
+      writeSingleFieldParquet(pq0, "pk", fieldId = 100)
+
+      val manifest = entry(
+        segmentId = 5007L,
+        binlogs = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(0L, pq0.toUri.toString, 10L))
+          )
+        ),
+        deltaLogFiles = Seq(
+          AvroFieldBinlogEntry(
+            slotFieldId = 100L,
+            binlogs = Seq(AvroBinlogEntry(9L, "s3a://bucket/delete-1", 1L))
+          )
+        )
+      )
+
+      val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(
+        manifest,
+        bucket = "",
+        new Configuration(),
+        applyDeletes = false
+      )
+
+      result shouldBe a[Right[_, _]]
+      val Some(seg) = result.toOption.get
+      seg.segmentId shouldBe 5007L
+      seg.columnGroups.map(_.fieldIds) shouldBe Seq(Seq(100L))
+      seg.deltaLogs shouldBe Seq(
+        V2DeltaLogFile(9L, "s3a://bucket/delete-1", 1L)
+      )
+    } finally {
+      Files.deleteIfExists(pq0)
+    }
+  }
+
   test("non-StorageV2 entry is skipped (returns Right(None))") {
     val manifest = entry(
-      segmentId = 5005L,
+      segmentId = 5008L,
       binlogs = Seq.empty,
       storageVersion = 3L // V3
     )

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -114,7 +114,7 @@ class V2SegmentLoaderTest
       segmentId: Long,
       binlogs: Seq[AvroFieldBinlogEntry],
       storageVersion: Long = 2L,
-      segmentLevel: Long = 1L,
+      segmentLevel: Long = 2L,
       partitionId: Long = 10L,
       deltaLogFiles: Seq[AvroFieldBinlogEntry] = Seq.empty
   ): AvroManifestEntry =
@@ -318,7 +318,7 @@ class V2SegmentLoaderTest
       binlogs = Seq(
         AvroFieldBinlogEntry(slotFieldId = 100L, binlogs = Seq.empty)
       ),
-      segmentLevel = 0L
+      segmentLevel = 1L
     )
 
     val result = V2SegmentLoader.buildV2SegmentInfoFromEntry(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -329,6 +329,21 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test("snapshotS3BucketForRelativePaths accepts connector bucket aliases") {
+    assert(
+      MilvusScan.snapshotS3BucketForRelativePaths(
+        "files/snapshots/1/metadata/2.json",
+        Map(MilvusOption.FsBucketName -> "connector-bucket")
+      ) == Some("connector-bucket")
+    )
+    assert(
+      MilvusScan.snapshotS3BucketForRelativePaths(
+        "files/snapshots/1/metadata/2.json",
+        Map(MilvusOption.S3BucketName -> "connector-bucket")
+      ) == Some("connector-bucket")
+    )
+  }
+
   test("snapshotBucketsToConfigure includes cross-bucket snapshot locations") {
     assert(
       MilvusScan.snapshotBucketsToConfigure(
@@ -842,6 +857,21 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       MilvusOption.ClientSnapshotCompactionProtectionSeconds ==
         "milvus.client.snapshot.compaction.protection.seconds"
     )
+    assert(
+      MilvusOption.ClientSnapshotAutoCleanup ==
+        "milvus.client.snapshot.auto.cleanup"
+    )
+  }
+
+  test("clientSnapshotAutoCleanup defaults to true and parses false") {
+    assert(
+      MilvusOption.clientSnapshotAutoCleanup(Map.empty[String, String])
+    )
+    assert(
+      !MilvusOption.clientSnapshotAutoCleanup(
+        Map(MilvusOption.ClientSnapshotAutoCleanup -> "false")
+      )
+    )
   }
 
   test("parsePositiveLongOption rejects non-numeric and non-positive values") {
@@ -1033,11 +1063,17 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(firstPartitions eq secondPartitions)
   }
 
-  test("client mode does not cache planned input partitions") {
+  test("client snapshot fast path caches planned input partitions") {
     val clientOptions = new ju.HashMap[String, String]()
     clientOptions.put(MilvusOption.MilvusUri, "http://localhost:19530")
     clientOptions.put(MilvusOption.MilvusCollectionName, "c")
-    assert(!scanWithOptions(clientOptions).shouldCacheInputPartitions)
+    assert(scanWithOptions(clientOptions).shouldCacheInputPartitions)
+
+    val partitionScopedOptions = new ju.HashMap[String, String]()
+    partitionScopedOptions.put(MilvusOption.MilvusUri, "http://localhost:19530")
+    partitionScopedOptions.put(MilvusOption.MilvusCollectionName, "c")
+    partitionScopedOptions.put(MilvusOption.MilvusPartitionName, "p1")
+    assert(!scanWithOptions(partitionScopedOptions).shouldCacheInputPartitions)
 
     val snapshotOptions = new ju.HashMap[String, String]()
     snapshotOptions.put(MilvusOption.SnapshotMode, "true")

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -39,6 +39,7 @@ import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
   Collection,
   CollectionSchema,
+  MilvusDeletePlan,
   MilvusPackedV2InputPartition,
   MilvusSnapshotReader,
   MilvusStorageV3InputPartition,
@@ -1173,6 +1174,34 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     val partition = partitions.head.asInstanceOf[MilvusPackedV2InputPartition]
     assert(partition.segmentID == 30L)
     assert(partition.partitionID == 20L)
+  }
+
+  test(
+    "snapshot planner keeps inherited delete plan reference out of per-segment plan"
+  ) {
+    val inherited = MilvusDeletePlan.fromLongPks(Map(7L -> 100L))
+    val segmentPlan = MilvusDeletePlan.fromLongPks(Map(9L -> 200L))
+    val partition = MilvusPackedV2InputPartition(
+      segmentID = 30L,
+      partitionID = 20L,
+      columnGroups = Seq(
+        V2ColumnGroup(
+          fieldIds = Seq(100L, 1L),
+          filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+          fileRowCounts = Seq(1L)
+        )
+      ),
+      milvusSchemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      milvusOption = MilvusOption(
+        new CaseInsensitiveStringMap(new ju.HashMap[String, String]())
+      ),
+      deletePlan = segmentPlan,
+      inheritedDeletePlanPartitionId = Some(20L)
+    )
+
+    assert(partition.deletePlan == segmentPlan)
+    assert(partition.inheritedDeletePlanPartitionId.contains(20L))
+    assert(inherited.containsLongPk(7L, 50L))
   }
 }
 


### PR DESCRIPTION
Add StorageV2 deltalog propagation, snapshot/client-snapshot planning, and PK-delete filtering on the packed-V2 read path, while keeping backfill explicitly delete-blind behind separate read/backfill options.

This change carries StorageV2 delta metadata through manifest/snapshot models, builds per-segment delete plans in Scala before reader creation, and applies them in packed-V2 readers without renumbering original row offsets. It also hardens client-snapshot bucket resolution for relative paths, blocks the legacy non-snapshot fallback on StorageV2 segments, and cleans up stale logging around ignored delete metadata.

Current scope is intentionally limited: only StorageV2 deltalogs are handled here, only PK-delete semantics are applied, and StorageV3 manifest-based deltalogs remain unsupported. StorageV2 delete-only/L0 segments are skipped when delete application is disabled rather than being materialized into backfill-style reads.