### PR TITLE
fix: [reader] Adapt l0 segment & v3 deltalog

### DIFF
--- a/src/main/scala/read/MilvusDeltaLogReader.scala
+++ b/src/main/scala/read/MilvusDeltaLogReader.scala
@@ -99,7 +99,7 @@ object MilvusDeltaLogReader extends Logging {
     ).map(_.toMap)
   }
 
-  private[read] def effectiveInheritedDeletePlan(
+  private[connector] def effectiveInheritedDeletePlan(
       partitionId: Long,
       inheritedPlansByPartition: Map[Long, MilvusDeletePlan]
   ): MilvusDeletePlan = {
@@ -114,7 +114,7 @@ object MilvusDeltaLogReader extends Logging {
     MilvusDeletePlan.union(collectionWidePlan, partitionPlan)
   }
 
-  private[read] def inheritedDeletePlanPartitionMarker(
+  private[connector] def inheritedDeletePlanPartitionMarker(
       partitionId: Long,
       inheritedPlansByPartition: Map[Long, MilvusDeletePlan]
   ): Option[Long] =

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -39,6 +39,8 @@ import io.milvus.storage.{
 }
 
 object MilvusLoonPartitionReader {
+  private[read] val TimestampColumnName = "1"
+
   private[read] val SystemFieldAliases: Seq[(String, Long)] = Seq(
     "RowID" -> 0L,
     "row_id" -> 0L,
@@ -379,7 +381,9 @@ class MilvusLoonPartitionReader(
         s"StorageV3 delete filtering requires PK column $pkColumnName to be loaded"
       )
     }
-    val rawTsVector = batch.getVector("Timestamp")
+    val rawTsVector = batch.getVector(
+      MilvusLoonPartitionReader.TimestampColumnName
+    )
     if (rawTsVector == null) {
       throw new IllegalStateException(
         "StorageV3 delete filtering requires Timestamp column to be loaded"
@@ -459,7 +463,10 @@ class MilvusLoonPartitionReader(
             "StorageV3 delete filtering requires a primary key field"
           )
         )
-      (requested ++ Seq(pkId, "1")).distinct
+      (requested ++ Seq(
+        pkId,
+        MilvusLoonPartitionReader.TimestampColumnName
+      )).distinct
     }
   }
 

--- a/src/main/scala/read/MilvusLoonPartitionReader.scala
+++ b/src/main/scala/read/MilvusLoonPartitionReader.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
-import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.{BigIntVector, VectorSchemaRoot}
 import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.catalyst.InternalRow
@@ -28,7 +28,7 @@ import com.zilliz.spark.connector.{FloatConverter, MilvusOption}
 import com.zilliz.spark.connector.filter.VectorBruteForceSearch
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
-import io.milvus.grpc.schema.{CollectionSchema, DataType}
+import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
 import io.milvus.storage.{
   ArrowUtils,
   LatestColumnGroupsResult,
@@ -139,7 +139,9 @@ class MilvusLoonPartitionReader(
     vectorColumn: Option[String] = None,
     pushedFilters: Array[Filter] = Array.empty[Filter],
     readVersion: Long =
-      -1L // -1 = LATEST, >0 = specific manifest version from snapshot
+      -1L, // -1 = LATEST, >0 = specific manifest version from snapshot
+    applyDeletes: Boolean = true,
+    deletePlan: MilvusDeletePlan = MilvusDeletePlan.empty
 ) extends PartitionReader[InternalRow]
     with Logging {
 
@@ -155,6 +157,10 @@ class MilvusLoonPartitionReader(
 
   private val fieldNameToIdString: Map[String, String] =
     fieldNameToId.map { case (name, id) => name -> id.toString }
+
+  private val pkField: Option[FieldSchema] =
+    milvusSchema.fields.find(_.isPrimaryKey)
+  private val pkColumnName = pkField.map(_.fieldID.toString).getOrElse("")
 
   private val columnNames = getColumnNames()
 
@@ -283,6 +289,14 @@ class MilvusLoonPartitionReader(
         if (
           _currentBatch != null && _currentRowIndex < _currentBatch.getRowCount
         ) {
+          if (
+            applyDeletes && !deletePlan.isEmpty && isDeleted(
+              _currentBatch,
+              _currentRowIndex
+            )
+          ) {
+            _currentRowIndex += 1
+          } else
           // If we have filters, check if current row passes
           if (pushedFilters.nonEmpty) {
             val row = ArrowConverter.arrowToInternalRow(
@@ -353,6 +367,34 @@ class MilvusLoonPartitionReader(
 
   override def close(): Unit = releaseAll()
 
+  private def isDeleted(batch: VectorSchemaRoot, rowIndex: Int): Boolean = {
+    val pk = pkField.getOrElse {
+      throw new IllegalArgumentException(
+        "StorageV3 delete filtering requires a primary key field"
+      )
+    }
+    val pkVector = batch.getVector(pkColumnName)
+    if (pkVector == null) {
+      throw new IllegalStateException(
+        s"StorageV3 delete filtering requires PK column $pkColumnName to be loaded"
+      )
+    }
+    val rawTsVector = batch.getVector("Timestamp")
+    if (rawTsVector == null) {
+      throw new IllegalStateException(
+        "StorageV3 delete filtering requires Timestamp column to be loaded"
+      )
+    }
+    MilvusPackedV2PartitionReader.rowDeleted(
+      deletePlan,
+      pk,
+      pkVector,
+      rawTsVector.asInstanceOf[BigIntVector],
+      rowIndex,
+      pkColumnName
+    )
+  }
+
   // Each native resource is released in its own try-catch so one failing
   // release doesn't strand the rest. Null/zero sentinels make this
   // idempotent — safe to call from both close() and the ctor rollback
@@ -404,8 +446,20 @@ class MilvusLoonPartitionReader(
   private def getColumnNames(): Array[String] = {
     // Convert column names to field IDs for manifest/reader matching.
     // System fields are mapped to Milvus field IDs 0 and 1 and requested from storage.
-    sourceSchema.fieldNames.flatMap { name =>
+    val requested = sourceSchema.fieldNames.flatMap { name =>
       fieldNameToId.get(name).map(_.toString)
+    }
+    if (!applyDeletes || deletePlan.isEmpty) {
+      requested
+    } else {
+      val pkId = pkField
+        .map(_.fieldID.toString)
+        .getOrElse(
+          throw new IllegalArgumentException(
+            "StorageV3 delete filtering requires a primary key field"
+          )
+        )
+      (requested ++ Seq(pkId, "1")).distinct
     }
   }
 
@@ -469,50 +523,52 @@ class MilvusLoonPartitionReader(
 
       // Process each row in batch
       for (i <- 0 until batchSize) {
-        val row = ArrowConverter.arrowToInternalRow(
-          batch,
-          i,
-          sourceSchema,
-          fieldNameToIdString
-        )
-
-        // Extract vector from row
-        val vector =
-          try {
-            extractVectorFromRow(
-              row,
-              vectorColIndex,
-              sourceSchema(vectorColIndex).dataType
-            )
-          } catch {
-            case e: Exception =>
-              logWarning(
-                s"Failed to extract vector from row $rowCount: ${e.getMessage}"
-              )
-              null
-          }
-
-        if (vector != null) {
-          val distance = calculateDistance(qv, vector, metric)
-          val result = MilvusLoonPartitionReader.VectorSearchResult(
-            row.copy(),
-            distance,
-            rowCount
+        if (!(applyDeletes && !deletePlan.isEmpty && isDeleted(batch, i))) {
+          val row = ArrowConverter.arrowToInternalRow(
+            batch,
+            i,
+            sourceSchema,
+            fieldNameToIdString
           )
 
-          if (heap.size < k) {
-            heap.enqueue(result)
-          } else {
-            val worst = heap.head
-            val shouldReplace = metric match {
-              case "L2"            => distance < worst.distance
-              case "IP" | "COSINE" => distance > worst.distance
-              case _               => distance < worst.distance
+          // Extract vector from row
+          val vector =
+            try {
+              extractVectorFromRow(
+                row,
+                vectorColIndex,
+                sourceSchema(vectorColIndex).dataType
+              )
+            } catch {
+              case e: Exception =>
+                logWarning(
+                  s"Failed to extract vector from row $rowCount: ${e.getMessage}"
+                )
+                null
             }
 
-            if (shouldReplace) {
-              heap.dequeue()
+          if (vector != null) {
+            val distance = calculateDistance(qv, vector, metric)
+            val result = MilvusLoonPartitionReader.VectorSearchResult(
+              row.copy(),
+              distance,
+              rowCount
+            )
+
+            if (heap.size < k) {
               heap.enqueue(result)
+            } else {
+              val worst = heap.head
+              val shouldReplace = metric match {
+                case "L2"            => distance < worst.distance
+                case "IP" | "COSINE" => distance > worst.distance
+                case _               => distance < worst.distance
+              }
+
+              if (shouldReplace) {
+                heap.dequeue()
+                heap.enqueue(result)
+              }
             }
           }
         }

--- a/src/main/scala/read/MilvusPartitionReaderFactory.scala
+++ b/src/main/scala/read/MilvusPartitionReaderFactory.scala
@@ -89,7 +89,9 @@ class MilvusPartitionReaderFactory(
           p.metricType,
           p.vectorColumn,
           pushedFilters,
-          p.readVersion
+          p.readVersion,
+          p.applyDeletes,
+          p.deletePlan
         )
 
         val hasMetadataExtraFields = schema.fieldNames.exists { name =>
@@ -142,13 +144,16 @@ class MilvusPartitionReaderFactory(
 
         val milvusSchema = CollectionSchema.parseFrom(p.milvusSchemaBytes)
 
-        val effectiveDeletePlan = MilvusDeletePlan.union(
-          packedV2DeleteContext.inheritedPlansByPartition.getOrElse(
-            p.inheritedDeletePlanPartitionId.getOrElse(Long.MinValue),
-            MilvusDeletePlan.empty
-          ),
-          p.deletePlan
-        )
+        val inheritedDeletePlan = p.inheritedDeletePlanPartitionId
+          .map(partitionId =>
+            MilvusDeltaLogReader.effectiveInheritedDeletePlan(
+              partitionId,
+              packedV2DeleteContext.inheritedPlansByPartition
+            )
+          )
+          .getOrElse(MilvusDeletePlan.empty)
+        val effectiveDeletePlan =
+          MilvusDeletePlan.union(inheritedDeletePlan, p.deletePlan)
 
         val underlying = new MilvusPackedV2PartitionReader(
           innerSchema,

--- a/src/main/scala/read/MilvusStorageV3ManifestReader.scala
+++ b/src/main/scala/read/MilvusStorageV3ManifestReader.scala
@@ -1,6 +1,7 @@
 package com.zilliz.spark.connector.read
 
 import java.io.ByteArrayInputStream
+import java.net.URI
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
@@ -8,9 +9,11 @@ import org.apache.avro.file.DataFileStream
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.util.Utf8
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
 
 object MilvusStorageV3ManifestReader {
   private val PrimaryKeyDeltaLogType = 0
+  private val ManifestFileName = """manifest-(\d+)\.avro""".r
 
   def loadDeltaLogs(
       basePath: String,
@@ -40,6 +43,52 @@ object MilvusStorageV3ManifestReader {
       )
     }
     s"${basePath.stripSuffix("/")}/_metadata/manifest-$readVersion.avro"
+  }
+
+  private[connector] def latestManifestVersion(
+      basePath: String,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Long] = {
+    var uri: URI = null
+    var fs: FileSystem = null
+    try {
+      val metadataPath = V2SegmentLoader.resolvePath(
+        s"${basePath.stripSuffix("/")}/_metadata",
+        bucket
+      )
+      uri = new URI(metadataPath)
+      fs = FileSystem.get(uri, hadoopConf)
+      val path = new Path(uri)
+      if (!fs.exists(path)) {
+        Right(0L)
+      } else {
+        Right(
+          fs.listStatus(path)
+            .iterator
+            .flatMap(status =>
+              status.getPath.getName match {
+                case ManifestFileName(version) => Some(version.toLong)
+                case _                         => None
+              }
+            )
+            .foldLeft(0L)(math.max)
+        )
+      }
+    } catch {
+      case NonFatal(e) => Left(e)
+    } finally {
+      Option(uri).flatMap(uri => Option(uri.getScheme)).foreach { scheme =>
+        if (
+          fs != null && hadoopConf.getBoolean(
+            s"fs.$scheme.impl.disable.cache",
+            false
+          )
+        ) {
+          fs.close()
+        }
+      }
+    }
   }
 
   private[read] def parseDeltaLogs(

--- a/src/main/scala/read/MilvusStorageV3ManifestReader.scala
+++ b/src/main/scala/read/MilvusStorageV3ManifestReader.scala
@@ -1,0 +1,136 @@
+package com.zilliz.spark.connector.read
+
+import java.io.ByteArrayInputStream
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+import org.apache.avro.file.DataFileStream
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
+import org.apache.avro.util.Utf8
+import org.apache.hadoop.conf.Configuration
+
+object MilvusStorageV3ManifestReader {
+  private val PrimaryKeyDeltaLogType = 0
+
+  def loadDeltaLogs(
+      basePath: String,
+      readVersion: Long,
+      bucket: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Seq[V2DeltaLogFile]] = {
+    try {
+      val manifestPath = V2SegmentLoader.resolvePath(
+        manifestFilePath(basePath, readVersion),
+        bucket
+      )
+      val bytes = V2SegmentLoader.readAllBytes(hadoopConf, manifestPath)
+      parseDeltaLogs(bytes, basePath)
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  private[read] def manifestFilePath(
+      basePath: String,
+      readVersion: Long
+  ): String = {
+    if (readVersion <= 0) {
+      throw new IllegalArgumentException(
+        s"StorageV3 deltalog planning requires a positive manifest version, got $readVersion for $basePath"
+      )
+    }
+    s"${basePath.stripSuffix("/")}/_metadata/manifest-$readVersion.avro"
+  }
+
+  private[read] def parseDeltaLogs(
+      avroBytes: Array[Byte],
+      basePath: String
+  ): Either[Throwable, Seq[V2DeltaLogFile]] = {
+    try {
+      val reader = new DataFileStream[GenericRecord](
+        new ByteArrayInputStream(avroBytes),
+        new GenericDatumReader[GenericRecord]()
+      )
+      try {
+        if (!reader.hasNext) {
+          Right(Seq.empty)
+        } else {
+          val rec = reader.next()
+          Right(projectDeltaLogs(rec, basePath))
+        }
+      } finally {
+        reader.close()
+      }
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  private def projectDeltaLogs(
+      rec: GenericRecord,
+      basePath: String
+  ): Seq[V2DeltaLogFile] = {
+    val raw = rec.get("delta_logs")
+    if (raw == null) {
+      Seq.empty
+    } else {
+      raw
+        .asInstanceOf[java.util.List[GenericRecord]]
+        .asScala
+        .toSeq
+        .filter(log => asInt(log.get("type")) == PrimaryKeyDeltaLogType)
+        .filter(log => asLong(log.get("num_entries")) > 0L)
+        .zipWithIndex
+        .map { case (log, idx) =>
+          V2DeltaLogFile(
+            logId = idx.toLong,
+            logPath =
+              resolveManifestDeltaPath(basePath, asString(log.get("path"))),
+            entriesNum = asLong(log.get("num_entries"))
+          )
+        }
+    }
+  }
+
+  private[read] def resolveManifestDeltaPath(
+      basePath: String,
+      path: String
+  ): String = {
+    if (path == null || path.isEmpty) path
+    else if (path.startsWith("s3a://")) path
+    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else if (path.startsWith("_delta/"))
+      s"${basePath.stripSuffix("/")}/$path"
+    else if (path.startsWith("/"))
+      s"${basePath.stripSuffix("/")}/_delta/${path.stripPrefix("/")}"
+    else s"${basePath.stripSuffix("/")}/_delta/$path"
+  }
+
+  private def asString(v: Any): String = v match {
+    case u: Utf8   => u.toString
+    case s: String => s
+    case null      => null
+    case other =>
+      throw new IllegalStateException(
+        s"expected string, got ${other.getClass.getName}: $other"
+      )
+  }
+
+  private def asInt(v: Any): Int = v match {
+    case i: java.lang.Integer => i.intValue()
+    case l: java.lang.Long    => l.intValue()
+    case other =>
+      throw new IllegalStateException(
+        s"expected int, got ${other.getClass.getName}: $other"
+      )
+  }
+
+  private def asLong(v: Any): Long = v match {
+    case l: java.lang.Long    => l.longValue()
+    case i: java.lang.Integer => i.longValue()
+    case other =>
+      throw new IllegalStateException(
+        s"expected long, got ${other.getClass.getName}: $other"
+      )
+  }
+}

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -65,6 +65,7 @@ import com.zilliz.spark.connector.read.{
   MilvusPartitionReaderFactory,
   MilvusSnapshotReader,
   MilvusStorageV3InputPartition,
+  MilvusStorageV3ManifestReader,
   SnapshotMetadata,
   StorageV2ManifestItem,
   V2SegmentInfo,
@@ -1268,6 +1269,21 @@ object MilvusScan extends Logging {
     out
   }
 
+  private[sources] def segmentIdForManifestItem(
+      item: StorageV2ManifestItem,
+      basePath: String
+  ): Long = {
+    if (item.segmentID != 0L) {
+      item.segmentID
+    } else {
+      val pathParts = basePath.split("/").filter(_.nonEmpty)
+      if (pathParts.nonEmpty) {
+        try pathParts.last.toLong
+        catch { case _: NumberFormatException => 0L }
+      } else 0L
+    }
+  }
+
   private[sources] def validateClientSnapshotMetadata(
       metadata: SnapshotMetadata,
       snapshotPath: String
@@ -1548,6 +1564,14 @@ class MilvusScan(
     val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
       metadata.collection.schema
     )
+    val v3DeletePlans =
+      loadV3DeletePlans(
+        storageV2ManifestList,
+        schemaBytes,
+        snapshotBucket,
+        hadoopConf,
+        errorContext = "client-created snapshot"
+      )
     val v2DeletePlans =
       loadV2DeletePlans(
         v2Segments,
@@ -1599,9 +1623,11 @@ class MilvusScan(
         .map(_.toString)
         .getOrElse("0"),
       schemaBytes = schemaBytes,
+      v3DeletePlans = v3DeletePlans,
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
-      inheritedDeletePlansByPartition = inheritedDeletePlansByPartition
+      inheritedDeletePlansByPartition = inheritedDeletePlansByPartition,
+      inlineInheritedDeletePlans = true
     )
   }
 
@@ -1853,10 +1879,79 @@ class MilvusScan(
     }
   }
 
-  private def buildSnapshotPartitions(
+  private def loadV3DeletePlans(
+      manifestList: Seq[StorageV2ManifestItem],
+      schemaBytes: Array[Byte],
+      snapshotBucket: Option[String],
+      hadoopConf: Configuration,
+      errorContext: String
+  ): Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
+    val applyDeletes = MilvusOption.readApplyDeletes(options)
+    if (!applyDeletes || manifestList.isEmpty) {
+      Map.empty
+    } else {
+      val pkField = CollectionSchema
+        .parseFrom(schemaBytes)
+        .fields
+        .find(_.isPrimaryKey)
+      if (pkField.isEmpty) {
+        return Map.empty
+      }
+
+      manifestList.flatMap { item =>
+        val (basePath, readVersion) =
+          MilvusSnapshotReader.parseManifestContent(item.manifest) match {
+            case Right(content) => (content.basePath, content.ver.toLong)
+            case Left(_)        => (item.manifest, -1L)
+          }
+        val segmentId = MilvusScan.segmentIdForManifestItem(item, basePath)
+        if (segmentId == 0L || readVersion <= 0L) {
+          None
+        } else {
+          val deltaLogs =
+            MilvusStorageV3ManifestReader.loadDeltaLogs(
+              basePath,
+              readVersion,
+              snapshotBucket.getOrElse(""),
+              hadoopConf
+            ) match {
+              case Right(logs) => logs
+              case Left(err) =>
+                throw new IllegalStateException(
+                  s"Failed to load StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
+                  err
+                )
+            }
+          if (deltaLogs.isEmpty) {
+            None
+          } else {
+            MilvusDeltaLogReader.loadDeletePlan(
+              deltaLogs,
+              pkField.get,
+              snapshotBucket.getOrElse(""),
+              hadoopConf
+            ) match {
+              case Right(plan) => Some(segmentId -> plan)
+              case Left(err) =>
+                throw new IllegalStateException(
+                  s"Failed to decode StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
+                  err
+                )
+            }
+          }
+        }
+      }.toMap
+    }
+  }
+
+  private[sources] def buildSnapshotPartitions(
       manifestList: Seq[StorageV2ManifestItem],
       defaultPartitionId: String,
       schemaBytes: Array[Byte],
+      v3DeletePlans: Map[
+        Long,
+        com.zilliz.spark.connector.read.MilvusDeletePlan
+      ] = Map.empty,
       v2Segments: Seq[V2SegmentInfo],
       v2DeletePlans: Map[
         Long,
@@ -1866,6 +1961,7 @@ class MilvusScan(
         Long,
         com.zilliz.spark.connector.read.MilvusDeletePlan
       ] = Map.empty,
+      inlineInheritedDeletePlans: Boolean = false,
       forceCanonicalBucket: Option[String] = None
   ): Array[InputPartition] = {
     val canonicalMilvusOption = forceCanonicalBucket
@@ -1887,13 +1983,7 @@ class MilvusScan(
         }
 
       val pathParts = basePath.split("/").filter(_.nonEmpty)
-      val segmentID =
-        if (item.segmentID != 0L) {
-          item.segmentID
-        } else if (pathParts.nonEmpty) {
-          try pathParts.last.toLong
-          catch { case _: NumberFormatException => 0L }
-        } else 0L
+      val segmentID = MilvusScan.segmentIdForManifestItem(item, basePath)
       val insertLogIdx = pathParts.lastIndexOf("insert_log")
       val partitionId =
         if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
@@ -1907,6 +1997,22 @@ class MilvusScan(
       logInfo(
         s"Creating partition with manifestPath=$basePath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
       )
+      val partitionIdLong =
+        try partitionId.toLong
+        catch { case _: NumberFormatException => Long.MinValue }
+      val inheritedDeletePlan =
+        if (partitionIdLong == Long.MinValue) {
+          com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+        } else {
+          MilvusDeltaLogReader.effectiveInheritedDeletePlan(
+            partitionIdLong,
+            inheritedDeletePlansByPartition
+          )
+        }
+      val ownDeletePlan = v3DeletePlans.getOrElse(
+        segmentID,
+        com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+      )
       MilvusStorageV3InputPartition(
         basePath,
         schemaBytes,
@@ -1917,7 +2023,12 @@ class MilvusScan(
         vectorSearchConfig.map(_.metricType),
         vectorSearchConfig.map(_.vectorColumn),
         segmentID,
-        readVersion
+        readVersion,
+        applyDeletes = MilvusOption.readApplyDeletes(options),
+        deletePlan = com.zilliz.spark.connector.read.MilvusDeletePlan.union(
+          inheritedDeletePlan,
+          ownDeletePlan
+        )
       ): InputPartition
     }
 
@@ -1930,6 +2041,24 @@ class MilvusScan(
     val packedV2Partitions = v2Segments
       .filter(_.columnGroups.nonEmpty)
       .map { seg =>
+        val ownDeletePlan = v2DeletePlans.getOrElse(
+          seg.segmentId,
+          com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+        )
+        val inheritedDeletePlan =
+          if (inlineInheritedDeletePlans) {
+            MilvusDeltaLogReader.effectiveInheritedDeletePlan(
+              seg.partitionId,
+              inheritedDeletePlansByPartition
+            )
+          } else {
+            com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+          }
+        val deletePlan =
+          com.zilliz.spark.connector.read.MilvusDeletePlan.union(
+            inheritedDeletePlan,
+            ownDeletePlan
+          )
         MilvusPackedV2InputPartition(
           segmentID = seg.segmentId,
           partitionID = seg.partitionId,
@@ -1938,14 +2067,14 @@ class MilvusScan(
           milvusOption = canonicalMilvusOption,
           neededColumnFieldIds = Seq.empty,
           applyDeletes = MilvusOption.readApplyDeletes(options),
-          deletePlan = v2DeletePlans.getOrElse(
-            seg.segmentId,
-            com.zilliz.spark.connector.read.MilvusDeletePlan.empty
-          ),
+          deletePlan = deletePlan,
           inheritedDeletePlanPartitionId =
-            if (inheritedDeletePlansByPartition.contains(seg.partitionId))
-              Some(seg.partitionId)
-            else None
+            if (inlineInheritedDeletePlans) None
+            else
+              MilvusDeltaLogReader.inheritedDeletePlanPartitionMarker(
+                seg.partitionId,
+                inheritedDeletePlansByPartition
+              )
         ): InputPartition
       }
 
@@ -2039,12 +2168,22 @@ class MilvusScan(
     val snapshotBucketForRelativePaths =
       MilvusScan.connectorS3BucketOption(options.asScala.toMap)
 
+    val snapshotHadoopConf = buildSnapshotHadoopConf("")
+    val v3DeletePlans =
+      loadV3DeletePlans(
+        manifestList,
+        schemaBytes,
+        snapshotBucket = snapshotBucketForRelativePaths,
+        hadoopConf = snapshotHadoopConf,
+        errorContext = "snapshot metadata"
+      )
+
     val v2DeletePlans =
       loadV2DeletePlans(
         v2Segments,
         schemaBytes,
         snapshotBucket = snapshotBucketForRelativePaths,
-        hadoopConf = buildSnapshotHadoopConf(""),
+        hadoopConf = snapshotHadoopConf,
         errorContext = "snapshot metadata"
       )
 
@@ -2073,7 +2212,7 @@ class MilvusScan(
           inheritedDeleteSegments,
           pkField,
           snapshotBucketForRelativePaths.getOrElse(""),
-          buildSnapshotHadoopConf("")
+          snapshotHadoopConf
         ) match {
           case Right(plans) => plans
           case Left(err) =>
@@ -2088,6 +2227,7 @@ class MilvusScan(
       manifestList = manifestList,
       defaultPartitionId = defaultPartitionId,
       schemaBytes = schemaBytes,
+      v3DeletePlans = v3DeletePlans,
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -68,6 +68,7 @@ import com.zilliz.spark.connector.read.{
   MilvusStorageV3ManifestReader,
   SnapshotMetadata,
   StorageV2ManifestItem,
+  V2DeltaLogFile,
   V2SegmentInfo,
   V2SegmentLoader
 }
@@ -740,6 +741,18 @@ object MilvusScan extends Logging {
     "software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider"
   private val SimpleAwsCredentialsProvider =
     "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+
+  private[sources] case class V3DeletePlanning(
+      deletePlans: Map[
+        Long,
+        com.zilliz.spark.connector.read.MilvusDeletePlan
+      ],
+      readVersions: Map[Long, Long]
+  )
+
+  private[sources] object V3DeletePlanning {
+    val empty: V3DeletePlanning = V3DeletePlanning(Map.empty, Map.empty)
+  }
 
   private def daemonThreadFactory(namePrefix: String): ThreadFactory =
     new ThreadFactory {
@@ -1564,8 +1577,8 @@ class MilvusScan(
     val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
       metadata.collection.schema
     )
-    val v3DeletePlans =
-      loadV3DeletePlans(
+    val v3DeletePlanning =
+      loadV3DeletePlanning(
         storageV2ManifestList,
         schemaBytes,
         snapshotBucket,
@@ -1623,7 +1636,8 @@ class MilvusScan(
         .map(_.toString)
         .getOrElse("0"),
       schemaBytes = schemaBytes,
-      v3DeletePlans = v3DeletePlans,
+      v3DeletePlans = v3DeletePlanning.deletePlans,
+      v3ReadVersions = v3DeletePlanning.readVersions,
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition,
@@ -1879,68 +1893,100 @@ class MilvusScan(
     }
   }
 
-  private def loadV3DeletePlans(
+  private def loadV3DeletePlanning(
       manifestList: Seq[StorageV2ManifestItem],
       schemaBytes: Array[Byte],
       snapshotBucket: Option[String],
       hadoopConf: Configuration,
       errorContext: String
-  ): Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
+  ): MilvusScan.V3DeletePlanning = {
     val applyDeletes = MilvusOption.readApplyDeletes(options)
     if (!applyDeletes || manifestList.isEmpty) {
-      Map.empty
+      MilvusScan.V3DeletePlanning.empty
     } else {
       val pkField = CollectionSchema
         .parseFrom(schemaBytes)
         .fields
         .find(_.isPrimaryKey)
       if (pkField.isEmpty) {
-        return Map.empty
+        return MilvusScan.V3DeletePlanning.empty
       }
 
-      manifestList.flatMap { item =>
-        val (basePath, readVersion) =
+      val entries = manifestList.flatMap { item =>
+        val (basePath, requestedReadVersion) =
           MilvusSnapshotReader.parseManifestContent(item.manifest) match {
             case Right(content) => (content.basePath, content.ver.toLong)
             case Left(_)        => (item.manifest, -1L)
           }
         val segmentId = MilvusScan.segmentIdForManifestItem(item, basePath)
-        if (segmentId == 0L || readVersion <= 0L) {
+        if (segmentId == 0L) {
           None
         } else {
-          val deltaLogs =
-            MilvusStorageV3ManifestReader.loadDeltaLogs(
-              basePath,
-              readVersion,
-              snapshotBucket.getOrElse(""),
-              hadoopConf
-            ) match {
-              case Right(logs) => logs
-              case Left(err) =>
-                throw new IllegalStateException(
-                  s"Failed to load StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
-                  err
-                )
+          val readVersion: Long =
+            if (requestedReadVersion > 0L) {
+              requestedReadVersion
+            } else {
+              MilvusStorageV3ManifestReader.latestManifestVersion(
+                basePath,
+                snapshotBucket.getOrElse(""),
+                hadoopConf
+              ) match {
+                case Right(version) => version
+                case Left(err) =>
+                  throw new IllegalStateException(
+                    s"Failed to resolve latest StorageV3 manifest version from $errorContext for segment $segmentId: ${err.getMessage}",
+                    err
+                  )
+              }
             }
-          if (deltaLogs.isEmpty) {
+          if (readVersion <= 0L) {
             None
           } else {
-            MilvusDeltaLogReader.loadDeletePlan(
-              deltaLogs,
-              pkField.get,
-              snapshotBucket.getOrElse(""),
-              hadoopConf
-            ) match {
-              case Right(plan) => Some(segmentId -> plan)
-              case Left(err) =>
-                throw new IllegalStateException(
-                  s"Failed to decode StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
-                  err
-                )
-            }
+            val deltaLogs: Seq[V2DeltaLogFile] =
+              MilvusStorageV3ManifestReader.loadDeltaLogs(
+                basePath,
+                readVersion,
+                snapshotBucket.getOrElse(""),
+                hadoopConf
+              ) match {
+                case Right(logs) => logs
+                case Left(err) =>
+                  throw new IllegalStateException(
+                    s"Failed to load StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
+                    err
+                  )
+              }
+            val deletePlan
+                : Option[com.zilliz.spark.connector.read.MilvusDeletePlan] =
+              if (deltaLogs.isEmpty) {
+                None
+              } else {
+                MilvusDeltaLogReader.loadDeletePlan(
+                  deltaLogs,
+                  pkField.get,
+                  snapshotBucket.getOrElse(""),
+                  hadoopConf
+                ) match {
+                  case Right(plan) => Some(plan)
+                  case Left(err) =>
+                    throw new IllegalStateException(
+                      s"Failed to decode StorageV3 manifest delete logs from $errorContext for segment $segmentId: ${err.getMessage}",
+                      err
+                    )
+                }
+              }
+            Some((segmentId, readVersion, deletePlan))
           }
         }
-      }.toMap
+      }
+      MilvusScan.V3DeletePlanning(
+        deletePlans = entries.flatMap { case (segmentId, _, deletePlan) =>
+          deletePlan.map(segmentId -> _)
+        }.toMap,
+        readVersions = entries.map { case (segmentId, readVersion, _) =>
+          segmentId -> readVersion
+        }.toMap
+      )
     }
   }
 
@@ -1952,6 +1998,7 @@ class MilvusScan(
         Long,
         com.zilliz.spark.connector.read.MilvusDeletePlan
       ] = Map.empty,
+      v3ReadVersions: Map[Long, Long] = Map.empty,
       v2Segments: Seq[V2SegmentInfo],
       v2DeletePlans: Map[
         Long,
@@ -1976,7 +2023,7 @@ class MilvusScan(
       .getOrElse(milvusOption)
 
     val v3Partitions = manifestList.map { item =>
-      val (basePath, readVersion) =
+      val (basePath, parsedReadVersion) =
         MilvusSnapshotReader.parseManifestContent(item.manifest) match {
           case Right(content) => (content.basePath, content.ver.toLong)
           case Left(_)        => (item.manifest, -1L)
@@ -1984,6 +2031,7 @@ class MilvusScan(
 
       val pathParts = basePath.split("/").filter(_.nonEmpty)
       val segmentID = MilvusScan.segmentIdForManifestItem(item, basePath)
+      val readVersion = v3ReadVersions.getOrElse(segmentID, parsedReadVersion)
       val insertLogIdx = pathParts.lastIndexOf("insert_log")
       val partitionId =
         if (insertLogIdx >= 0 && pathParts.length > insertLogIdx + 3) {
@@ -2169,8 +2217,8 @@ class MilvusScan(
       MilvusScan.connectorS3BucketOption(options.asScala.toMap)
 
     val snapshotHadoopConf = buildSnapshotHadoopConf("")
-    val v3DeletePlans =
-      loadV3DeletePlans(
+    val v3DeletePlanning =
+      loadV3DeletePlanning(
         manifestList,
         schemaBytes,
         snapshotBucket = snapshotBucketForRelativePaths,
@@ -2227,7 +2275,8 @@ class MilvusScan(
       manifestList = manifestList,
       defaultPartitionId = defaultPartitionId,
       schemaBytes = schemaBytes,
-      v3DeletePlans = v3DeletePlans,
+      v3DeletePlans = v3DeletePlanning.deletePlans,
+      v3ReadVersions = v3DeletePlanning.readVersions,
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition

--- a/src/test/scala/read/MilvusDeltaLogReaderTest.scala
+++ b/src/test/scala/read/MilvusDeltaLogReaderTest.scala
@@ -55,4 +55,29 @@ class MilvusDeltaLogReaderTest extends AnyFunSuite with Matchers {
     merged.containsLongPk(7L, 250L) shouldBe false
     merged.containsLongPk(8L, 140L) shouldBe true
   }
+
+  test("collection-wide L0 delete plan applies to every partition") {
+    val inheritedPlansByPartition = Map(
+      -1L -> MilvusDeletePlan.fromLongPks(Map(7L -> 100L)),
+      10L -> MilvusDeletePlan.fromLongPks(Map(9L -> 200L))
+    )
+
+    val partition10Plan = MilvusDeltaLogReader.effectiveInheritedDeletePlan(
+      10L,
+      inheritedPlansByPartition
+    )
+    val partition11Plan = MilvusDeltaLogReader.effectiveInheritedDeletePlan(
+      11L,
+      inheritedPlansByPartition
+    )
+
+    partition10Plan.containsLongPk(7L, 50L) shouldBe true
+    partition10Plan.containsLongPk(9L, 150L) shouldBe true
+    partition11Plan.containsLongPk(7L, 50L) shouldBe true
+    partition11Plan.containsLongPk(9L, 150L) shouldBe false
+    MilvusDeltaLogReader.inheritedDeletePlanPartitionMarker(
+      11L,
+      inheritedPlansByPartition
+    ) shouldBe Some(11L)
+  }
 }

--- a/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
+++ b/src/test/scala/read/MilvusLoonPartitionReaderTest.scala
@@ -13,6 +13,10 @@ import com.zilliz.spark.connector.FloatConverter
 import io.milvus.grpc.schema.{CollectionSchema, DataType, FieldSchema}
 
 class MilvusLoonPartitionReaderTest extends AnyFunSuite {
+  test("delete filtering uses field-id column name for timestamp") {
+    assert(MilvusLoonPartitionReader.TimestampColumnName == "1")
+  }
+
   test("buildFieldNameToId exposes non-conflicting system aliases") {
     val schema = CollectionSchema(
       fields = Seq(

--- a/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
@@ -1,10 +1,12 @@
 package com.zilliz.spark.connector.read
 
 import java.io.ByteArrayOutputStream
+import java.nio.file.Files
 
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
 import org.apache.avro.Schema
+import org.apache.hadoop.conf.Configuration
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -70,6 +72,21 @@ class MilvusStorageV3ManifestReaderTest extends AnyFunSuite with Matchers {
       "files/insert_log/10/20/30",
       "s3://bucket/files/insert_log/10/20/30/_delta/9001"
     ) shouldBe "s3a://bucket/files/insert_log/10/20/30/_delta/9001"
+  }
+
+  test("latestManifestVersion returns greatest StorageV3 manifest version") {
+    val basePath = Files.createTempDirectory("milvus-v3-manifest-test")
+    val metadataPath = Files.createDirectory(basePath.resolve("_metadata"))
+    Files.createFile(metadataPath.resolve("manifest-2.avro"))
+    Files.createFile(metadataPath.resolve("manifest-11.avro"))
+    Files.createFile(metadataPath.resolve("manifest-not-a-version.avro"))
+    Files.createFile(metadataPath.resolve("other"))
+
+    MilvusStorageV3ManifestReader.latestManifestVersion(
+      basePath.toString,
+      "",
+      new Configuration()
+    ) shouldBe Right(11L)
   }
 
   private def writeManifest(

--- a/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
@@ -1,0 +1,104 @@
+package com.zilliz.spark.connector.read
+
+import java.io.ByteArrayOutputStream
+
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
+import org.apache.avro.Schema
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class MilvusStorageV3ManifestReaderTest extends AnyFunSuite with Matchers {
+  private val schema = new Schema.Parser().parse("""
+      {
+        "type": "record",
+        "name": "Manifest",
+        "namespace": "milvus_storage",
+        "fields": [
+          {
+            "name": "delta_logs",
+            "type": {
+              "type": "array",
+              "items": {
+                "type": "record",
+                "name": "DeltaLog",
+                "fields": [
+                  {"name": "path", "type": "string"},
+                  {"name": "type", "type": "int"},
+                  {"name": "num_entries", "type": "long"}
+                ]
+              }
+            }
+          }
+        ]
+      }
+    """)
+
+  test("parseDeltaLogs reads primary-key StorageV3 manifest deltalogs") {
+    val bytes = writeManifest(
+      Seq(
+        ("9001", 0, 3L),
+        ("ignored-positional", 1, 5L),
+        ("ignored-empty", 0, 0L)
+      )
+    )
+
+    val result = MilvusStorageV3ManifestReader.parseDeltaLogs(
+      bytes,
+      "files/insert_log/10/20/30"
+    )
+
+    result shouldBe a[Right[_, _]]
+    result.toOption.get shouldBe Seq(
+      V2DeltaLogFile(
+        0L,
+        "files/insert_log/10/20/30/_delta/9001",
+        3L
+      )
+    )
+  }
+
+  test("manifestFilePath builds the StorageV3 metadata avro path") {
+    MilvusStorageV3ManifestReader.manifestFilePath(
+      "files/insert_log/10/20/30",
+      7L
+    ) shouldBe "files/insert_log/10/20/30/_metadata/manifest-7.avro"
+  }
+
+  test("resolveManifestDeltaPath preserves absolute deltalog paths") {
+    MilvusStorageV3ManifestReader.resolveManifestDeltaPath(
+      "files/insert_log/10/20/30",
+      "s3://bucket/files/insert_log/10/20/30/_delta/9001"
+    ) shouldBe "s3a://bucket/files/insert_log/10/20/30/_delta/9001"
+  }
+
+  private def writeManifest(
+      deltaLogs: Seq[(String, Int, Long)]
+  ): Array[Byte] = {
+    val deltaSchema = schema
+      .getField("delta_logs")
+      .schema()
+      .getElementType
+    val rec = new GenericData.Record(schema)
+    val arr = new GenericData.Array[GenericRecord](
+      deltaLogs.size,
+      schema.getField("delta_logs").schema()
+    )
+    deltaLogs.foreach { case (path, logType, entries) =>
+      val log = new GenericData.Record(deltaSchema)
+      log.put("path", path)
+      log.put("type", logType)
+      log.put("num_entries", entries)
+      arr.add(log)
+    }
+    rec.put("delta_logs", arr)
+
+    val out = new ByteArrayOutputStream()
+    val writer =
+      new DataFileWriter[GenericRecord](new GenericDatumWriter[GenericRecord]())
+    writer.create(schema, out)
+    writer.append(rec)
+    writer.close()
+    out.toByteArray
+  }
+}

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1170,6 +1170,28 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(partition.applyDeletes)
   }
 
+  test(
+    "snapshot planner pins StorageV3 raw manifest path to resolved version"
+  ) {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq(
+        StorageV2ManifestItem(
+          30L,
+          "files/insert_log/10/20/30"
+        )
+      ),
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v3ReadVersions = Map(30L -> 11L),
+      v2Segments = Seq.empty,
+      v2DeletePlans = Map.empty
+    )
+
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.readVersion == 11L)
+  }
+
   test("snapshot planner applies inherited L0 delete plans to StorageV3") {
     val scan = scanWithOptions(new ju.HashMap[String, String]())
     val v3Plan = MilvusDeletePlan.fromLongPks(Map(7L -> 100L))

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1147,6 +1147,65 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(partition.readVersion == 7L)
   }
 
+  test("snapshot planner attaches StorageV3 manifest delete plans") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val deletePlan = MilvusDeletePlan.fromLongPks(Map(7L -> 100L))
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+        )
+      ),
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v3DeletePlans = Map(30L -> deletePlan),
+      v2Segments = Seq.empty,
+      v2DeletePlans = Map.empty
+    )
+
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.segmentID == 30L)
+    assert(partition.deletePlan == deletePlan)
+    assert(partition.applyDeletes)
+  }
+
+  test("snapshot planner applies inherited L0 delete plans to StorageV3") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val v3Plan = MilvusDeletePlan.fromLongPks(Map(7L -> 100L))
+    val inheritedPlans = Map(
+      -1L -> MilvusDeletePlan.fromLongPks(Map(8L -> 120L)),
+      20L -> MilvusDeletePlan.fromLongPks(Map(9L -> 140L))
+    )
+
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq(
+        StorageV2ManifestItem(
+          30L,
+          "{\"ver\":7,\"base_path\":\"files/insert_log/10/20/30\"}"
+        ),
+        StorageV2ManifestItem(
+          31L,
+          "{\"ver\":7,\"base_path\":\"files/insert_log/10/21/31\"}"
+        )
+      ),
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v3DeletePlans = Map(30L -> v3Plan),
+      v2Segments = Seq.empty,
+      v2DeletePlans = Map.empty,
+      inheritedDeletePlansByPartition = inheritedPlans
+    )
+
+    val first = partitions(0).asInstanceOf[MilvusStorageV3InputPartition]
+    val second = partitions(1).asInstanceOf[MilvusStorageV3InputPartition]
+    assert(first.deletePlan.containsLongPk(7L, 50L))
+    assert(first.deletePlan.containsLongPk(8L, 100L))
+    assert(first.deletePlan.containsLongPk(9L, 130L))
+    assert(second.deletePlan.containsLongPk(8L, 100L))
+    assert(!second.deletePlan.containsLongPk(9L, 130L))
+  }
+
   test("snapshot planner accepts V2-only snapshot segments") {
     val v2Json = MilvusSnapshotReader.serializeV2Segments(
       Seq(
@@ -1202,6 +1261,118 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(partition.deletePlan == segmentPlan)
     assert(partition.inheritedDeletePlanPartitionId.contains(20L))
     assert(inherited.containsLongPk(7L, 50L))
+  }
+
+  test(
+    "snapshot partition planning marks collection-wide L0 deletes for every partition"
+  ) {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val inheritedPlans = Map(
+      -1L -> MilvusDeletePlan.fromLongPks(Map(7L -> 100L)),
+      20L -> MilvusDeletePlan.fromLongPks(Map(8L -> 120L))
+    )
+    val ownPlan = MilvusDeletePlan.fromLongPks(Map(9L -> 140L))
+
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq.empty,
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v2Segments = Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        ),
+        V2SegmentInfo(
+          segmentId = 31L,
+          partitionId = 21L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/21/31/100/1.parquet"),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        )
+      ),
+      v2DeletePlans = Map(30L -> ownPlan),
+      inheritedDeletePlansByPartition = inheritedPlans
+    )
+
+    val first = partitions(0).asInstanceOf[MilvusPackedV2InputPartition]
+    val second = partitions(1).asInstanceOf[MilvusPackedV2InputPartition]
+    assert(first.deletePlan == ownPlan)
+    assert(first.inheritedDeletePlanPartitionId.contains(20L))
+    assert(second.deletePlan == MilvusDeletePlan.empty)
+    assert(second.inheritedDeletePlanPartitionId.contains(21L))
+  }
+
+  test(
+    "client snapshot partition planning inlines inherited L0 deletes into V2 partition plans"
+  ) {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val inheritedPlans = Map(
+      -1L -> MilvusDeletePlan.fromLongPks(Map(7L -> 100L)),
+      20L -> MilvusDeletePlan.fromLongPks(Map(8L -> 120L))
+    )
+    val ownPlan = MilvusDeletePlan.fromLongPks(Map(9L -> 140L))
+
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq.empty,
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v2Segments = Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        ),
+        V2SegmentInfo(
+          segmentId = 31L,
+          partitionId = 21L,
+          numOfRows = 1L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/21/31/100/1.parquet"),
+              fileRowCounts = Seq(1L)
+            )
+          )
+        )
+      ),
+      v2DeletePlans = Map(30L -> ownPlan),
+      inheritedDeletePlansByPartition = inheritedPlans,
+      inlineInheritedDeletePlans = true
+    )
+
+    val first = partitions(0).asInstanceOf[MilvusPackedV2InputPartition]
+    val second = partitions(1).asInstanceOf[MilvusPackedV2InputPartition]
+    assert(first.inheritedDeletePlanPartitionId.isEmpty)
+    assert(first.deletePlan.containsLongPk(7L, 50L))
+    assert(first.deletePlan.containsLongPk(8L, 100L))
+    assert(first.deletePlan.containsLongPk(9L, 130L))
+    assert(second.inheritedDeletePlanPartitionId.isEmpty)
+    assert(second.deletePlan.containsLongPk(7L, 50L))
+    assert(!second.deletePlan.containsLongPk(8L, 100L))
   }
 }
 


### PR DESCRIPTION
Parse StorageV3 manifest primary-key deltalogs and attach the resulting delete plans to V3 snapshot partitions. Merge inherited L0 delete plans into V3 reads, including collection-wide partition -1 deletes, and apply delete filtering in the Loon reader for normal scans and vector search.