### PR TITLE
feat: [backfill] support vector column backfill

### DIFF
--- a/src/main/scala/MilvusUtil.scala
+++ b/src/main/scala/MilvusUtil.scala
@@ -542,33 +542,83 @@ object IntConverter {
 }
 
 object SparseFloatVectorConverter {
+  private val MaxIndexExclusive = 0xffffffffL
+
   def encodeSparseFloatVector(sparse: Map[Long, Float]): Array[Byte] = {
-    val sortedEntries = sparse.toSeq.sortBy(_._1)
+    encodeSparseFloatVectorEntries(sparse.toSeq)
+  }
+
+  private[connector] def encodeSparseFloatVectorEntries(
+      entries: Seq[(Long, Float)]
+  ): Array[Byte] = {
+    val sortedEntries = entries.sortBy(_._1)
 
     val buf = ByteBuffer.allocate((4 + 4) * sortedEntries.size)
     buf.order(ByteOrder.LITTLE_ENDIAN)
 
+    var previousIndex: Option[Long] = None
     for ((k, v) <- sortedEntries) {
-      if (k < 0 || k >= Math.pow(2.0, 32) - 1) {
+      if (k < 0 || k >= MaxIndexExclusive) {
         throw new DataParseException(
-          s"Sparse vector index ($k) must be positive and less than 2^32-1"
+          s"Sparse vector index ($k) must be non-negative and less than 2^32-1"
+        )
+      }
+      if (previousIndex.contains(k)) {
+        throw new DataParseException(
+          s"Sparse vector index ($k) is duplicated"
         )
       }
 
-      val lBuf = ByteBuffer.allocate(8)
-      lBuf.order(ByteOrder.LITTLE_ENDIAN)
-      lBuf.putLong(k)
-      buf.put(lBuf.array(), 0, 4)
+      buf.putInt(k.toInt)
 
-      if (v.isNaN || v.isInfinite) {
+      if (v.isNaN || v.isInfinite || v < 0.0f) {
         throw new DataParseException(
-          s"Sparse vector value ($v) cannot be NaN or Infinite"
+          s"Sparse vector value ($v) must be finite and non-negative"
         )
       }
 
       buf.putFloat(v)
+      previousIndex = Some(k)
     }
 
     buf.array()
+  }
+
+  private[connector] def decodeSparseFloatVector(
+      bytes: Array[Byte]
+  ): Seq[(Long, Float)] = {
+    if (bytes.length % 8 != 0) {
+      throw new DataParseException(
+        s"Sparse vector byte length must be a multiple of 8, got ${bytes.length}"
+      )
+    }
+
+    val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    val entries = Seq.newBuilder[(Long, Float)]
+    var previousIndex: Option[Long] = None
+    while (buffer.hasRemaining) {
+      val index = buffer.getInt() & 0xffffffffL
+      val value = buffer.getFloat()
+      if (index >= MaxIndexExclusive) {
+        throw new DataParseException(
+          s"Sparse vector index ($index) must be less than 2^32-1"
+        )
+      }
+      previousIndex.foreach { previous =>
+        if (index <= previous) {
+          throw new DataParseException(
+            s"Sparse vector indices must be strictly increasing, got $index after $previous"
+          )
+        }
+      }
+      if (value.isNaN || value.isInfinite || value < 0.0f) {
+        throw new DataParseException(
+          s"Sparse vector value ($value) must be finite and non-negative"
+        )
+      }
+      entries += index -> value
+      previousIndex = Some(index)
+    }
+    entries.result()
   }
 }

--- a/src/main/scala/MilvusUtil.scala
+++ b/src/main/scala/MilvusUtil.scala
@@ -353,34 +353,47 @@ object FloatConverter {
       )
     }
 
-    // IEEE 754 float32 format: 1 sign bit, 8 exponent bits, 23 fraction bits
+    // Match Milvus's float16.Fromfloat32 conversion: IEEE-754
+    // round-to-nearest-even, including subnormal values. Truncating the
+    // mantissa here makes normal ingestion produce different bytes from
+    // Milvus import/backfill for values such as 0.3f and 0.7f.
     val bits = java.lang.Float.floatToRawIntBits(value)
-    val sign = (bits >>> 31) & 0x1
-    val exp = (bits >>> 23) & 0xff
-    val frac = bits & 0x7fffff
+    val sign = (bits >>> 16) & 0x8000
+    val exponent = (bits >>> 23) & 0xff
+    val mantissa = bits & 0x7fffff
+    val halfExponent = exponent - 127 + 15
 
-    // IEEE 754 float16 format: 1 sign bit, 5 exponent bits, 10 fraction bits
-    val f16Sign = sign
-    val f16Exp = if (exp == 0) {
-      0 // Zero/Subnormal
-    } else if (exp == 0xff) {
-      0x1f // Infinity/NaN
+    val f16Bits = if (halfExponent <= 0) {
+      if (halfExponent < -10) {
+        sign
+      } else {
+        val normalizedMantissa = mantissa | 0x800000
+        val shift = 14 - halfExponent
+        var halfMantissa = normalizedMantissa >>> shift
+        val remainderMask = (1 << shift) - 1
+        val remainder = normalizedMantissa & remainderMask
+        val halfway = 1 << (shift - 1)
+        if (
+          remainder > halfway ||
+          (remainder == halfway && (halfMantissa & 1) != 0)
+        ) {
+          halfMantissa += 1
+        }
+        sign | halfMantissa
+      }
     } else {
-      val newExp = exp - 127 + 15
-      if (newExp < 0) 0
-      else if (newExp > 0x1f) 0x1f
-      else newExp
+      var half = sign | (halfExponent << 10) | (mantissa >>> 13)
+      val remainder = mantissa & 0x1fff
+      if (remainder > 0x1000 || (remainder == 0x1000 && (half & 1) != 0)) {
+        half += 1
+      }
+      if (((half >>> 10) & 0x1f) == 0x1f) {
+        throw new DataParseException(
+          s"Value $value rounds out of float16 range"
+        )
+      }
+      half
     }
-    val f16Frac = frac >>> 13
-
-    // Combine components into a half-precision (float16) value
-    val f16Bits = (f16Sign << 15) | (f16Exp << 10) | f16Frac
-
-    // Create byte array in big-endian format (high byte first)
-    // val bytes = new Array[Byte](2)
-    // bytes(0) = ((f16Bits >>> 8) & 0xff).toByte
-    // bytes(1) = (f16Bits & 0xff).toByte
-    // bytes.toSeq
 
     // Create byte array in little-endian format (low byte first)
     val bytes = new Array[Byte](2)

--- a/src/main/scala/MilvusUtil.scala
+++ b/src/main/scala/MilvusUtil.scala
@@ -333,11 +333,8 @@ object MilvusFieldData {
 }
 
 object FloatConverter {
-  private def isWithinFloat16Range(value: Float): Boolean = {
-    val absValue = Math.abs(value)
-    // float16 range: ±65504
-    absValue <= 65504f && !value.isNaN && !value.isInfinite
-  }
+  private def isFiniteFloat16Input(value: Float): Boolean =
+    !value.isNaN && !value.isInfinite
 
   private def isWithinBFloat16Range(value: Float): Boolean = {
     // bfloat16 has 8 exponent bits, same as float32
@@ -347,9 +344,9 @@ object FloatConverter {
   }
 
   def toFloat16Bytes(value: Float): Seq[Byte] = {
-    if (!isWithinFloat16Range(value)) {
+    if (!isFiniteFloat16Input(value)) {
       throw new DataParseException(
-        s"Value $value is out of float16 range"
+        s"Value $value is not a finite float16 input"
       )
     }
 
@@ -362,6 +359,12 @@ object FloatConverter {
     val exponent = (bits >>> 23) & 0xff
     val mantissa = bits & 0x7fffff
     val halfExponent = exponent - 127 + 15
+
+    if (halfExponent >= 31) {
+      throw new DataParseException(
+        s"Value $value is out of float16 range"
+      )
+    }
 
     val f16Bits = if (halfExponent <= 0) {
       if (halfExponent < -10) {

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -174,7 +174,7 @@ object MilvusBackfill {
       // Reproject via the column mapping (or legacy implicit mapping) so that
       // downstream code can assume the DataFrame's column names match the
       // Milvus schema exactly — in particular, the pk column is named pkName.
-      val backfillDF = applyColumnMapping(
+      val mappedBackfillDF = applyColumnMapping(
         rawBackfillDF,
         pkName,
         config.columnMapping
@@ -183,14 +183,8 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
-      // Cache so the upcoming count / distinct-PK aggregation doesn't force
-      // a second parquet scan when performJoin consumes the DF later. Held
-      // until after processSegments (see finally block for unpersist).
-      backfillDF.cache()
-      cachedBackfillDF = backfillDF
-
       // Extract new field names (all post-mapping columns except the PK).
-      val newFieldNames = backfillDF.schema.fields
+      val newFieldNames = mappedBackfillDF.schema.fields
         .map(_.name)
         .filterNot(_ == pkName)
         .toSeq
@@ -205,35 +199,6 @@ object MilvusBackfill {
             s"Backfill parquet contains a column named '$MatchFlagCol', " +
               "which is reserved for internal use by the backfill join. " +
               "Rename the column (or use --column-mapping) and retry."
-          )
-        )
-      }
-
-      // One aggregation over the cached DF gives us both totals: the raw
-      // input row count (reported in the result / logs for debugging low
-      // match rates) and the distinct-PK count (used below to fail fast on
-      // duplicates — see rationale there).
-      val countsRow = backfillDF
-        .agg(count(lit(1)), countDistinct(col(pkName)))
-        .head()
-      val backfillRowCount = countsRow.getLong(0)
-      val distinctPkCount = countsRow.getLong(1)
-      logger.info(
-        s"Backfill data file rows: $backfillRowCount " +
-          s"(distinct ${pkName}: $distinctPkCount)"
-      )
-
-      // Duplicate PKs on the backfill side cause each source row with a
-      // matching PK to be emitted once per duplicate by the left join,
-      // inflating per-segment rowCount / sourceRowCount / matchedRowCount.
-      // Rather than silently report misleading metrics, fail fast so the
-      // user can dedupe upstream.
-      if (distinctPkCount != backfillRowCount) {
-        return Left(
-          SchemaValidationError(
-            s"Backfill parquet contains duplicate primary-key values " +
-              s"(rows=$backfillRowCount, distinct ${pkName}=$distinctPkCount). " +
-              "Deduplicate the input (e.g. dropDuplicates on the PK) and retry."
           )
         )
       }
@@ -264,6 +229,78 @@ object MilvusBackfill {
       }
       val newFieldNameToId = newFieldNames.map(n => n -> fieldNameToId(n)).toMap
 
+      val snapshotMetadata = snapshotMetadataOpt.getOrElse {
+        return Left(
+          SchemaValidationError(
+            "ADDFIELD backfill requires collection schema from a snapshot"
+          )
+        )
+      }
+      val targetFieldsByName = newFieldNames.map { name =>
+        val field = snapshotMetadata.collection.schema.fields
+          .find(_.name == name)
+          .getOrElse(
+            return Left(
+              SchemaValidationError(
+                s"Field '$name' not found in snapshot collection schema"
+              )
+            )
+          )
+        name -> field
+      }.toMap
+
+      // User parquet uses normal ingestion-friendly vector shapes (numeric
+      // arrays, byte arrays, sparse maps/structs/JSON). Normalize vector
+      // fields to Milvus's physical per-row bytes before caching or joining so
+      // Spark never widens or rewrites half/int8/sparse representations.
+      val backfillDF = VectorBackfillSupport.normalizeVectorColumns(
+        mappedBackfillDF,
+        targetFieldsByName
+      ) match {
+        case Left(error) => return Left(error)
+        case Right(df)   => df
+      }
+
+      // Cache so the upcoming count / distinct-PK aggregation doesn't force
+      // a second parquet scan when performJoin consumes the DF later. The
+      // count also eagerly validates every normalized vector row.
+      backfillDF.cache()
+      cachedBackfillDF = backfillDF
+
+      // One aggregation over the cached DF gives us both totals: the raw
+      // input row count (reported in the result / logs for debugging low
+      // match rates) and the distinct-PK count (used below to fail fast on
+      // duplicates — see rationale there).
+      val countsRow = backfillDF
+        .agg(count(lit(1)), countDistinct(col(pkName)))
+        .head()
+      val backfillRowCount = countsRow.getLong(0)
+      val distinctPkCount = countsRow.getLong(1)
+      logger.info(
+        s"Backfill data file rows: $backfillRowCount " +
+          s"(distinct ${pkName}: $distinctPkCount)"
+      )
+
+      // Duplicate PKs on the backfill side cause each source row with a
+      // matching PK to be emitted once per duplicate by the left join,
+      // inflating per-segment rowCount / sourceRowCount / matchedRowCount.
+      // Rather than silently report misleading metrics, fail fast so the
+      // user can dedupe upstream.
+      if (distinctPkCount != backfillRowCount) {
+        return Left(
+          SchemaValidationError(
+            s"Backfill parquet contains duplicate primary-key values " +
+              s"(rows=$backfillRowCount, distinct ${pkName}=$distinctPkCount). " +
+              "Deduplicate the input (e.g. dropDuplicates on the PK) and retry."
+          )
+        )
+      }
+
+      val targetVectorFields = targetFieldsByName.collect {
+        case (name, field) if VectorBackfillSupport.isVectorField(field) =>
+          name -> VectorBackfillSupport.canonicalStructField(field)
+      }
+
       // In coalesce / overwrite modes, also read each target field from source
       // so the merge step (coalesce(src,bf) or when(matched, bf).otherwise(src))
       // can compare source and parquet values per row. Requires a snapshot —
@@ -272,26 +309,13 @@ object MilvusBackfill {
       val extraReadFields
           : Seq[(String, Long, org.apache.spark.sql.types.StructField)] =
         if (readsSourceFields) {
-          val metadata = snapshotMetadataOpt.getOrElse {
-            return Left(
-              SchemaValidationError(
-                s"--mode=${config.mode} requires a snapshot path so source " +
-                  "field values can be read"
-              )
-            )
-          }
           newFieldNames.map { n =>
             val fid = newFieldNameToId(n)
-            val field = metadata.collection.schema.fields
-              .find(_.getFieldIDAsLong == fid)
-              .getOrElse(
-                return Left(
-                  SchemaValidationError(
-                    s"Field '$n' (id=$fid) not found in snapshot schema"
-                  )
-                )
-              )
-            val structField = MilvusSnapshotReader.fieldToStructField(field)
+            val field = targetFieldsByName(n)
+            val structField = targetVectorFields.getOrElse(
+              n,
+              MilvusSnapshotReader.fieldToStructField(field)
+            )
             (
               n,
               fid,
@@ -369,7 +393,8 @@ object MilvusBackfill {
         v2SegmentIdSet,
         config,
         newFieldNames,
-        newFieldNameToId
+        newFieldNameToId,
+        targetVectorFields
       ) match {
         case Left(error)    => return Left(error)
         case Right(results) => results
@@ -953,7 +978,11 @@ object MilvusBackfill {
       v2SegmentIdSet: Set[Long],
       config: BackfillConfig,
       newFieldNames: Seq[String],
-      fieldNameToId: Map[String, Long] = Map.empty
+      fieldNameToId: Map[String, Long] = Map.empty,
+      targetFieldOverrides: Map[
+        String,
+        org.apache.spark.sql.types.StructField
+      ] = Map.empty
   ): Either[BackfillError, Map[Long, SegmentBackfillResult]] = {
 
     try {
@@ -981,7 +1010,10 @@ object MilvusBackfill {
       // or the match flag)
       val targetSchema = org.apache.spark.sql.types.StructType(
         newFieldNames.map(fieldName =>
-          preparedDF.schema.fields.find(_.name == fieldName).get
+          targetFieldOverrides.getOrElse(
+            fieldName,
+            preparedDF.schema.fields.find(_.name == fieldName).get
+          )
         )
       )
 

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -83,6 +83,24 @@ spark-submit \
 | `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |
 | `--output-result` | *(none)*    | Path to write the result JSON.                                               |
 
+## Vector columns
+
+Backfill accepts the same practical shapes commonly used by Milvus import
+clients, plus already-encoded Milvus bytes:
+
+| Milvus type | Accepted Parquet/Spark values |
+|-------------|-------------------------------|
+| `FloatVector` | Numeric array of length `dim`; JSON array string; or little-endian internal binary (`dim * 4` bytes). |
+| `BinaryVector` | Packed integral-byte array or binary of length `dim / 8`; JSON byte-array string. |
+| `Float16Vector`, `BFloat16Vector` | Float/double array of length `dim`; encoded byte/short array or binary of length `dim * 2`; JSON numeric-array string. |
+| `Int8Vector` | Integral array of length `dim` with values in `[-128, 127]`; JSON integral-array string; or internal binary. |
+| `SparseFloatVector` | Map of index to non-negative weight; `{indices, values}` struct; JSON object string; or Milvus sparse binary. |
+
+Before the join, vector values are validated and normalized to Milvus's
+per-row byte layout. Non-nullable dense vectors are written as Arrow
+`FixedSizeBinary`; nullable dense vectors and sparse vectors are written as
+Arrow `Binary`, matching Milvus storage metadata and endianness.
+
 ## Merge modes (`--mode`)
 
 Distinct from the read-mode choice above (snapshot vs client), `--mode`

--- a/src/main/scala/operations/backfill/VectorBackfillSupport.scala
+++ b/src/main/scala/operations/backfill/VectorBackfillSupport.scala
@@ -1,0 +1,866 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import java.nio.{ByteBuffer, ByteOrder}
+import scala.collection.JavaConverters._
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.functions.{col, to_json, udf}
+import org.apache.spark.sql.types._
+
+import com.zilliz.spark.connector.read.Field
+import com.zilliz.spark.connector.serde.ArrowConverter
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
+
+/** Normalizes user-facing vector values to the byte layout Milvus stores in
+  * Arrow/parquet column groups.
+  *
+  * Dense vectors are represented as one little-endian byte array per row:
+  *
+  *   - FloatVector: dim * 4 bytes
+  *   - BinaryVector: dim / 8 bytes
+  *   - Float16Vector / BFloat16Vector: dim * 2 bytes
+  *   - Int8Vector: dim bytes
+  *
+  * SparseFloatVector is represented as a variable-width byte array containing
+  * sorted `(uint32 index, float32 value)` pairs (8 bytes per non-zero entry).
+  * The writer later chooses FixedSizeBinary for non-nullable dense vectors and
+  * Binary for nullable dense vectors / sparse vectors, matching Milvus's
+  * storage schema.
+  */
+private[backfill] object VectorBackfillSupport {
+
+  private val DenseVectorTypes: Set[MilvusDataType] = Set(
+    MilvusDataType.FloatVector,
+    MilvusDataType.BinaryVector,
+    MilvusDataType.Float16Vector,
+    MilvusDataType.BFloat16Vector,
+    MilvusDataType.Int8Vector
+  )
+
+  private val VectorTypes: Set[MilvusDataType] =
+    DenseVectorTypes + MilvusDataType.SparseFloatVector
+
+  private val mapper = new ObjectMapper()
+
+  def isVectorField(field: Field): Boolean =
+    VectorTypes.contains(MilvusDataType.fromValue(field.dataType))
+
+  /** Spark schema used only inside backfill. BinaryType deliberately carries
+    * the already-normalized Milvus row bytes so joins never widen or
+    * reinterpret half/binary/int8/sparse vector values.
+    */
+  def canonicalStructField(field: Field): StructField = {
+    val milvusType = MilvusDataType.fromValue(field.dataType)
+    require(
+      VectorTypes.contains(milvusType),
+      s"Field '${field.name}' is not a supported vector type: $milvusType"
+    )
+
+    val metadata = new MetadataBuilder()
+      .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType.toLong)
+
+    if (DenseVectorTypes.contains(milvusType)) {
+      metadata.putLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey,
+        dimension(field).toLong
+      )
+    }
+
+    StructField(
+      field.name,
+      BinaryType,
+      nullable = field.nullable.getOrElse(false),
+      metadata = metadata.build()
+    )
+  }
+
+  /** Convert every vector column in `targetFieldsByName` to canonical Milvus
+    * bytes while preserving non-vector columns unchanged.
+    */
+  def normalizeVectorColumns(
+      df: DataFrame,
+      targetFieldsByName: Map[String, Field]
+  ): Either[BackfillError, DataFrame] = {
+    if (!targetFieldsByName.values.exists(isVectorField)) {
+      return Right(df)
+    }
+
+    val projected = df.schema.fields.map { inputField =>
+      targetFieldsByName.get(inputField.name) match {
+        case Some(targetField) if isVectorField(targetField) =>
+          normalizeVectorColumn(inputField, targetField).map { normalized =>
+            val canonical = canonicalStructField(targetField)
+            normalized.as(inputField.name, canonical.metadata)
+          }
+        case _ => Right(col(inputField.name))
+      }
+    }
+
+    projected.collectFirst { case Left(error) => error } match {
+      case Some(error) => Left(error)
+      case None =>
+        Right(df.select(projected.collect { case Right(column) => column }: _*))
+    }
+  }
+
+  private def normalizeVectorColumn(
+      inputField: StructField,
+      targetField: Field
+  ): Either[BackfillError, Column] = {
+    val fieldName = inputField.name
+    val milvusType = MilvusDataType.fromValue(targetField.dataType)
+    val dim =
+      if (DenseVectorTypes.contains(milvusType)) dimension(targetField) else 0
+
+    def internalBinary(column: Column): Column = {
+      val encoder = udf((bytes: Array[Byte]) =>
+        if (bytes == null) null
+        else validateInternalBytes(fieldName, milvusType, dim, bytes)
+      )
+      encoder(column)
+    }
+
+    def jsonArray(column: Column, encodedHalfBytes: Boolean): Column = {
+      val encoder = udf((json: String) =>
+        if (json == null) null
+        else
+          encodeDenseJsonArray(
+            fieldName,
+            milvusType,
+            dim,
+            json,
+            encodedHalfBytes
+          )
+      )
+      encoder(column)
+    }
+
+    def denseArray(
+        column: Column,
+        elementType: DataType,
+        encodedHalfBytes: Boolean
+    ): Column = {
+      elementType match {
+        case ByteType =>
+          val encoder = udf((values: Seq[Byte]) =>
+            encodeDenseIntegralNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values,
+              encodedHalfBytes
+            )
+          )
+          encoder(column)
+        case ShortType =>
+          val encoder = udf((values: Seq[Short]) =>
+            encodeDenseIntegralNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values,
+              encodedHalfBytes
+            )
+          )
+          encoder(column)
+        case IntegerType =>
+          val encoder = udf((values: Seq[Int]) =>
+            encodeDenseIntegralNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values,
+              encodedHalfBytes
+            )
+          )
+          encoder(column)
+        case LongType =>
+          val encoder = udf((values: Seq[Long]) =>
+            encodeDenseIntegralNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values,
+              encodedHalfBytes
+            )
+          )
+          encoder(column)
+        case FloatType =>
+          val encoder = udf((values: Seq[Float]) =>
+            encodeDenseFloatingNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values
+            )
+          )
+          encoder(column)
+        case DoubleType =>
+          val encoder = udf((values: Seq[Double]) =>
+            encodeDenseFloatingNumbers(
+              fieldName,
+              milvusType,
+              dim,
+              values
+            )
+          )
+          encoder(column)
+        case _: DecimalType =>
+          // Decimal arrays are uncommon for vectors. Keep compatibility while
+          // avoiding a fragile Decimal external-type UDF contract.
+          jsonArray(to_json(column), encodedHalfBytes = false)
+        case other =>
+          throw new IllegalArgumentException(
+            s"Unsupported dense vector element type $other"
+          )
+      }
+    }
+
+    def sparseJson(column: Column): Column = {
+      val encoder = udf((json: String) =>
+        if (json == null) null else encodeSparseJson(fieldName, json)
+      )
+      encoder(column)
+    }
+
+    val input = col(fieldName)
+    inputField.dataType match {
+      case BinaryType =>
+        Right(internalBinary(input))
+
+      case StringType if milvusType == MilvusDataType.SparseFloatVector =>
+        Right(sparseJson(input))
+
+      case StringType if DenseVectorTypes.contains(milvusType) =>
+        // CSV-style / generic parquet writers often persist a JSON array as a
+        // string. For half vectors this form means numeric float values; raw
+        // encoded half bytes should use BinaryType or Array[Byte/Short].
+        Right(jsonArray(input, encodedHalfBytes = false))
+
+      case ArrayType(elementType, _)
+          if DenseVectorTypes.contains(milvusType) &&
+            isSupportedDenseElementType(milvusType, elementType) =>
+        val encodedHalfBytes =
+          (milvusType == MilvusDataType.Float16Vector ||
+            milvusType == MilvusDataType.BFloat16Vector) &&
+            (elementType == ByteType || elementType == ShortType)
+        Right(denseArray(input, elementType, encodedHalfBytes))
+
+      case MapType(keyType, valueType, _)
+          if milvusType == MilvusDataType.SparseFloatVector &&
+            isSparseKeyType(keyType) && isNumericType(valueType) =>
+        Right(sparseJson(to_json(input)))
+
+      case structType: StructType
+          if milvusType == MilvusDataType.SparseFloatVector &&
+            isSparseStruct(structType) =>
+        Right(sparseJson(to_json(input)))
+
+      case other =>
+        Left(
+          SchemaValidationError(
+            s"Vector field '$fieldName' targets $milvusType but parquet type " +
+              s"${other.simpleString} is unsupported. Accepted forms: " +
+              acceptedForms(milvusType)
+          )
+        )
+    }
+  }
+
+  private def acceptedForms(milvusType: MilvusDataType): String =
+    milvusType match {
+      case MilvusDataType.FloatVector =>
+        "array<numeric>, JSON array string, or internal binary"
+      case MilvusDataType.BinaryVector =>
+        "array<integral byte>, JSON byte-array string, or internal binary"
+      case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector =>
+        "array<float/double> values, array<byte/short> encoded bytes, JSON numeric-array string, or internal binary"
+      case MilvusDataType.Int8Vector =>
+        "array<integral>, JSON integral-array string, or internal binary"
+      case MilvusDataType.SparseFloatVector =>
+        "map<integral|string,numeric>, struct<indices:array,values:array>, JSON object string, or internal binary"
+      case _ => "a supported Milvus vector representation"
+    }
+
+  private def isSupportedDenseElementType(
+      milvusType: MilvusDataType,
+      elementType: DataType
+  ): Boolean = milvusType match {
+    case MilvusDataType.FloatVector => isNumericType(elementType)
+    case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector =>
+      isNumericType(elementType)
+    case MilvusDataType.BinaryVector | MilvusDataType.Int8Vector =>
+      isIntegralType(elementType)
+    case _ => false
+  }
+
+  private def isNumericType(dataType: DataType): Boolean =
+    isIntegralType(dataType) || dataType == FloatType ||
+      dataType == DoubleType || dataType.isInstanceOf[DecimalType]
+
+  private def isIntegralType(dataType: DataType): Boolean =
+    dataType == ByteType || dataType == ShortType ||
+      dataType == IntegerType || dataType == LongType
+
+  private def isSparseKeyType(dataType: DataType): Boolean =
+    isIntegralType(dataType) || dataType == StringType
+
+  private def isSparseStruct(structType: StructType): Boolean = {
+    val fields =
+      structType.fields.map(field => field.name -> field.dataType).toMap
+    (fields.get("indices"), fields.get("values")) match {
+      case (Some(ArrayType(indexType, _)), Some(ArrayType(valueType, _))) =>
+        isIntegralType(indexType) && isNumericType(valueType)
+      case _ => false
+    }
+  }
+
+  private def dimension(field: Field): Int = {
+    val dim = field
+      .getTypeParam("dim")
+      .flatMap(value => scala.util.Try(value.toInt).toOption)
+      .filter(_ > 0)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          s"Vector field '${field.name}' (${MilvusDataType.fromValue(field.dataType)}) has no valid positive dim"
+        )
+      }
+
+    if (
+      MilvusDataType.fromValue(field.dataType) == MilvusDataType.BinaryVector &&
+      dim % 8 != 0
+    ) {
+      throw new IllegalArgumentException(
+        s"BinaryVector field '${field.name}' dimension must be a multiple of 8, got $dim"
+      )
+    }
+    dim
+  }
+
+  private def requireNoNullElements(
+      fieldName: String,
+      values: Seq[_]
+  ): Unit = {
+    if (values.exists(_ == null)) {
+      fail(fieldName, "vector arrays cannot contain null elements")
+    }
+  }
+
+  private def encodeDenseIntegralNumbers(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      values: Seq[_],
+      encodedHalfBytes: Boolean
+  ): Array[Byte] =
+    if (values == null) null
+    else {
+      requireNoNullElements(fieldName, values)
+      encodeDenseIntegralArray(
+        fieldName,
+        milvusType,
+        dim,
+        values.map(_.asInstanceOf[java.lang.Number].longValue()),
+        encodedHalfBytes
+      )
+    }
+
+  private def encodeDenseFloatingNumbers(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      values: Seq[_]
+  ): Array[Byte] =
+    if (values == null) null
+    else {
+      requireNoNullElements(fieldName, values)
+      encodeDenseFloatingArray(
+        fieldName,
+        milvusType,
+        dim,
+        values.map(_.asInstanceOf[java.lang.Number].doubleValue())
+      )
+    }
+
+  private def encodeDenseFloatingArray(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      values: Seq[Double]
+  ): Array[Byte] = {
+    requireDimension(fieldName, dim, values.size)
+    milvusType match {
+      case MilvusDataType.FloatVector =>
+        val bytes = ByteBuffer
+          .allocate(dim * 4)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        values.foreach(value => bytes.putFloat(finiteFloat(fieldName, value)))
+        bytes.array()
+
+      case MilvusDataType.Float16Vector =>
+        val bytes = ByteBuffer
+          .allocate(dim * 2)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        values.foreach { value =>
+          val floatValue = finiteFloat(fieldName, value)
+          bytes.putShort(floatToHalfBits(fieldName, floatValue).toShort)
+        }
+        bytes.array()
+
+      case MilvusDataType.BFloat16Vector =>
+        val bytes = ByteBuffer
+          .allocate(dim * 2)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        values.foreach { value =>
+          val floatValue = finiteFloat(fieldName, value)
+          bytes.putShort(
+            (java.lang.Float.floatToRawIntBits(floatValue) >>> 16).toShort
+          )
+        }
+        bytes.array()
+
+      case other =>
+        fail(fieldName, s"$other does not accept floating-point arrays")
+    }
+  }
+
+  private def encodeDenseIntegralArray(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      values: Seq[Long],
+      encodedHalfBytes: Boolean
+  ): Array[Byte] = milvusType match {
+    case MilvusDataType.FloatVector =>
+      encodeDenseFloatingArray(
+        fieldName,
+        milvusType,
+        dim,
+        values.map(_.toDouble)
+      )
+
+    case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector
+        if !encodedHalfBytes =>
+      encodeDenseFloatingArray(
+        fieldName,
+        milvusType,
+        dim,
+        values.map(_.toDouble)
+      )
+
+    case MilvusDataType.BinaryVector =>
+      requireByteWidth(fieldName, milvusType, dim / 8, values.size)
+      values
+        .map(value => byteValue(fieldName, value, allowUnsigned = true))
+        .toArray
+
+    case MilvusDataType.Int8Vector =>
+      requireDimension(fieldName, dim, values.size)
+      values
+        .map(value => byteValue(fieldName, value, allowUnsigned = false))
+        .toArray
+
+    case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector =>
+      requireByteWidth(fieldName, milvusType, dim * 2, values.size)
+      val bytes = values
+        .map(value => byteValue(fieldName, value, allowUnsigned = true))
+        .toArray
+      validateInternalBytes(fieldName, milvusType, dim, bytes)
+
+    case other =>
+      fail(fieldName, s"$other does not accept integral arrays")
+  }
+
+  private[backfill] def encodeDenseJsonArray(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      json: String,
+      encodedHalfBytes: Boolean
+  ): Array[Byte] = {
+    val node = parseJson(fieldName, json)
+    if (!node.isArray) {
+      fail(fieldName, s"expected a JSON array, got ${node.getNodeType}")
+    }
+    val elements = node.elements().asScala.toSeq
+
+    milvusType match {
+      case MilvusDataType.FloatVector =>
+        requireDimension(fieldName, dim, elements.size)
+        val bytes = ByteBuffer
+          .allocate(dim * 4)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        elements.foreach(node => bytes.putFloat(finiteFloat(fieldName, node)))
+        bytes.array()
+
+      case MilvusDataType.BinaryVector =>
+        val expectedBytes = dim / 8
+        requireByteWidth(fieldName, milvusType, expectedBytes, elements.size)
+        elements
+          .map(node => byteValue(fieldName, node, allowUnsigned = true))
+          .toArray
+
+      case MilvusDataType.Int8Vector =>
+        requireDimension(fieldName, dim, elements.size)
+        elements.map(node => int8Value(fieldName, node)).toArray
+
+      case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector
+          if encodedHalfBytes =>
+        val expectedBytes = dim * 2
+        requireByteWidth(fieldName, milvusType, expectedBytes, elements.size)
+        val bytes = elements
+          .map(node => byteValue(fieldName, node, allowUnsigned = true))
+          .toArray
+        validateInternalBytes(fieldName, milvusType, dim, bytes)
+
+      case MilvusDataType.Float16Vector =>
+        requireDimension(fieldName, dim, elements.size)
+        val bytes = ByteBuffer
+          .allocate(dim * 2)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        elements.foreach { node =>
+          val value = finiteFloat(fieldName, node)
+          bytes.putShort(floatToHalfBits(fieldName, value).toShort)
+        }
+        bytes.array()
+
+      case MilvusDataType.BFloat16Vector =>
+        requireDimension(fieldName, dim, elements.size)
+        val bytes = ByteBuffer
+          .allocate(dim * 2)
+          .order(ByteOrder.LITTLE_ENDIAN)
+        elements.foreach { node =>
+          val value = finiteFloat(fieldName, node)
+          bytes.putShort(
+            (java.lang.Float.floatToRawIntBits(value) >>> 16).toShort
+          )
+        }
+        bytes.array()
+
+      case other =>
+        fail(fieldName, s"$other is not a dense vector type")
+    }
+  }
+
+  private[backfill] def encodeSparseJson(
+      fieldName: String,
+      json: String
+  ): Array[Byte] = {
+    val node = parseJson(fieldName, json)
+    if (!node.isObject) {
+      fail(fieldName, s"expected a sparse JSON object, got ${node.getNodeType}")
+    }
+
+    val entries: Seq[(Long, Float)] = {
+      val indices = node.get("indices")
+      val values = node.get("values")
+      if (indices != null || values != null) {
+        if (
+          indices == null || values == null || !indices.isArray || !values.isArray
+        ) {
+          fail(
+            fieldName,
+            "sparse struct format requires array fields 'indices' and 'values'"
+          )
+        }
+        val indexNodes = indices.elements().asScala.toSeq
+        val valueNodes = values.elements().asScala.toSeq
+        if (indexNodes.size != valueNodes.size) {
+          fail(
+            fieldName,
+            s"sparse indices/values length mismatch: ${indexNodes.size} != ${valueNodes.size}"
+          )
+        }
+        indexNodes.zip(valueNodes).map { case (index, value) =>
+          sparseIndex(fieldName, index) -> sparseValue(fieldName, value)
+        }
+      } else {
+        node
+          .fields()
+          .asScala
+          .map { entry =>
+            val indexNode = mapper.getNodeFactory.numberNode(
+              parseSparseMapIndex(fieldName, entry.getKey)
+            )
+            sparseIndex(fieldName, indexNode) -> sparseValue(
+              fieldName,
+              entry.getValue
+            )
+          }
+          .toSeq
+      }
+    }
+
+    val sorted = entries.sortBy(_._1)
+    sorted.sliding(2).foreach {
+      case Seq((left, _), (right, _)) if left == right =>
+        fail(fieldName, s"sparse vector contains duplicate index $left")
+      case _ =>
+    }
+
+    val bytes = ByteBuffer
+      .allocate(sorted.size * 8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+    sorted.foreach { case (index, value) =>
+      bytes.putInt(index.toInt)
+      bytes.putFloat(value)
+    }
+    bytes.array()
+  }
+
+  private[backfill] def validateInternalBytes(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      dim: Int,
+      bytes: Array[Byte]
+  ): Array[Byte] = {
+    milvusType match {
+      case MilvusDataType.FloatVector =>
+        requireByteWidth(fieldName, milvusType, dim * 4, bytes.length)
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        while (buffer.remaining() >= 4) {
+          val value = buffer.getFloat()
+          if (!java.lang.Float.isFinite(value)) {
+            fail(fieldName, s"$milvusType contains non-finite value $value")
+          }
+        }
+
+      case MilvusDataType.BinaryVector =>
+        requireByteWidth(fieldName, milvusType, dim / 8, bytes.length)
+
+      case MilvusDataType.Int8Vector =>
+        requireByteWidth(fieldName, milvusType, dim, bytes.length)
+
+      case MilvusDataType.Float16Vector =>
+        requireByteWidth(fieldName, milvusType, dim * 2, bytes.length)
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        while (buffer.remaining() >= 2) {
+          val bits = buffer.getShort() & 0xffff
+          if (((bits >>> 10) & 0x1f) == 0x1f) {
+            fail(fieldName, s"$milvusType contains NaN or infinity")
+          }
+        }
+
+      case MilvusDataType.BFloat16Vector =>
+        requireByteWidth(fieldName, milvusType, dim * 2, bytes.length)
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        while (buffer.remaining() >= 2) {
+          val bits = buffer.getShort() & 0xffff
+          if (((bits >>> 7) & 0xff) == 0xff) {
+            fail(fieldName, s"$milvusType contains NaN or infinity")
+          }
+        }
+
+      case MilvusDataType.SparseFloatVector =>
+        if (bytes.length % 8 != 0) {
+          fail(
+            fieldName,
+            s"SparseFloatVector binary length must be divisible by 8, got ${bytes.length}"
+          )
+        }
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        var previous = -1L
+        while (buffer.remaining() >= 8) {
+          val index = buffer.getInt() & 0xffffffffL
+          val value = buffer.getFloat()
+          if (index == 0xffffffffL) {
+            fail(
+              fieldName,
+              "SparseFloatVector index must be less than 2^32 - 1"
+            )
+          }
+          if (index <= previous) {
+            fail(
+              fieldName,
+              s"SparseFloatVector indices must be strictly increasing, got $index after $previous"
+            )
+          }
+          if (!java.lang.Float.isFinite(value)) {
+            fail(
+              fieldName,
+              s"SparseFloatVector contains non-finite value $value"
+            )
+          }
+          if (value < 0.0f) {
+            fail(fieldName, s"SparseFloatVector contains negative value $value")
+          }
+          previous = index
+        }
+
+      case other =>
+        fail(fieldName, s"$other is not a supported vector type")
+    }
+    bytes
+  }
+
+  private def parseJson(fieldName: String, json: String): JsonNode =
+    try mapper.readTree(json)
+    catch {
+      case e: Exception =>
+        throw new IllegalArgumentException(
+          s"Vector field '$fieldName' contains invalid JSON: ${e.getMessage}",
+          e
+        )
+    }
+
+  private def finiteFloat(fieldName: String, node: JsonNode): Float = {
+    if (node == null || !node.isNumber) {
+      fail(fieldName, s"expected a numeric vector value, got $node")
+    }
+    finiteFloat(fieldName, node.doubleValue())
+  }
+
+  private def finiteFloat(fieldName: String, doubleValue: Double): Float = {
+    val floatValue = doubleValue.toFloat
+    if (
+      !java.lang.Double
+        .isFinite(doubleValue) || !java.lang.Float.isFinite(floatValue)
+    ) {
+      fail(
+        fieldName,
+        s"vector value is non-finite or outside float32 range: $doubleValue"
+      )
+    }
+    floatValue
+  }
+
+  private def sparseValue(fieldName: String, node: JsonNode): Float = {
+    val value = finiteFloat(fieldName, node)
+    if (value < 0.0f) {
+      fail(fieldName, s"sparse vector value must be non-negative, got $value")
+    }
+    value
+  }
+
+  private def integralValue(fieldName: String, node: JsonNode): Long = {
+    if (node == null || !node.isNumber) {
+      fail(fieldName, s"expected an integral vector value, got $node")
+    }
+    val decimal = node.decimalValue()
+    try decimal.longValueExact()
+    catch {
+      case _: ArithmeticException =>
+        fail(fieldName, s"expected an integral vector value, got $node")
+    }
+  }
+
+  private def byteValue(
+      fieldName: String,
+      node: JsonNode,
+      allowUnsigned: Boolean
+  ): Byte =
+    byteValue(fieldName, integralValue(fieldName, node), allowUnsigned)
+
+  private def byteValue(
+      fieldName: String,
+      value: Long,
+      allowUnsigned: Boolean
+  ): Byte = {
+    val max = if (allowUnsigned) 255L else 127L
+    if (value < -128L || value > max) {
+      fail(fieldName, s"byte value $value is outside [-128, $max]")
+    }
+    value.toByte
+  }
+
+  private def int8Value(fieldName: String, node: JsonNode): Byte =
+    byteValue(fieldName, node, allowUnsigned = false)
+
+  private def sparseIndex(fieldName: String, node: JsonNode): Long = {
+    val value = integralValue(fieldName, node)
+    if (value < 0L || value >= 0xffffffffL) {
+      fail(
+        fieldName,
+        s"sparse index $value is outside [0, ${0xffffffffL - 1L}]"
+      )
+    }
+    value
+  }
+
+  private def parseSparseMapIndex(fieldName: String, value: String): Long =
+    try java.lang.Long.parseLong(value)
+    catch {
+      case _: NumberFormatException =>
+        fail(fieldName, s"sparse map key '$value' is not an integer index")
+    }
+
+  private def requireDimension(
+      fieldName: String,
+      expected: Int,
+      actual: Int
+  ): Unit = {
+    if (actual != expected) {
+      fail(
+        fieldName,
+        s"vector dimension mismatch: expected $expected, got $actual"
+      )
+    }
+  }
+
+  private def requireByteWidth(
+      fieldName: String,
+      milvusType: MilvusDataType,
+      expected: Int,
+      actual: Int
+  ): Unit = {
+    if (actual != expected) {
+      fail(
+        fieldName,
+        s"$milvusType byte-width mismatch: expected $expected, got $actual"
+      )
+    }
+  }
+
+  /** IEEE-754 binary32 -> binary16, round-to-nearest-even. */
+  private def floatToHalfBits(fieldName: String, value: Float): Int = {
+    val bits = java.lang.Float.floatToRawIntBits(value)
+    val sign = (bits >>> 16) & 0x8000
+    val exponent = (bits >>> 23) & 0xff
+    val mantissa = bits & 0x7fffff
+
+    if (exponent == 0xff) {
+      fail(fieldName, s"Float16Vector contains non-finite value $value")
+    }
+
+    val halfExponent = exponent - 127 + 15
+    if (halfExponent >= 31) {
+      fail(
+        fieldName,
+        s"Float16Vector value $value is outside finite float16 range"
+      )
+    }
+
+    if (halfExponent <= 0) {
+      if (halfExponent < -10) return sign
+      val normalizedMantissa = mantissa | 0x800000
+      val shift = 14 - halfExponent
+      var halfMantissa = normalizedMantissa >>> shift
+      val remainderMask = (1 << shift) - 1
+      val remainder = normalizedMantissa & remainderMask
+      val halfway = 1 << (shift - 1)
+      if (
+        remainder > halfway || (remainder == halfway && (halfMantissa & 1) != 0)
+      ) {
+        halfMantissa += 1
+      }
+      sign | halfMantissa
+    } else {
+      var half = sign | (halfExponent << 10) | (mantissa >>> 13)
+      val remainder = mantissa & 0x1fff
+      if (remainder > 0x1000 || (remainder == 0x1000 && (half & 1) != 0)) {
+        half += 1
+      }
+      if (((half >>> 10) & 0x1f) == 0x1f) {
+        fail(
+          fieldName,
+          s"Float16Vector value $value rounds outside finite float16 range"
+        )
+      }
+      half
+    }
+  }
+
+  private def fail(fieldName: String, message: String): Nothing =
+    throw new IllegalArgumentException(s"Vector field '$fieldName': $message")
+}

--- a/src/main/scala/operations/backfill/VectorBackfillSupport.scala
+++ b/src/main/scala/operations/backfill/VectorBackfillSupport.scala
@@ -8,6 +8,7 @@ import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions.{col, to_json, udf}
 import org.apache.spark.sql.types._
 
+import com.zilliz.spark.connector.{DataParseException, FloatConverter}
 import com.zilliz.spark.connector.read.Field
 import com.zilliz.spark.connector.serde.ArrowConverter
 import io.milvus.grpc.schema.{DataType => MilvusDataType}
@@ -404,7 +405,7 @@ private[backfill] object VectorBackfillSupport {
           .order(ByteOrder.LITTLE_ENDIAN)
         values.foreach { value =>
           val floatValue = finiteFloat(fieldName, value)
-          bytes.putShort(floatToHalfBits(fieldName, floatValue).toShort)
+          bytes.put(float16Bytes(fieldName, floatValue))
         }
         bytes.array()
 
@@ -521,7 +522,7 @@ private[backfill] object VectorBackfillSupport {
           .order(ByteOrder.LITTLE_ENDIAN)
         elements.foreach { node =>
           val value = finiteFloat(fieldName, node)
-          bytes.putShort(floatToHalfBits(fieldName, value).toShort)
+          bytes.put(float16Bytes(fieldName, value))
         }
         bytes.array()
 
@@ -812,54 +813,11 @@ private[backfill] object VectorBackfillSupport {
     }
   }
 
-  /** IEEE-754 binary32 -> binary16, round-to-nearest-even. */
-  private def floatToHalfBits(fieldName: String, value: Float): Int = {
-    val bits = java.lang.Float.floatToRawIntBits(value)
-    val sign = (bits >>> 16) & 0x8000
-    val exponent = (bits >>> 23) & 0xff
-    val mantissa = bits & 0x7fffff
-
-    if (exponent == 0xff) {
-      fail(fieldName, s"Float16Vector contains non-finite value $value")
+  private def float16Bytes(fieldName: String, value: Float): Array[Byte] =
+    try FloatConverter.toFloat16Bytes(value).toArray
+    catch {
+      case e: DataParseException => fail(fieldName, e.getMessage)
     }
-
-    val halfExponent = exponent - 127 + 15
-    if (halfExponent >= 31) {
-      fail(
-        fieldName,
-        s"Float16Vector value $value is outside finite float16 range"
-      )
-    }
-
-    if (halfExponent <= 0) {
-      if (halfExponent < -10) return sign
-      val normalizedMantissa = mantissa | 0x800000
-      val shift = 14 - halfExponent
-      var halfMantissa = normalizedMantissa >>> shift
-      val remainderMask = (1 << shift) - 1
-      val remainder = normalizedMantissa & remainderMask
-      val halfway = 1 << (shift - 1)
-      if (
-        remainder > halfway || (remainder == halfway && (halfMantissa & 1) != 0)
-      ) {
-        halfMantissa += 1
-      }
-      sign | halfMantissa
-    } else {
-      var half = sign | (halfExponent << 10) | (mantissa >>> 13)
-      val remainder = mantissa & 0x1fff
-      if (remainder > 0x1000 || (remainder == 0x1000 && (half & 1) != 0)) {
-        half += 1
-      }
-      if (((half >>> 10) & 0x1f) == 0x1f) {
-        fail(
-          fieldName,
-          s"Float16Vector value $value rounds outside finite float16 range"
-        )
-      }
-      half
-    }
-  }
 
   private def fail(fieldName: String, message: String): Nothing =
     throw new IllegalArgumentException(s"Vector field '$fieldName': $message")

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.module.scala.{
 import org.apache.spark.sql.types._
 
 import com.zilliz.spark.connector.serde.ArrowConverter
+import com.zilliz.spark.connector.DataTypeUtil
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
 
 /** Helper object for converting JSON values that may be either numeric or
   * string to Long/Int Milvus snapshot JSON format may serialize numbers as
@@ -813,13 +815,23 @@ object MilvusSnapshotReader {
   /** Convert a Field to Spark StructField with Milvus metadata preserved.
     */
   def fieldToStructField(field: Field): StructField = {
+    val metadata = new MetadataBuilder()
+      .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType)
+    val milvusType = MilvusDataType.fromValue(field.dataType)
+    if (DataTypeUtil.isDenseVectorType(milvusType)) {
+      field.getTypeParam("dim").foreach { rawDimension =>
+        metadata.putLong(
+          ArrowConverter.MilvusVectorDimensionMetadataKey,
+          DataTypeUtil.parseVectorDimension(field.name, rawDimension)
+        )
+      }
+    }
+
     StructField(
       field.name,
       dataTypeToSparkType(field.dataType, field.elementType),
       nullable = field.nullable.getOrElse(true),
-      metadata = new MetadataBuilder()
-        .putLong(ArrowConverter.MilvusDataTypeMetadataKey, field.dataType)
-        .build()
+      metadata = metadata.build()
     )
   }
 

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -124,80 +124,48 @@ object ArrowConverter extends Logging {
       case StringType =>
         utf8StringFromVariableWidth(vector, rowIndex)
 
-      case ArrayType(ByteType, _)
-          if vector.isInstanceOf[FixedSizeBinaryVector] =>
-        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
+      case ArrayType(ByteType, _) if isBinaryBackedVector(vector) =>
+        val bytes = binaryVectorBytes(vector, rowIndex)
         milvusType match {
           case Some(MilvusDataType.BinaryVector) =>
             ArrayData.toArrayData(bytes)
           case Some(other) =>
             throw new IllegalArgumentException(
-              s"Cannot decode FixedSizeBinary as Array[Byte] for Milvus type $other"
+              s"Cannot decode binary-backed vector as Array[Byte] for Milvus type $other"
             )
           case None =>
             throw new IllegalArgumentException(
-              s"FixedSizeBinary byte vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
+              s"Binary-backed byte vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
             )
         }
 
-      case ArrayType(ShortType, _)
-          if vector.isInstanceOf[FixedSizeBinaryVector] =>
-        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
+      case ArrayType(ShortType, _) if isBinaryBackedVector(vector) =>
+        val bytes = binaryVectorBytes(vector, rowIndex)
         milvusType match {
           case Some(MilvusDataType.Int8Vector) =>
             ArrayData.toArrayData(bytes.map(_.toShort))
           case Some(other) =>
             throw new IllegalArgumentException(
-              s"Cannot decode FixedSizeBinary as Array[Short] for Milvus type $other"
+              s"Cannot decode binary-backed vector as Array[Short] for Milvus type $other"
             )
           case None =>
             throw new IllegalArgumentException(
-              s"FixedSizeBinary short vectors require ${MilvusDataTypeMetadataKey} metadata"
+              s"Binary-backed short vectors require ${MilvusDataTypeMetadataKey} metadata"
             )
         }
 
-      case ArrayType(FloatType, _)
-          if vector.isInstanceOf[FixedSizeBinaryVector] =>
-        val bytes = vector.asInstanceOf[FixedSizeBinaryVector].get(rowIndex)
+      case ArrayType(FloatType, _) if isBinaryBackedVector(vector) =>
+        val bytes = binaryVectorBytes(vector, rowIndex)
         ArrayData.toArrayData(
-          decodeFixedSizeBinaryFloats(
+          decodeBinaryFloats(
             bytes,
             milvusType,
             allowLegacyFloatVector
           )
         )
 
-      case ArrayType(FloatType, _) =>
-        val listVector = vector.asInstanceOf[ListVector]
-        val dataVector = listVector.getDataVector
-        val startIndex = listVector.getElementStartIndex(rowIndex)
-        val endIndex = listVector.getElementEndIndex(rowIndex)
-        val length = endIndex - startIndex
-        val arrayElements = (0 until length).map { i =>
-          val elemIndex = startIndex + i
-          if (dataVector.isNull(elemIndex)) null
-          else arrowValueToSparkValue(dataVector, elemIndex, FloatType, None)
-        }.toArray
-        ArrayData.toArrayData(arrayElements)
-
       case ArrayType(elementType, _) =>
-        // Generic array handling
-        val listVector = vector.asInstanceOf[ListVector]
-        val dataVector = listVector.getDataVector
-        val startIndex = listVector.getElementStartIndex(rowIndex)
-        val endIndex = listVector.getElementEndIndex(rowIndex)
-        val length = endIndex - startIndex
-
-        val arrayElements = (0 until length).map { i =>
-          val elemIndex = startIndex + i
-          if (dataVector.isNull(elemIndex)) {
-            null
-          } else {
-            arrowValueToSparkValue(dataVector, elemIndex, elementType, None)
-          }
-        }.toArray
-
-        ArrayData.toArrayData(arrayElements)
+        decodeListArray(vector, rowIndex, elementType)
 
       case BinaryType =>
         vector match {
@@ -267,6 +235,51 @@ object ArrowConverter extends Logging {
       .map(MilvusDataType.fromValue)
   }
 
+  private def isBinaryBackedVector(vector: FieldVector): Boolean =
+    vector.isInstanceOf[FixedSizeBinaryVector] ||
+      vector.isInstanceOf[VarBinaryVector]
+
+  private def binaryVectorBytes(
+      vector: FieldVector,
+      rowIndex: Int
+  ): Array[Byte] = vector match {
+    case fixed: FixedSizeBinaryVector => fixed.get(rowIndex)
+    case variable: VarBinaryVector    => variable.get(rowIndex)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Cannot read ${other.getClass.getSimpleName} as a binary-backed vector"
+      )
+  }
+
+  private def decodeListArray(
+      vector: FieldVector,
+      rowIndex: Int,
+      elementType: DataType
+  ): ArrayData = {
+    val listVector = vector match {
+      case list: ListVector => list
+      case other =>
+        throw new IllegalArgumentException(
+          s"Cannot decode ${other.getClass.getSimpleName} as Array[$elementType]"
+        )
+    }
+    val dataVector = listVector.getDataVector
+    val startIndex = listVector.getElementStartIndex(rowIndex)
+    val endIndex = listVector.getElementEndIndex(rowIndex)
+    val length = endIndex - startIndex
+
+    val arrayElements = (0 until length).map { i =>
+      val elemIndex = startIndex + i
+      if (dataVector.isNull(elemIndex)) {
+        null
+      } else {
+        arrowValueToSparkValue(dataVector, elemIndex, elementType, None)
+      }
+    }.toArray
+
+    ArrayData.toArrayData(arrayElements)
+  }
+
   private def utf8StringFromVariableWidth(
       vector: FieldVector,
       rowIndex: Int
@@ -298,7 +311,7 @@ object ArrowConverter extends Logging {
     UTF8String.fromBytes(bytes)
   }
 
-  private def decodeFixedSizeBinaryFloats(
+  private def decodeBinaryFloats(
       bytes: Array[Byte],
       milvusType: Option[MilvusDataType],
       allowLegacyFloatVector: Boolean
@@ -320,11 +333,11 @@ object ArrowConverter extends Logging {
         decodeFloatVectorBytes(bytes)
       case None =>
         throw new IllegalArgumentException(
-          s"FixedSizeBinary float vectors require ${MilvusDataTypeMetadataKey} metadata"
+          s"Binary-backed float vectors require ${MilvusDataTypeMetadataKey} metadata"
         )
       case Some(other) =>
         throw new IllegalArgumentException(
-          s"Cannot decode FixedSizeBinary as Array[Float] for Milvus type $other"
+          s"Cannot decode binary-backed vector as Array[Float] for Milvus type $other"
         )
     }
   }
@@ -332,6 +345,29 @@ object ArrowConverter extends Logging {
   private def decodeFloatVectorBytes(bytes: Array[Byte]): Array[Float] = {
     val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
     (0 until (bytes.length / 4)).map(_ => buffer.getFloat()).toArray
+  }
+
+  private def encodeFloatVectorBytes(values: Array[Float]): Array[Byte] = {
+    val bytes = new Array[Byte](values.length * 4)
+    val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    values.foreach(buffer.putFloat)
+    bytes
+  }
+
+  private def setBinaryVectorValue(
+      vector: FieldVector,
+      rowIndex: Int,
+      bytes: Array[Byte],
+      sparkType: String
+  ): Unit = vector match {
+    case fixed: FixedSizeBinaryVector => fixed.set(rowIndex, bytes)
+    case variable: VarBinaryVector    =>
+      // setSafe grows the variable-width data buffer when needed.
+      variable.setSafe(rowIndex, bytes)
+    case other =>
+      throw new IllegalArgumentException(
+        s"Cannot encode $sparkType into ${other.getClass.getSimpleName}"
+      )
   }
 
   val MilvusDataTypeMetadataKey = "milvus.data_type"
@@ -356,6 +392,23 @@ object ArrowConverter extends Logging {
       record: InternalRow,
       colIndex: Int,
       sparkType: DataType
+  ): Unit =
+    sparkValueToArrowValue(
+      vector,
+      rowIndex,
+      record,
+      colIndex,
+      sparkType,
+      None
+    )
+
+  private def sparkValueToArrowValue(
+      vector: FieldVector,
+      rowIndex: Int,
+      record: InternalRow,
+      colIndex: Int,
+      sparkType: DataType,
+      milvusType: Option[MilvusDataType]
   ): Unit = {
     if (record.isNullAt(colIndex)) {
       vector.setNull(rowIndex)
@@ -403,20 +456,78 @@ object ArrowConverter extends Logging {
           vector.asInstanceOf[VarCharVector].setSafe(rowIndex, str.getBytes)
         }
 
-      case ArrayType(FloatType, _) =>
-        // FloatVector stored as FixedSizeBinaryVector
+      case ArrayType(FloatType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
         val floats = (0 until arrayData.numElements())
           .map(i => arrayData.getFloat(i))
           .toArray
-        val bytes = new Array[Byte](floats.length * 4)
-        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
-        floats.foreach(buffer.putFloat)
-        vector.asInstanceOf[FixedSizeBinaryVector].set(rowIndex, bytes)
+        val bytes = milvusType match {
+          case Some(MilvusDataType.Float16Vector) =>
+            floats.flatMap(value => FloatConverter.toFloat16Bytes(value))
+          case Some(MilvusDataType.BFloat16Vector) =>
+            floats.flatMap(value => FloatConverter.toBFloat16Bytes(value))
+          case Some(MilvusDataType.FloatVector) | None =>
+            encodeFloatVectorBytes(floats)
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot encode Array[Float] as binary-backed Milvus type $other"
+            )
+        }
+        setBinaryVectorValue(vector, rowIndex, bytes, "Array[Float]")
+
+      case ArrayType(ShortType, _) if isBinaryBackedVector(vector) =>
+        val arrayData = record.getArray(colIndex)
+        val values = (0 until arrayData.numElements())
+          .map(i => arrayData.getShort(i))
+          .toArray
+        val bytes = milvusType match {
+          case Some(MilvusDataType.Int8Vector) =>
+            values.map { value =>
+              if (value < Byte.MinValue || value > Byte.MaxValue) {
+                throw new IllegalArgumentException(
+                  s"Int8Vector value $value is outside [${Byte.MinValue}, ${Byte.MaxValue}]"
+                )
+              }
+              value.toByte
+            }
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot encode Array[Short] as binary-backed Milvus type $other"
+            )
+          case None =>
+            throw new IllegalArgumentException(
+              s"Binary-backed Array[Short] requires ${MilvusDataTypeMetadataKey} metadata for Int8Vector"
+            )
+        }
+        setBinaryVectorValue(vector, rowIndex, bytes, "Array[Short]")
+
+      case ArrayType(ByteType, _) if isBinaryBackedVector(vector) =>
+        val arrayData = record.getArray(colIndex)
+        val bytes = (0 until arrayData.numElements())
+          .map(i => arrayData.getByte(i))
+          .toArray
+        milvusType match {
+          case Some(MilvusDataType.BinaryVector) =>
+            setBinaryVectorValue(vector, rowIndex, bytes, "Array[Byte]")
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot encode Array[Byte] as binary-backed Milvus type $other"
+            )
+          case None =>
+            throw new IllegalArgumentException(
+              s"Binary-backed Array[Byte] requires ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
+            )
+        }
 
       case ArrayType(elementType, _) =>
         // Generic array handling
-        val listVector = vector.asInstanceOf[ListVector]
+        val listVector = vector match {
+          case list: ListVector => list
+          case other =>
+            throw new IllegalArgumentException(
+              s"Cannot encode Array[$elementType] into ${other.getClass.getSimpleName}"
+            )
+        }
         val dataVector = listVector.getDataVector
         val arrayData = record.getArray(colIndex)
 
@@ -435,7 +546,8 @@ object ArrowConverter extends Logging {
               elemIndex,
               elemRow,
               0,
-              elementType
+              elementType,
+              None
             )
           }
         }
@@ -447,16 +559,7 @@ object ArrowConverter extends Logging {
         if (bytes == null) {
           vector.setNull(rowIndex)
         } else {
-          vector match {
-            case fixed: FixedSizeBinaryVector => fixed.set(rowIndex, bytes)
-            case variable: VarBinaryVector    =>
-              // See StringType above — setSafe grows the data buffer; set does not.
-              variable.setSafe(rowIndex, bytes)
-            case other =>
-              throw new IllegalArgumentException(
-                s"Cannot encode BinaryType into ${other.getClass.getSimpleName}"
-              )
-          }
+          setBinaryVectorValue(vector, rowIndex, bytes, "BinaryType")
         }
 
       case MapType(keyType, valueType, _) =>
@@ -480,14 +583,16 @@ object ArrowConverter extends Logging {
             elemIndex,
             keyRow,
             0,
-            keyType
+            keyType,
+            None
           )
           sparkValueToArrowValue(
             structVector.getChild("value"),
             elemIndex,
             valueRow,
             0,
-            valueType
+            valueType,
+            None
           )
         }
 
@@ -517,7 +622,14 @@ object ArrowConverter extends Logging {
   ): Unit = {
     sparkSchema.fields.zipWithIndex.foreach { case (field, colIndex) =>
       val vector = root.getVector(colIndex)
-      sparkValueToArrowValue(vector, rowIndex, record, colIndex, field.dataType)
+      sparkValueToArrowValue(
+        vector,
+        rowIndex,
+        record,
+        colIndex,
+        field.dataType,
+        milvusDataType(field)
+      )
     }
   }
 }

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -23,6 +23,16 @@ import io.milvus.grpc.schema.{DataType => MilvusDataType}
   */
 object ArrowConverter extends Logging {
 
+  private val DenseVectorTypes: Set[MilvusDataType] = Set(
+    MilvusDataType.FloatVector,
+    MilvusDataType.BinaryVector,
+    MilvusDataType.Float16Vector,
+    MilvusDataType.BFloat16Vector,
+    MilvusDataType.Int8Vector
+  )
+
+  private val ArrowVectorDimensionMetadataKey = "dim"
+
   /** Convert an Arrow VectorSchemaRoot row to Spark InternalRow
     *
     * @param root
@@ -358,16 +368,88 @@ object ArrowConverter extends Logging {
       vector: FieldVector,
       rowIndex: Int,
       bytes: Array[Byte],
-      sparkType: String
-  ): Unit = vector match {
-    case fixed: FixedSizeBinaryVector => fixed.set(rowIndex, bytes)
-    case variable: VarBinaryVector    =>
-      // setSafe grows the variable-width data buffer when needed.
-      variable.setSafe(rowIndex, bytes)
-    case other =>
+      sparkType: String,
+      milvusType: Option[MilvusDataType],
+      vectorDimension: Option[Int]
+  ): Unit = {
+    validateDenseVectorByteWidth(
+      vector,
+      bytes,
+      sparkType,
+      milvusType,
+      vectorDimension
+    )
+
+    vector match {
+      case fixed: FixedSizeBinaryVector => fixed.set(rowIndex, bytes)
+      case variable: VarBinaryVector    =>
+        // setSafe grows the variable-width data buffer when needed.
+        variable.setSafe(rowIndex, bytes)
+      case other =>
+        throw new IllegalArgumentException(
+          s"Cannot encode $sparkType into ${other.getClass.getSimpleName}"
+        )
+    }
+  }
+
+  private def validateDenseVectorByteWidth(
+      vector: FieldVector,
+      bytes: Array[Byte],
+      sparkType: String,
+      milvusType: Option[MilvusDataType],
+      vectorDimension: Option[Int]
+  ): Unit =
+    milvusType.filter(DenseVectorTypes.contains).foreach { dataType =>
+      val expectedBytes = vectorDimension match {
+        case Some(dimension) => denseVectorByteWidth(dataType, dimension)
+        case None =>
+          vector match {
+            case fixed: FixedSizeBinaryVector => fixed.getByteWidth
+            case _: VarBinaryVector =>
+              throw new IllegalArgumentException(
+                s"Cannot encode $sparkType for nullable dense vector '${vector.getName}' ($dataType): missing $MilvusVectorDimensionMetadataKey or Arrow $ArrowVectorDimensionMetadataKey metadata"
+              )
+            case other =>
+              throw new IllegalArgumentException(
+                s"Cannot determine dense vector width from ${other.getClass.getSimpleName}"
+              )
+          }
+      }
+
+      if (bytes.length != expectedBytes) {
+        throw new IllegalArgumentException(
+          s"Cannot encode $sparkType for dense vector '${vector.getName}' ($dataType): expected $expectedBytes bytes, got ${bytes.length}"
+        )
+      }
+    }
+
+  private def denseVectorByteWidth(
+      dataType: MilvusDataType,
+      dimension: Int
+  ): Int = {
+    if (dimension <= 0) {
       throw new IllegalArgumentException(
-        s"Cannot encode $sparkType into ${other.getClass.getSimpleName}"
+        s"Dense vector dimension must be positive, got $dimension for $dataType"
       )
+    }
+
+    dataType match {
+      case MilvusDataType.FloatVector => Math.multiplyExact(dimension, 4)
+      case MilvusDataType.Float16Vector | MilvusDataType.BFloat16Vector =>
+        Math.multiplyExact(dimension, 2)
+      case MilvusDataType.Int8Vector => dimension
+      case MilvusDataType.BinaryVector =>
+        if (dimension % 8 != 0) {
+          throw new IllegalArgumentException(
+            s"BinaryVector dimension must be a multiple of 8, got $dimension"
+          )
+        }
+        dimension / 8
+      case other =>
+        throw new IllegalArgumentException(
+          s"Cannot compute dense vector byte width for $other"
+        )
+    }
   }
 
   val MilvusDataTypeMetadataKey = "milvus.data_type"
@@ -399,6 +481,7 @@ object ArrowConverter extends Logging {
       record,
       colIndex,
       sparkType,
+      None,
       None
     )
 
@@ -408,7 +491,8 @@ object ArrowConverter extends Logging {
       record: InternalRow,
       colIndex: Int,
       sparkType: DataType,
-      milvusType: Option[MilvusDataType]
+      milvusType: Option[MilvusDataType],
+      vectorDimension: Option[Int]
   ): Unit = {
     if (record.isNullAt(colIndex)) {
       vector.setNull(rowIndex)
@@ -473,7 +557,14 @@ object ArrowConverter extends Logging {
               s"Cannot encode Array[Float] as binary-backed Milvus type $other"
             )
         }
-        setBinaryVectorValue(vector, rowIndex, bytes, "Array[Float]")
+        setBinaryVectorValue(
+          vector,
+          rowIndex,
+          bytes,
+          "Array[Float]",
+          milvusType,
+          vectorDimension
+        )
 
       case ArrayType(ShortType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
@@ -499,7 +590,14 @@ object ArrowConverter extends Logging {
               s"Binary-backed Array[Short] requires ${MilvusDataTypeMetadataKey} metadata for Int8Vector"
             )
         }
-        setBinaryVectorValue(vector, rowIndex, bytes, "Array[Short]")
+        setBinaryVectorValue(
+          vector,
+          rowIndex,
+          bytes,
+          "Array[Short]",
+          milvusType,
+          vectorDimension
+        )
 
       case ArrayType(ByteType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
@@ -508,7 +606,14 @@ object ArrowConverter extends Logging {
           .toArray
         milvusType match {
           case Some(MilvusDataType.BinaryVector) =>
-            setBinaryVectorValue(vector, rowIndex, bytes, "Array[Byte]")
+            setBinaryVectorValue(
+              vector,
+              rowIndex,
+              bytes,
+              "Array[Byte]",
+              milvusType,
+              vectorDimension
+            )
           case Some(other) =>
             throw new IllegalArgumentException(
               s"Cannot encode Array[Byte] as binary-backed Milvus type $other"
@@ -547,6 +652,7 @@ object ArrowConverter extends Logging {
               elemRow,
               0,
               elementType,
+              None,
               None
             )
           }
@@ -559,7 +665,14 @@ object ArrowConverter extends Logging {
         if (bytes == null) {
           vector.setNull(rowIndex)
         } else {
-          setBinaryVectorValue(vector, rowIndex, bytes, "BinaryType")
+          setBinaryVectorValue(
+            vector,
+            rowIndex,
+            bytes,
+            "BinaryType",
+            milvusType,
+            vectorDimension
+          )
         }
 
       case MapType(keyType, valueType, _) =>
@@ -584,6 +697,7 @@ object ArrowConverter extends Logging {
             keyRow,
             0,
             keyType,
+            None,
             None
           )
           sparkValueToArrowValue(
@@ -592,6 +706,7 @@ object ArrowConverter extends Logging {
             valueRow,
             0,
             valueType,
+            None,
             None
           )
         }
@@ -628,8 +743,42 @@ object ArrowConverter extends Logging {
         record,
         colIndex,
         field.dataType,
-        milvusDataType(field)
+        milvusDataType(field),
+        milvusVectorDimension(field, vector)
       )
+    }
+  }
+
+  private def milvusVectorDimension(
+      field: StructField,
+      vector: FieldVector
+  ): Option[Int] = {
+    val sparkDimension = Option(field.metadata)
+      .filter(_.contains(MilvusVectorDimensionMetadataKey))
+      .map(_.getLong(MilvusVectorDimensionMetadataKey))
+
+    val arrowDimension = Option(vector.getField)
+      .flatMap(arrowField => Option(arrowField.getMetadata))
+      .flatMap(metadata =>
+        Option(metadata.get(ArrowVectorDimensionMetadataKey))
+      )
+      .map { rawDimension =>
+        try rawDimension.toLong
+        catch {
+          case _: NumberFormatException =>
+            throw new IllegalArgumentException(
+              s"Invalid Arrow $ArrowVectorDimensionMetadataKey metadata '$rawDimension' for vector '${vector.getName}'"
+            )
+        }
+      }
+
+    sparkDimension.orElse(arrowDimension).map { dimension =>
+      if (dimension <= 0 || dimension > Int.MaxValue) {
+        throw new IllegalArgumentException(
+          s"Invalid vector dimension $dimension for field '${field.name}'"
+        )
+      }
+      dimension.toInt
     }
   }
 }

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -11,12 +11,16 @@ import scala.collection.JavaConverters._
 import org.apache.arrow.vector._
 import org.apache.arrow.vector.complex.{ListVector, MapVector, StructVector}
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
+import org.apache.spark.sql.catalyst.util.{
+  ArrayBasedMapData,
+  ArrayData,
+  MapData
+}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import com.zilliz.spark.connector.FloatConverter
+import com.zilliz.spark.connector.{FloatConverter, SparseFloatVectorConverter}
 import io.milvus.grpc.schema.{DataType => MilvusDataType}
 
 /** Utilities for converting between Spark InternalRow and Arrow vectors
@@ -204,6 +208,21 @@ object ArrowConverter extends Logging {
             )
         }
 
+      case MapType(keyType, valueType, _) if isBinaryBackedVector(vector) =>
+        milvusType match {
+          case Some(MilvusDataType.SparseFloatVector) =>
+            requireSparseSparkTypes(keyType, valueType)
+            decodeSparseMap(binaryVectorBytes(vector, rowIndex))
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Cannot decode binary-backed vector as MapType for Milvus type $other"
+            )
+          case None =>
+            throw new IllegalArgumentException(
+              s"Binary-backed maps require ${MilvusDataTypeMetadataKey} metadata for SparseFloatVector"
+            )
+        }
+
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]
         val dataVector = mapVector.getDataVector.asInstanceOf[StructVector]
@@ -288,6 +307,47 @@ object ArrowConverter extends Logging {
     }.toArray
 
     ArrayData.toArrayData(arrayElements)
+  }
+
+  private def requireSparseSparkTypes(
+      keyType: DataType,
+      valueType: DataType
+  ): Unit = {
+    if (keyType != LongType || valueType != FloatType) {
+      throw new IllegalArgumentException(
+        s"SparseFloatVector requires MapType(LongType, FloatType), got MapType($keyType, $valueType)"
+      )
+    }
+  }
+
+  private def decodeSparseMap(bytes: Array[Byte]): ArrayBasedMapData = {
+    val entries = SparseFloatVectorConverter.decodeSparseFloatVector(bytes)
+    val keys = new Array[Any](entries.size)
+    val values = new Array[Any](entries.size)
+    entries.zipWithIndex.foreach { case ((index, value), entryIndex) =>
+      keys(entryIndex) = index
+      values(entryIndex) = value
+    }
+    ArrayBasedMapData(keys, values)
+  }
+
+  private def encodeSparseMap(
+      mapData: MapData,
+      keyType: DataType,
+      valueType: DataType
+  ): Array[Byte] = {
+    requireSparseSparkTypes(keyType, valueType)
+    val keys = mapData.keyArray()
+    val values = mapData.valueArray()
+    val entries = (0 until mapData.numElements()).map { index =>
+      if (keys.isNullAt(index) || values.isNullAt(index)) {
+        throw new IllegalArgumentException(
+          "SparseFloatVector map entries cannot contain null keys or values"
+        )
+      }
+      keys.getLong(index) -> values.getFloat(index)
+    }
+    SparseFloatVectorConverter.encodeSparseFloatVectorEntries(entries)
   }
 
   private def utf8StringFromVariableWidth(
@@ -674,6 +734,28 @@ object ArrowConverter extends Logging {
             vectorDimension
           )
         }
+
+      case MapType(keyType, valueType, _)
+          if milvusType.contains(MilvusDataType.SparseFloatVector) =>
+        if (!isBinaryBackedVector(vector)) {
+          throw new IllegalArgumentException(
+            s"SparseFloatVector MapType requires a binary-backed Arrow vector, got ${vector.getClass.getSimpleName}"
+          )
+        }
+        val bytes = encodeSparseMap(record.getMap(colIndex), keyType, valueType)
+        setBinaryVectorValue(
+          vector,
+          rowIndex,
+          bytes,
+          "SparseFloatVector MapType",
+          milvusType,
+          vectorDimension
+        )
+
+      case MapType(_, _, _) if isBinaryBackedVector(vector) =>
+        throw new IllegalArgumentException(
+          s"Binary-backed MapType requires ${MilvusDataTypeMetadataKey} metadata for SparseFloatVector"
+        )
 
       case MapType(keyType, valueType, _) =>
         val mapVector = vector.asInstanceOf[MapVector]

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -205,7 +205,11 @@ object ArrowConverter extends Logging {
             v.get(rowIndex)
           case v: FixedSizeBinaryVector =>
             milvusType match {
-              case Some(MilvusDataType.BinaryVector) =>
+              case Some(
+                    MilvusDataType.BinaryVector | MilvusDataType.FloatVector |
+                    MilvusDataType.Float16Vector |
+                    MilvusDataType.BFloat16Vector | MilvusDataType.Int8Vector
+                  ) =>
                 v.get(rowIndex)
               case Some(other) =>
                 throw new IllegalArgumentException(
@@ -213,7 +217,7 @@ object ArrowConverter extends Logging {
                 )
               case None =>
                 throw new IllegalArgumentException(
-                  s"FixedSizeBinary binary vectors require ${MilvusDataTypeMetadataKey} metadata for BinaryVector"
+                  s"FixedSizeBinary vectors require ${MilvusDataTypeMetadataKey} metadata"
                 )
             }
           case other =>
@@ -331,6 +335,7 @@ object ArrowConverter extends Logging {
   }
 
   val MilvusDataTypeMetadataKey = "milvus.data_type"
+  val MilvusVectorDimensionMetadataKey = "milvus.vector_dim"
 
   /** Set a value in an Arrow vector from a Spark InternalRow
     *
@@ -442,8 +447,16 @@ object ArrowConverter extends Logging {
         if (bytes == null) {
           vector.setNull(rowIndex)
         } else {
-          // See StringType above — setSafe grows the data buffer; set does not.
-          vector.asInstanceOf[VarBinaryVector].setSafe(rowIndex, bytes)
+          vector match {
+            case fixed: FixedSizeBinaryVector => fixed.set(rowIndex, bytes)
+            case variable: VarBinaryVector    =>
+              // See StringType above — setSafe grows the data buffer; set does not.
+              variable.setSafe(rowIndex, bytes)
+            case other =>
+              throw new IllegalArgumentException(
+                s"Cannot encode BinaryType into ${other.getClass.getSimpleName}"
+              )
+          }
         }
 
       case MapType(keyType, valueType, _) =>

--- a/src/main/scala/serde/ArrowConverter.scala
+++ b/src/main/scala/serde/ArrowConverter.scala
@@ -350,6 +350,19 @@ object ArrowConverter extends Logging {
     SparseFloatVectorConverter.encodeSparseFloatVectorEntries(entries)
   }
 
+  private def requireNonNullVectorArrayElement(
+      arrayData: ArrayData,
+      index: Int,
+      vector: FieldVector,
+      sparkType: String
+  ): Unit = {
+    if (arrayData.isNullAt(index)) {
+      throw new IllegalArgumentException(
+        s"Cannot encode $sparkType for vector '${vector.getName}': null element at index $index"
+      )
+    }
+  }
+
   private def utf8StringFromVariableWidth(
       vector: FieldVector,
       rowIndex: Int
@@ -602,9 +615,15 @@ object ArrowConverter extends Logging {
 
       case ArrayType(FloatType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
-        val floats = (0 until arrayData.numElements())
-          .map(i => arrayData.getFloat(i))
-          .toArray
+        val floats = (0 until arrayData.numElements()).map { i =>
+          requireNonNullVectorArrayElement(
+            arrayData,
+            i,
+            vector,
+            "Array[Float]"
+          )
+          arrayData.getFloat(i)
+        }.toArray
         val bytes = milvusType match {
           case Some(MilvusDataType.Float16Vector) =>
             floats.flatMap(value => FloatConverter.toFloat16Bytes(value))
@@ -628,9 +647,15 @@ object ArrowConverter extends Logging {
 
       case ArrayType(ShortType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
-        val values = (0 until arrayData.numElements())
-          .map(i => arrayData.getShort(i))
-          .toArray
+        val values = (0 until arrayData.numElements()).map { i =>
+          requireNonNullVectorArrayElement(
+            arrayData,
+            i,
+            vector,
+            "Array[Short]"
+          )
+          arrayData.getShort(i)
+        }.toArray
         val bytes = milvusType match {
           case Some(MilvusDataType.Int8Vector) =>
             values.map { value =>
@@ -661,9 +686,15 @@ object ArrowConverter extends Logging {
 
       case ArrayType(ByteType, _) if isBinaryBackedVector(vector) =>
         val arrayData = record.getArray(colIndex)
-        val bytes = (0 until arrayData.numElements())
-          .map(i => arrayData.getByte(i))
-          .toArray
+        val bytes = (0 until arrayData.numElements()).map { i =>
+          requireNonNullVectorArrayElement(
+            arrayData,
+            i,
+            vector,
+            "Array[Byte]"
+          )
+          arrayData.getByte(i)
+        }.toArray
         milvusType match {
           case Some(MilvusDataType.BinaryVector) =>
             setBinaryVectorValue(

--- a/src/main/scala/serde/DataTypeUtil.scala
+++ b/src/main/scala/serde/DataTypeUtil.scala
@@ -11,6 +11,38 @@ import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
 object DataTypeUtil {
 
+  private[connector] val DenseVectorTypes: Set[MilvusDataType] = Set(
+    MilvusDataType.FloatVector,
+    MilvusDataType.BinaryVector,
+    MilvusDataType.Float16Vector,
+    MilvusDataType.BFloat16Vector,
+    MilvusDataType.Int8Vector
+  )
+
+  private[connector] def isDenseVectorType(
+      dataType: MilvusDataType
+  ): Boolean = DenseVectorTypes.contains(dataType)
+
+  private[connector] def parseVectorDimension(
+      fieldName: String,
+      rawDimension: String
+  ): Long = {
+    val dimension =
+      try rawDimension.toLong
+      catch {
+        case _: NumberFormatException =>
+          throw new DataParseException(
+            s"Invalid vector dimension '$rawDimension' for field '$fieldName'"
+          )
+      }
+    if (dimension <= 0 || dimension > Int.MaxValue) {
+      throw new DataParseException(
+        s"Invalid vector dimension $dimension for field '$fieldName'"
+      )
+    }
+    dimension
+  }
+
   /** Converts Milvus DataType to Arrow type given dimension and element type
     */
   def toArrowType(dim: Int, dataType: MilvusDataType): ArrowType = {
@@ -49,12 +81,24 @@ object DataTypeUtil {
   }
 
   def metadata(fieldSchema: FieldSchema) = {
-    new MetadataBuilder()
+    val builder = new MetadataBuilder()
       .putLong(
         ArrowConverter.MilvusDataTypeMetadataKey,
         fieldSchema.dataType.value
       )
-      .build()
+
+    if (isDenseVectorType(fieldSchema.dataType)) {
+      fieldSchema.typeParams
+        .find(_.key == "dim")
+        .foreach { param =>
+          builder.putLong(
+            ArrowConverter.MilvusVectorDimensionMetadataKey,
+            parseVectorDimension(fieldSchema.name, param.value)
+          )
+        }
+    }
+
+    builder.build()
   }
 
   def toDataType(fieldSchema: FieldSchema): SparkDataType = {

--- a/src/main/scala/serde/SchemaUtil.scala
+++ b/src/main/scala/serde/SchemaUtil.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector
 
+import com.zilliz.spark.connector.serde.ArrowConverter
 import io.milvus.grpc.schema.{
   ArrayArray,
   BoolArray,
@@ -101,7 +102,7 @@ object MilvusSchemaUtil {
       collectionSchema: io.milvus.grpc.schema.CollectionSchema
   ): org.apache.arrow.vector.types.pojo.Schema = {
     import scala.collection.JavaConverters._
-    import org.apache.arrow.vector.types.pojo.{Field, FieldType}
+    import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType}
 
     val arrowFields = scala.collection.mutable.ArrayBuffer[Field]()
 
@@ -153,6 +154,32 @@ object MilvusSchemaUtil {
           // field.fieldID.toString,
           fieldType,
           null // children
+        )
+      } else if (
+        field.dataType == DataType.BinaryVector ||
+        field.dataType == DataType.FloatVector ||
+        field.dataType == DataType.Float16Vector ||
+        field.dataType == DataType.BFloat16Vector ||
+        field.dataType == DataType.Int8Vector ||
+        field.dataType == DataType.SparseFloatVector
+      ) {
+        val isDense = field.dataType != DataType.SparseFloatVector
+        val physicalType =
+          if (isDense && field.nullable) new ArrowType.Binary() else arrowType
+        val metadata = (Map(
+          "PARQUET:field_id" -> field.fieldID.toString
+        ) ++
+          (if (isDense && field.nullable) Map("dim" -> dim.toString)
+           else Map.empty)).asJava
+        new Field(
+          field.name,
+          new FieldType(
+            field.nullable,
+            physicalType,
+            null,
+            metadata
+          ),
+          null
         )
       } else {
         convertToArrowField(field, arrowType)
@@ -214,18 +241,32 @@ object MilvusSchemaUtil {
       }
 
       val arrowType = DataTypeUtil.toArrowType(dim, field.dataType)
+      val isDenseVector = field.dataType match {
+        case DataType.BinaryVector | DataType.FloatVector |
+            DataType.Float16Vector | DataType.BFloat16Vector |
+            DataType.Int8Vector =>
+          true
+        case _ => false
+      }
+      val isVector =
+        isDenseVector || field.dataType == DataType.SparseFloatVector
+      val physicalType =
+        if (isDenseVector && field.nullable) new ArrowType.Binary()
+        else arrowType
 
       // Create metadata with both field_id and original name for reference
       val metadata = Map(
         "PARQUET:field_id" -> field.fieldID.toString,
         "original_name" -> field.name
-      ).asJava
+      ) ++
+        (if (isDenseVector && field.nullable) Map("dim" -> dim.toString)
+         else Map.empty)
 
       val fieldType = new FieldType(
-        true, // nullable
-        arrowType,
+        if (isVector) field.nullable else true,
+        physicalType,
         null, // dictionary encoding
-        metadata
+        metadata.asJava
       )
 
       // Use fieldID.toString as the field name
@@ -277,48 +318,109 @@ object MilvusSchemaUtil {
     import org.apache.spark.sql.types._
     import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType}
     import org.apache.arrow.vector.types.FloatingPointPrecision
+    import io.milvus.grpc.schema.{DataType => MilvusDataType}
+
+    val denseVectorTypes: Set[MilvusDataType] = Set(
+      MilvusDataType.FloatVector,
+      MilvusDataType.BinaryVector,
+      MilvusDataType.Float16Vector,
+      MilvusDataType.BFloat16Vector,
+      MilvusDataType.Int8Vector
+    )
+    val vectorTypes: Set[MilvusDataType] =
+      denseVectorTypes + MilvusDataType.SparseFloatVector
+
+    def milvusVectorType(field: StructField): Option[MilvusDataType] =
+      Option(field.metadata)
+        .filter(_.contains(ArrowConverter.MilvusDataTypeMetadataKey))
+        .map(
+          _.getLong(ArrowConverter.MilvusDataTypeMetadataKey).toInt
+        )
+        .map(MilvusDataType.fromValue)
+        .filter(vectorTypes.contains)
+
+    def vectorDimension(
+        field: StructField,
+        milvusType: MilvusDataType
+    ): Int =
+      if (!denseVectorTypes.contains(milvusType)) 0
+      else {
+        Option(field.metadata)
+          .filter(
+            _.contains(ArrowConverter.MilvusVectorDimensionMetadataKey)
+          )
+          .map(
+            _.getLong(ArrowConverter.MilvusVectorDimensionMetadataKey).toInt
+          )
+          .orElse(vectorDimensions.get(field.name))
+          .filter(_ > 0)
+          .getOrElse {
+            throw new IllegalArgumentException(
+              s"Milvus vector field '${field.name}' ($milvusType) requires positive ${ArrowConverter.MilvusVectorDimensionMetadataKey} metadata or vectorDimensions entry"
+            )
+          }
+      }
 
     val fields = sparkSchema.fields.zipWithIndex.map { case (field, idx) =>
-      val arrowType: ArrowType = field.dataType match {
-        case LongType    => new ArrowType.Int(64, true)
-        case IntegerType => new ArrowType.Int(32, true)
-        case ShortType   => new ArrowType.Int(16, true)
-        case ByteType    => new ArrowType.Int(8, true)
-        case FloatType =>
-          new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
-        case DoubleType =>
-          new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
-        case BooleanType             => new ArrowType.Bool()
-        case StringType              => new ArrowType.Utf8()
-        case BinaryType              => new ArrowType.Binary()
-        case ArrayType(FloatType, _) =>
-          // Check if this field is a vector (has dimension specified)
-          vectorDimensions.get(field.name) match {
-            case Some(dim) =>
-              // FloatVector as FixedSizeBinary (dim * 4 bytes)
-              new ArrowType.FixedSizeBinary(dim * 4)
-            case None =>
-              // Regular float array as List
-              new ArrowType.List()
-          }
-        case ArrayType(IntegerType, _) => new ArrowType.List()
-        case ArrayType(LongType, _)    => new ArrowType.List()
-        case ArrayType(DoubleType, _)  => new ArrowType.List()
-        case ArrayType(StringType, _)  => new ArrowType.List()
-        case ArrayType(_, _)           => new ArrowType.List()
-        case MapType(_, _, _)          => new ArrowType.Map(false)
-        case StructType(_)             => new ArrowType.Struct()
+      val vectorType = milvusVectorType(field)
+      val dim = vectorType.map(vectorDimension(field, _)).getOrElse(0)
+      val arrowType: ArrowType = vectorType match {
+        case Some(milvusType) if denseVectorTypes.contains(milvusType) =>
+          // Milvus uses variable-width Binary for nullable dense vectors so a
+          // null row does not have to carry a fixed-width payload. Non-nullable
+          // dense vectors use their exact FixedSizeBinary width.
+          if (field.nullable) new ArrowType.Binary()
+          else DataTypeUtil.toArrowType(dim, milvusType)
+        case Some(MilvusDataType.SparseFloatVector) =>
+          new ArrowType.Binary()
         case _ =>
-          throw new IllegalArgumentException(
-            s"Unsupported Spark type: ${field.dataType}"
-          )
+          field.dataType match {
+            case LongType    => new ArrowType.Int(64, true)
+            case IntegerType => new ArrowType.Int(32, true)
+            case ShortType   => new ArrowType.Int(16, true)
+            case ByteType    => new ArrowType.Int(8, true)
+            case FloatType =>
+              new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
+            case DoubleType =>
+              new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
+            case BooleanType             => new ArrowType.Bool()
+            case StringType              => new ArrowType.Utf8()
+            case BinaryType              => new ArrowType.Binary()
+            case ArrayType(FloatType, _) =>
+              // Legacy/general writer path: vector dimensions supplied via
+              // options identify Array[Float] as FloatVector.
+              vectorDimensions.get(field.name) match {
+                case Some(vectorDim) =>
+                  new ArrowType.FixedSizeBinary(vectorDim * 4)
+                case None =>
+                  new ArrowType.List()
+              }
+            case ArrayType(IntegerType, _) => new ArrowType.List()
+            case ArrayType(LongType, _)    => new ArrowType.List()
+            case ArrayType(DoubleType, _)  => new ArrowType.List()
+            case ArrayType(StringType, _)  => new ArrowType.List()
+            case ArrayType(_, _)           => new ArrowType.List()
+            case MapType(_, _, _)          => new ArrowType.Map(false)
+            case StructType(_)             => new ArrowType.Struct()
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Unsupported Spark type: ${field.dataType}"
+              )
+          }
       }
 
       // Use explicit field ID if provided, otherwise avoid Milvus system IDs 0/1.
       val fieldId = fieldIds.getOrElse(field.name, (idx + 100).toLong)
-      val metadata = Map("PARQUET:field_id" -> fieldId.toString).asJava
+      val metadata = (Map("PARQUET:field_id" -> fieldId.toString) ++
+        vectorType
+          .filter(denseVectorTypes.contains)
+          .filter(_ => field.nullable)
+          .map(_ => Map("dim" -> dim.toString))
+          .getOrElse(Map.empty)).asJava
 
-      val fieldType = new FieldType(true, arrowType, null, metadata)
+      val arrowNullable = if (vectorType.isDefined) field.nullable else true
+      val fieldType =
+        new FieldType(arrowNullable, arrowType, null, metadata)
       val fieldName =
         if (useFieldIdAsName && fieldIds.contains(field.name))
           fieldId.toString

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -353,22 +353,53 @@ case class MilvusTable(
   private def rehydrateSnapshotSchemaMetadata(
       baseSchema: StructType
   ): StructType = {
-    val fieldTypeByName = milvusCollection.schema.fields.map { field =>
-      field.name -> field.dataType.value.toLong
+    val collectionFieldByName = milvusCollection.schema.fields.map { field =>
+      field.name -> field
     }.toMap
 
     val fields = baseSchema.fields.map { field =>
-      if (
-        milvusOption.extraColumns.contains(field.name) ||
-        field.metadata.contains(ArrowConverter.MilvusDataTypeMetadataKey)
-      ) {
+      if (milvusOption.extraColumns.contains(field.name)) {
         field
       } else {
-        fieldTypeByName.get(field.name) match {
-          case Some(milvusType) =>
+        collectionFieldByName.get(field.name) match {
+          case Some(collectionField) =>
+            val collectionMetadata = DataTypeUtil.metadata(collectionField)
             val metadataBuilder = new MetadataBuilder()
               .withMetadata(field.metadata)
-              .putLong(ArrowConverter.MilvusDataTypeMetadataKey, milvusType)
+
+            if (
+              !field.metadata.contains(ArrowConverter.MilvusDataTypeMetadataKey)
+            ) {
+              metadataBuilder.putLong(
+                ArrowConverter.MilvusDataTypeMetadataKey,
+                collectionMetadata.getLong(
+                  ArrowConverter.MilvusDataTypeMetadataKey
+                )
+              )
+            }
+            val existingTypeMatchesCollection =
+              !field.metadata.contains(
+                ArrowConverter.MilvusDataTypeMetadataKey
+              ) || field.metadata.getLong(
+                ArrowConverter.MilvusDataTypeMetadataKey
+              ) == collectionMetadata.getLong(
+                ArrowConverter.MilvusDataTypeMetadataKey
+              )
+            if (
+              collectionMetadata.contains(
+                ArrowConverter.MilvusVectorDimensionMetadataKey
+              ) && !field.metadata.contains(
+                ArrowConverter.MilvusVectorDimensionMetadataKey
+              ) && existingTypeMatchesCollection
+            ) {
+              metadataBuilder.putLong(
+                ArrowConverter.MilvusVectorDimensionMetadataKey,
+                collectionMetadata.getLong(
+                  ArrowConverter.MilvusVectorDimensionMetadataKey
+                )
+              )
+            }
+
             field.copy(metadata = metadataBuilder.build())
           case None =>
             field

--- a/src/main/scala/write/MilvusLoonWriter.scala
+++ b/src/main/scala/write/MilvusLoonWriter.scala
@@ -34,9 +34,10 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.unsafe.types.UTF8String
 
-import com.zilliz.spark.connector.{MilvusOption, MilvusSchemaUtil}
+import com.zilliz.spark.connector.{DataTypeUtil, MilvusOption, MilvusSchemaUtil}
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.serde.ArrowConverter
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
 import io.milvus.storage.{
   ArrowUtils,
   MilvusStorageProperties,
@@ -521,8 +522,9 @@ class MilvusLoonPartitionWriter(
     s"$bucket/$rootPath/spark_write/$collectionName/$partitionName/$timestamp/task_${partitionId}_$taskId"
   }
 
-  /** Extract vector dimensions from MilvusOption for vector fields Vector
-    * fields are identified as Array[Float] in Spark schema
+  /** Extract vector dimensions from MilvusOption for vector fields. Vector
+    * metadata identifies all current dense vector types; Array[Float] remains
+    * as the legacy FloatVector fallback.
     */
   private def extractVectorDimensions(
       schema: StructType,
@@ -532,9 +534,17 @@ class MilvusLoonPartitionWriter(
     // Format: vector.field_name.dim = dimension_value
     val vectorFields = schema.fields.collect {
       case field
-          if field.dataType.isInstanceOf[ArrayType] &&
-            field.dataType.asInstanceOf[ArrayType].elementType == FloatType =>
+          if field.metadata.contains(
+            ArrowConverter.MilvusDataTypeMetadataKey
+          ) && DataTypeUtil.isDenseVectorType(
+            MilvusDataType.fromValue(
+              field.metadata
+                .getLong(ArrowConverter.MilvusDataTypeMetadataKey)
+                .toInt
+            )
+          ) =>
         field.name
+      case field @ StructField(_, ArrayType(FloatType, _), _, _) => field.name
     }
 
     vectorFields.flatMap { fieldName =>

--- a/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
+++ b/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import com.zilliz.spark.connector.read.{Field, TypeParam}
 import com.zilliz.spark.connector.serde.ArrowConverter
+import com.zilliz.spark.connector.FloatConverter
 import io.milvus.grpc.schema.{DataType => MilvusDataType}
 
 class VectorBackfillSupportTest
@@ -155,6 +156,17 @@ class VectorBackfillSupportTest
       "[0.11111,0.22222]",
       encodedHalfBytes = false
     ) shouldBe Array[Byte](0x1c, 0x2f, 0x1c, 0x33)
+
+    val rounded = Array[Byte](0xcd.toByte, 0x34, 0x9a.toByte, 0x39)
+    FloatConverter.toFloat16Bytes(0.3f).toArray ++
+      FloatConverter.toFloat16Bytes(0.7f).toArray shouldBe rounded
+    VectorBackfillSupport.encodeDenseJsonArray(
+      "float16",
+      MilvusDataType.Float16Vector,
+      2,
+      "[0.3,0.7]",
+      encodedHalfBytes = false
+    ) shouldBe rounded
   }
 
   test("rejects negative sparse weights like Milvus validation") {

--- a/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
+++ b/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
@@ -1,0 +1,218 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import com.fasterxml.jackson.databind.node.IntNode
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.types._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+import com.zilliz.spark.connector.read.{Field, TypeParam}
+import com.zilliz.spark.connector.serde.ArrowConverter
+import io.milvus.grpc.schema.{DataType => MilvusDataType}
+
+class VectorBackfillSupportTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    spark = SparkSession
+      .builder()
+      .appName("VectorBackfillSupportTest")
+      .master("local[1]")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  private def vectorField(
+      name: String,
+      dataType: MilvusDataType,
+      dim: Option[Int] = None,
+      nullable: Boolean = false
+  ): Field =
+    Field(
+      name = name,
+      rawDataType = Some(IntNode.valueOf(dataType.value)),
+      typeParams = dim.map(value => Seq(TypeParam("dim", value.toString))),
+      nullable = Some(nullable)
+    )
+
+  test("normalizes common parquet vector shapes to Milvus internal bytes") {
+    val schema = StructType(
+      Seq(
+        StructField("pk", LongType, nullable = false),
+        StructField("float_vec", ArrayType(DoubleType), nullable = false),
+        StructField("binary_vec", ArrayType(ShortType), nullable = false),
+        StructField("float16_vec", ArrayType(FloatType), nullable = false),
+        StructField("bfloat16_vec", ArrayType(ShortType), nullable = false),
+        StructField("int8_vec", ArrayType(IntegerType), nullable = false),
+        StructField(
+          "sparse_vec",
+          MapType(StringType, DoubleType),
+          nullable = false
+        )
+      )
+    )
+    val row = Row(
+      1L,
+      Seq(1.25d, -2.5d),
+      Seq[Short](0, 255),
+      Seq(1.5f, -2.0f),
+      Seq[Short](192, 63, 0, 192),
+      Seq(-128, 127),
+      Map("3" -> 2.5d, "1" -> 1.25d)
+    )
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(row)),
+      schema
+    )
+
+    val targets = Seq(
+      vectorField("float_vec", MilvusDataType.FloatVector, Some(2)),
+      vectorField("binary_vec", MilvusDataType.BinaryVector, Some(16)),
+      vectorField("float16_vec", MilvusDataType.Float16Vector, Some(2)),
+      vectorField("bfloat16_vec", MilvusDataType.BFloat16Vector, Some(2)),
+      vectorField("int8_vec", MilvusDataType.Int8Vector, Some(2)),
+      vectorField("sparse_vec", MilvusDataType.SparseFloatVector)
+    ).map(field => field.name -> field).toMap
+
+    val normalized = VectorBackfillSupport
+      .normalizeVectorColumns(df, targets)
+      .toOption
+      .get
+
+    targets.keys.foreach { name =>
+      normalized.schema(name).dataType shouldBe BinaryType
+      normalized
+        .schema(name)
+        .metadata
+        .getLong(ArrowConverter.MilvusDataTypeMetadataKey) shouldBe
+        targets(name).dataType.toLong
+    }
+    normalized
+      .schema("float_vec")
+      .metadata
+      .getLong(ArrowConverter.MilvusVectorDimensionMetadataKey) shouldBe 2L
+
+    val result = normalized.head()
+    result.getAs[Array[Byte]]("float_vec") shouldBe ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.25f)
+      .putFloat(-2.5f)
+      .array()
+    result.getAs[Array[Byte]]("binary_vec") shouldBe Array[Byte](0, -1)
+    result.getAs[Array[Byte]]("float16_vec") shouldBe
+      VectorBackfillSupport.encodeDenseJsonArray(
+        "float16_vec",
+        MilvusDataType.Float16Vector,
+        2,
+        "[1.5,-2.0]",
+        encodedHalfBytes = false
+      )
+    result.getAs[Array[Byte]]("bfloat16_vec") shouldBe
+      Array[Byte](192.toByte, 63.toByte, 0.toByte, 192.toByte)
+    result.getAs[Array[Byte]]("int8_vec") shouldBe Array[Byte](-128, 127)
+    result.getAs[Array[Byte]]("sparse_vec") shouldBe
+      VectorBackfillSupport.encodeSparseJson(
+        "sparse_vec",
+        """{"1":1.25,"3":2.5}"""
+      )
+  }
+
+  test("sparse map JSON and indices-values struct encode identically") {
+    val mapBytes = VectorBackfillSupport.encodeSparseJson(
+      "sparse",
+      """{"5":3.0,"1":2.0}"""
+    )
+    val structBytes = VectorBackfillSupport.encodeSparseJson(
+      "sparse",
+      """{"indices":[5,1],"values":[3.0,2.0]}"""
+    )
+
+    structBytes shouldBe mapBytes
+    val buffer = ByteBuffer.wrap(mapBytes).order(ByteOrder.LITTLE_ENDIAN)
+    (buffer.getInt() & 0xffffffffL) shouldBe 1L
+    buffer.getFloat() shouldBe 2.0f
+    (buffer.getInt() & 0xffffffffL) shouldBe 5L
+    buffer.getFloat() shouldBe 3.0f
+  }
+
+  test("Float16 conversion matches Milvus round-to-nearest byte layout") {
+    VectorBackfillSupport.encodeDenseJsonArray(
+      "float16",
+      MilvusDataType.Float16Vector,
+      2,
+      "[0.11111,0.22222]",
+      encodedHalfBytes = false
+    ) shouldBe Array[Byte](0x1c, 0x2f, 0x1c, 0x33)
+  }
+
+  test("rejects negative sparse weights like Milvus validation") {
+    val error = intercept[IllegalArgumentException] {
+      VectorBackfillSupport.encodeSparseJson(
+        "sparse",
+        """{"1":-0.5}"""
+      )
+    }
+    error.getMessage should include("non-negative")
+  }
+
+  test("internal binary vectors are validated before write") {
+    val valid = ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.0f)
+      .putFloat(2.0f)
+      .array()
+
+    VectorBackfillSupport.validateInternalBytes(
+      "vec",
+      MilvusDataType.FloatVector,
+      2,
+      valid
+    ) shouldBe valid
+
+    val error = intercept[IllegalArgumentException] {
+      VectorBackfillSupport.validateInternalBytes(
+        "vec",
+        MilvusDataType.FloatVector,
+        2,
+        valid.dropRight(1)
+      )
+    }
+    error.getMessage should include("byte-width mismatch")
+  }
+
+  test("rejects incompatible user shape with accepted-format guidance") {
+    val schema = StructType(
+      Seq(StructField("binary_vec", ArrayType(DoubleType), nullable = false))
+    )
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(Seq(1.0d, 2.0d)))),
+      schema
+    )
+    val target = vectorField(
+      "binary_vec",
+      MilvusDataType.BinaryVector,
+      Some(16)
+    )
+
+    val error = VectorBackfillSupport
+      .normalizeVectorColumns(df, Map(target.name -> target))
+      .left
+      .toOption
+      .get
+    error.message should include("array<double>")
+    error.message should include("array<integral byte>")
+  }
+}

--- a/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
+++ b/src/test/scala/operations/backfill/VectorBackfillSupportTest.scala
@@ -167,6 +167,21 @@ class VectorBackfillSupportTest
       "[0.3,0.7]",
       encodedHalfBytes = false
     ) shouldBe rounded
+
+    val maxFinite = Array[Byte](0xff.toByte, 0x7b)
+    FloatConverter.toFloat16Bytes(65510.0f).toArray shouldBe maxFinite
+    VectorBackfillSupport.encodeDenseJsonArray(
+      "float16",
+      MilvusDataType.Float16Vector,
+      1,
+      "[65510]",
+      encodedHalfBytes = false
+    ) shouldBe maxFinite
+
+    val overflow = intercept[com.zilliz.spark.connector.DataParseException] {
+      FloatConverter.toFloat16Bytes(65520.0f)
+    }
+    overflow.getMessage should include("float16 range")
   }
 
   test("rejects negative sparse weights like Milvus validation") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -1030,10 +1030,26 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     sparkSchema("binary_vec").metadata.getLong(
       com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
     ) shouldBe 100L
+    sparkSchema("binary_vec").metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusVectorDimensionMetadataKey
+    ) shouldBe 128L
     sparkSchema("int8_vec").dataType shouldBe ArrayType(ShortType)
     sparkSchema("int8_vec").metadata.getLong(
       com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
     ) shouldBe 105L
+    sparkSchema("int8_vec").metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusVectorDimensionMetadataKey
+    ) shouldBe 4L
+
+    import scala.collection.JavaConverters._
+    val arrowFields = com.zilliz.spark.connector.MilvusSchemaUtil
+      .convertSparkSchemaToArrow(sparkSchema)
+      .getFields
+      .asScala
+      .map(field => field.getName -> field)
+      .toMap
+    arrowFields("binary_vec").getMetadata.get("dim") shouldBe "128"
+    arrowFields("int8_vec").getMetadata.get("dim") shouldBe "4"
   }
 
   test("fieldToStructField preserves milvus.data_type metadata") {
@@ -1041,6 +1057,7 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
       name = "binary_vec",
       rawDataType =
         Some(com.fasterxml.jackson.databind.node.IntNode.valueOf(100)),
+      typeParams = Some(Seq(TypeParam("dim", "128"))),
       nullable = Some(false)
     )
 
@@ -1052,5 +1069,8 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     structField.metadata.getLong(
       com.zilliz.spark.connector.serde.ArrowConverter.MilvusDataTypeMetadataKey
     ) shouldBe 100L
+    structField.metadata.getLong(
+      com.zilliz.spark.connector.serde.ArrowConverter.MilvusVectorDimensionMetadataKey
+    ) shouldBe 128L
   }
 }

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -398,6 +398,57 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
     } finally allocator.close()
   }
 
+  test("internalRowToArrow rejects null dense vector array elements") {
+    def reject(field: StructField, value: ArrayData): Unit = {
+      val sparkSchema = StructType(Seq(field))
+      val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema)
+      val allocator = new RootAllocator(Long.MaxValue)
+      try {
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        try {
+          root.allocateNew()
+          val error = intercept[IllegalArgumentException] {
+            ArrowConverter.internalRowToArrow(
+              root,
+              0,
+              InternalRow(value),
+              sparkSchema
+            )
+          }
+          error.getMessage should include("null element at index 1")
+        } finally root.close()
+      } finally allocator.close()
+    }
+
+    reject(
+      vectorField(
+        "float",
+        ArrayType(FloatType, containsNull = true),
+        MilvusDataType.FloatVector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(Array[Any](1.0f, null))
+    )
+    reject(
+      vectorField(
+        "int8",
+        ArrayType(ShortType, containsNull = true),
+        MilvusDataType.Int8Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(Array[Any](1.toShort, null))
+    )
+    reject(
+      vectorField(
+        "binary",
+        ArrayType(ByteType, containsNull = true),
+        MilvusDataType.BinaryVector,
+        Some(16)
+      ),
+      ArrayData.toArrayData(Array[Any](1.toByte, null))
+    )
+  }
+
   test("arrowToInternalRow decodes nullable dense vectors from VarBinary") {
     val floats = Array(1.5f, -2.0f)
     val floatBytes = ByteBuffer

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -259,6 +259,139 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
     ) shouldBe Array[Byte](-128, -1, 0, 127)
   }
 
+  test("internalRowToArrow rejects wrong-width nullable dense vectors") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+
+    def reject(
+        field: StructField,
+        value: Any,
+        expectedBytes: Int,
+        actualBytes: Int,
+        vectorDimensions: Map[String, Int] = Map.empty
+    ): Unit = {
+      val sparkSchema = StructType(Seq(field))
+      val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(
+        sparkSchema,
+        vectorDimensions
+      )
+      val allocator = new RootAllocator(Long.MaxValue)
+      try {
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        try {
+          root.allocateNew()
+          val error = intercept[IllegalArgumentException] {
+            ArrowConverter.internalRowToArrow(
+              root,
+              0,
+              InternalRow.fromSeq(Seq(value)),
+              sparkSchema
+            )
+          }
+          error.getMessage should include(s"expected $expectedBytes bytes")
+          error.getMessage should include(s"got $actualBytes")
+        } finally root.close()
+      } finally allocator.close()
+    }
+
+    // No Spark dimension metadata here: exercise the Arrow `dim` metadata
+    // emitted from the normal writer's vectorDimensions option.
+    reject(
+      vectorField(
+        "float",
+        ArrayType(FloatType),
+        MilvusDataType.FloatVector
+      ),
+      ArrayData.toArrayData(Array(1.0f)),
+      expectedBytes = 8,
+      actualBytes = 4,
+      vectorDimensions = Map("float" -> 2)
+    )
+    reject(
+      vectorField(
+        "float16",
+        ArrayType(FloatType),
+        MilvusDataType.Float16Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(Array(1.0f)),
+      expectedBytes = 4,
+      actualBytes = 2
+    )
+    reject(
+      vectorField(
+        "bfloat16",
+        ArrayType(FloatType),
+        MilvusDataType.BFloat16Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(Array(1.0f)),
+      expectedBytes = 4,
+      actualBytes = 2
+    )
+    reject(
+      vectorField(
+        "int8",
+        ArrayType(ShortType),
+        MilvusDataType.Int8Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(Array[Short](1)),
+      expectedBytes = 2,
+      actualBytes = 1
+    )
+    reject(
+      vectorField(
+        "binary_array",
+        ArrayType(ByteType),
+        MilvusDataType.BinaryVector,
+        Some(16)
+      ),
+      ArrayData.toArrayData(Array[Byte](1)),
+      expectedBytes = 2,
+      actualBytes = 1
+    )
+    reject(
+      vectorField(
+        "binary_bytes",
+        BinaryType,
+        MilvusDataType.BinaryVector,
+        Some(16)
+      ),
+      Array[Byte](1),
+      expectedBytes = 2,
+      actualBytes = 1
+    )
+  }
+
+  test("internalRowToArrow rejects non-byte-aligned BinaryVector dimension") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+
+    val field = vectorField(
+      "binary",
+      BinaryType,
+      MilvusDataType.BinaryVector,
+      Some(10)
+    )
+    val sparkSchema = StructType(Seq(field))
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema)
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val root = VectorSchemaRoot.create(arrowSchema, allocator)
+      try {
+        root.allocateNew()
+        val error = intercept[IllegalArgumentException] {
+          ArrowConverter.internalRowToArrow(
+            root,
+            0,
+            InternalRow(Array[Byte](1, 2)),
+            sparkSchema
+          )
+        }
+        error.getMessage should include("multiple of 8")
+      } finally root.close()
+    } finally allocator.close()
+  }
+
   test("arrowToInternalRow decodes nullable dense vectors from VarBinary") {
     val floats = Array(1.5f, -2.0f)
     val floatBytes = ByteBuffer

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -11,13 +11,15 @@ import org.apache.arrow.vector.{
   VectorSchemaRoot
 }
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
-import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.{
   ArrayType,
   BinaryType,
   ByteType,
   FloatType,
+  LongType,
+  MapType,
   MetadataBuilder,
   ShortType,
   StringType,
@@ -27,7 +29,11 @@ import org.apache.spark.sql.types.{
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import com.zilliz.spark.connector.FloatConverter
+import com.zilliz.spark.connector.{
+  FloatConverter,
+  MilvusSchemaUtil,
+  SparseFloatVectorConverter
+}
 import io.milvus.grpc.schema.{DataType => MilvusDataType}
 
 class ArrowConverterTest extends AnyFunSuite with Matchers {
@@ -449,6 +455,90 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
       )
       row.getArray(0).toShortArray shouldBe int8Bytes.map(_.toShort)
     }
+  }
+
+  test("internalRowToArrow round-trips SparseFloatVector MapType as Binary") {
+    val field = vectorField(
+      "sparse",
+      MapType(LongType, FloatType, valueContainsNull = false),
+      MilvusDataType.SparseFloatVector
+    )
+    val sparkSchema = StructType(Seq(field))
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema)
+    arrowSchema.findField("sparse").getType shouldBe new ArrowType.Binary()
+
+    val mapData = ArrayBasedMapData(
+      Array[Any](3L, 1L),
+      Array[Any](2.5f, 1.25f)
+    )
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val root = VectorSchemaRoot.create(arrowSchema, allocator)
+      try {
+        root.allocateNew()
+        ArrowConverter.internalRowToArrow(
+          root,
+          0,
+          InternalRow(mapData),
+          sparkSchema
+        )
+        val vector = root.getVector("sparse").asInstanceOf[VarBinaryVector]
+        vector.setValueCount(1)
+        root.setRowCount(1)
+
+        vector.get(0) shouldBe SparseFloatVectorConverter
+          .encodeSparseFloatVector(Map(1L -> 1.25f, 3L -> 2.5f))
+
+        val decoded = ArrowConverter
+          .arrowToInternalRow(root, 0, sparkSchema)
+          .getMap(0)
+        decoded.keyArray().toLongArray shouldBe Array(1L, 3L)
+        decoded.valueArray().toFloatArray shouldBe Array(1.25f, 2.5f)
+      } finally root.close()
+    } finally allocator.close()
+  }
+
+  test("SparseFloatVector binary conversion validates malformed values") {
+    val field = vectorField(
+      "sparse",
+      MapType(LongType, FloatType, valueContainsNull = false),
+      MilvusDataType.SparseFloatVector
+    )
+    val sparkSchema = StructType(Seq(field))
+
+    withVariableWidthRoot(
+      "sparse",
+      new ArrowType.Binary(),
+      Array[Byte](1)
+    ) { root =>
+      val error = intercept[com.zilliz.spark.connector.DataParseException] {
+        ArrowConverter.arrowToInternalRow(root, 0, sparkSchema)
+      }
+      error.getMessage should include("multiple of 8")
+    }
+
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema)
+    val allocator = new RootAllocator(Long.MaxValue)
+    try {
+      val root = VectorSchemaRoot.create(arrowSchema, allocator)
+      try {
+        root.allocateNew()
+        val error = intercept[com.zilliz.spark.connector.DataParseException] {
+          ArrowConverter.internalRowToArrow(
+            root,
+            0,
+            InternalRow(
+              ArrayBasedMapData(
+                Array[Any](1L),
+                Array[Any](-0.5f)
+              )
+            ),
+            sparkSchema
+          )
+        }
+        error.getMessage should include("non-negative")
+      } finally root.close()
+    } finally allocator.close()
   }
 
   test("arrowToInternalRow decodes valid UTF-8 from VarBinary as StringType") {

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.serde
 
+import java.nio.{ByteBuffer, ByteOrder}
 import scala.collection.JavaConverters._
 
 import org.apache.arrow.memory.RootAllocator
@@ -94,15 +95,22 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
   private def vectorField(
       name: String,
       sparkType: org.apache.spark.sql.types.DataType,
-      milvusType: MilvusDataType
+      milvusType: MilvusDataType,
+      dimension: Option[Int] = None
   ): StructField = {
+    val metadata = new MetadataBuilder()
+      .putLong(ArrowConverter.MilvusDataTypeMetadataKey, milvusType.value)
+    dimension.foreach(value =>
+      metadata.putLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey,
+        value
+      )
+    )
     StructField(
       name,
       sparkType,
       nullable = true,
-      metadata = new MetadataBuilder()
-        .putLong(ArrowConverter.MilvusDataTypeMetadataKey, milvusType.value)
-        .build()
+      metadata = metadata.build()
     )
   }
 
@@ -168,6 +176,145 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
           }
         } finally root.close()
       } finally allocator.close()
+    }
+  }
+
+  test("internalRowToArrow writes nullable dense arrays to VarBinary") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+
+    def write(
+        field: StructField,
+        value: ArrayData
+    ): Array[Byte] = {
+      val sparkSchema = StructType(Seq(field))
+      val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(sparkSchema)
+      val allocator = new RootAllocator(Long.MaxValue)
+      try {
+        val root = VectorSchemaRoot.create(arrowSchema, allocator)
+        try {
+          root.allocateNew()
+          ArrowConverter.internalRowToArrow(
+            root,
+            0,
+            InternalRow.fromSeq(Seq(value)),
+            sparkSchema
+          )
+          ArrowConverter.internalRowToArrow(
+            root,
+            1,
+            InternalRow.fromSeq(Seq(null)),
+            sparkSchema
+          )
+          val vector = root.getVector(field.name).asInstanceOf[VarBinaryVector]
+          vector.setValueCount(2)
+          vector.isNull(1) shouldBe true
+          vector.get(0)
+        } finally root.close()
+      } finally allocator.close()
+    }
+
+    val floats = Array(1.5f, -2.0f)
+    val floatBytes = ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putFloat(floats(0))
+      .putFloat(floats(1))
+      .array()
+
+    write(
+      vectorField(
+        "float",
+        ArrayType(FloatType),
+        MilvusDataType.FloatVector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(floats)
+    ) shouldBe floatBytes
+    write(
+      vectorField(
+        "float16",
+        ArrayType(FloatType),
+        MilvusDataType.Float16Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(floats)
+    ) shouldBe floats.flatMap(FloatConverter.toFloat16Bytes)
+    write(
+      vectorField(
+        "bfloat16",
+        ArrayType(FloatType),
+        MilvusDataType.BFloat16Vector,
+        Some(2)
+      ),
+      ArrayData.toArrayData(floats)
+    ) shouldBe floats.flatMap(FloatConverter.toBFloat16Bytes)
+    write(
+      vectorField(
+        "int8",
+        ArrayType(ShortType),
+        MilvusDataType.Int8Vector,
+        Some(4)
+      ),
+      ArrayData.toArrayData(Array[Short](-128, -1, 0, 127))
+    ) shouldBe Array[Byte](-128, -1, 0, 127)
+  }
+
+  test("arrowToInternalRow decodes nullable dense vectors from VarBinary") {
+    val floats = Array(1.5f, -2.0f)
+    val floatBytes = ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putFloat(floats(0))
+      .putFloat(floats(1))
+      .array()
+
+    def readFloats(
+        name: String,
+        bytes: Array[Byte],
+        milvusType: MilvusDataType
+    ): Array[Float] = {
+      var result: Array[Float] = null
+      withVariableWidthRoot(name, new ArrowType.Binary(), bytes) { root =>
+        val row = ArrowConverter.arrowToInternalRow(
+          root,
+          0,
+          StructType(
+            Seq(vectorField(name, ArrayType(FloatType), milvusType))
+          )
+        )
+        result = row.getArray(0).toFloatArray
+      }
+      result
+    }
+
+    readFloats("float", floatBytes, MilvusDataType.FloatVector) shouldBe floats
+    readFloats(
+      "float16",
+      floats.flatMap(FloatConverter.toFloat16Bytes),
+      MilvusDataType.Float16Vector
+    ) shouldBe floats
+    readFloats(
+      "bfloat16",
+      floats.flatMap(FloatConverter.toBFloat16Bytes),
+      MilvusDataType.BFloat16Vector
+    ) shouldBe floats
+
+    val int8Bytes = Array[Byte](-128, -1, 0, 127)
+    withVariableWidthRoot("int8", new ArrowType.Binary(), int8Bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(
+            vectorField(
+              "int8",
+              ArrayType(ShortType),
+              MilvusDataType.Int8Vector
+            )
+          )
+        )
+      )
+      row.getArray(0).toShortArray shouldBe int8Bytes.map(_.toShort)
     }
   }
 

--- a/src/test/scala/serde/ArrowConverterTest.scala
+++ b/src/test/scala/serde/ArrowConverterTest.scala
@@ -11,6 +11,7 @@ import org.apache.arrow.vector.{
 }
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.{
   ArrayType,
   BinaryType,
@@ -119,6 +120,57 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("arrowToInternalRow keeps dense vector fixed-size bytes as BinaryType") {
+    val bytes = java.nio.ByteBuffer
+      .allocate(8)
+      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+      .putFloat(1.5f)
+      .putFloat(-2.0f)
+      .array()
+    withFixedSizeBinaryRoot("float", bytes.length, bytes) { root =>
+      val row = ArrowConverter.arrowToInternalRow(
+        root,
+        0,
+        StructType(
+          Seq(vectorField("float", BinaryType, MilvusDataType.FloatVector))
+        )
+      )
+      row.getBinary(0) shouldBe bytes
+    }
+  }
+
+  test("internalRowToArrow writes BinaryType to fixed and variable binary") {
+    val bytes = Array[Byte](1, 2, 3, 4)
+    val sparkSchema = StructType(Seq(StructField("vec", BinaryType)))
+
+    Seq[ArrowType](
+      new ArrowType.FixedSizeBinary(bytes.length),
+      new ArrowType.Binary()
+    ).foreach { arrowType =>
+      val allocator = new RootAllocator(Long.MaxValue)
+      try {
+        val schema = new Schema(
+          Seq(new Field("vec", FieldType.nullable(arrowType), null)).asJava
+        )
+        val root = VectorSchemaRoot.create(schema, allocator)
+        try {
+          root.allocateNew()
+          ArrowConverter.internalRowToArrow(
+            root,
+            0,
+            InternalRow(bytes),
+            sparkSchema
+          )
+          root.getVector("vec") match {
+            case vector: FixedSizeBinaryVector => vector.get(0) shouldBe bytes
+            case vector: VarBinaryVector       => vector.get(0) shouldBe bytes
+            case other => fail(s"unexpected vector ${other.getClass}")
+          }
+        } finally root.close()
+      } finally allocator.close()
+    }
+  }
+
   test("arrowToInternalRow decodes valid UTF-8 from VarBinary as StringType") {
     val bytes = "hello, 世界".getBytes(java.nio.charset.StandardCharsets.UTF_8)
     withVariableWidthRoot("text", new ArrowType.Binary(), bytes) { root =>
@@ -144,29 +196,6 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
         )
       }
       err.getMessage should include("not valid UTF-8")
-    }
-  }
-
-  test(
-    "arrowToInternalRow rejects BinaryType for FloatVector fixed-size bytes"
-  ) {
-    val bytes = java.nio.ByteBuffer
-      .allocate(8)
-      .order(java.nio.ByteOrder.LITTLE_ENDIAN)
-      .putFloat(1.5f)
-      .putFloat(-2.0f)
-      .array()
-    withFixedSizeBinaryRoot("float", bytes.length, bytes) { root =>
-      val err = intercept[IllegalArgumentException] {
-        ArrowConverter.arrowToInternalRow(
-          root,
-          0,
-          StructType(
-            Seq(vectorField("float", BinaryType, MilvusDataType.FloatVector))
-          )
-        )
-      }
-      err.getMessage should include("BinaryType")
     }
   }
 
@@ -242,7 +271,7 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
     }
   }
 
-  test("arrowToInternalRow rejects BinaryType without BinaryVector metadata") {
+  test("arrowToInternalRow rejects BinaryType without vector metadata") {
     val bytes = Array[Byte](0x01, 0x23, 0x45, 0x67)
     withFixedSizeBinaryRoot("binary", bytes.length, bytes) { root =>
       val err = intercept[IllegalArgumentException] {
@@ -252,7 +281,7 @@ class ArrowConverterTest extends AnyFunSuite with Matchers {
           StructType(Seq(StructField("binary", BinaryType)))
         )
       }
-      err.getMessage should include("BinaryVector")
+      err.getMessage should include(ArrowConverter.MilvusDataTypeMetadataKey)
     }
   }
 

--- a/src/test/scala/serde/DataTypeUtilTest.scala
+++ b/src/test/scala/serde/DataTypeUtilTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import com.zilliz.spark.connector.serde.ArrowConverter
+import io.milvus.grpc.common.KeyValuePair
 import io.milvus.grpc.schema.{DataType => MilvusDataType, FieldSchema}
 
 /** Unit tests for DataTypeUtil type conversions
@@ -281,11 +282,17 @@ class DataTypeUtilTest extends AnyFunSuite with Matchers {
   }
 
   test("metadata stores Milvus data type code") {
-    val fieldSchema = FieldSchema(dataType = MilvusDataType.Float16Vector)
+    val fieldSchema = FieldSchema(
+      name = "float16_vec",
+      dataType = MilvusDataType.Float16Vector,
+      typeParams = Seq(KeyValuePair(key = "dim", value = "128"))
+    )
     val result = DataTypeUtil.metadata(fieldSchema)
 
     result.getLong(ArrowConverter.MilvusDataTypeMetadataKey) shouldBe
       MilvusDataType.Float16Vector.value.toLong
+    result.getLong(ArrowConverter.MilvusVectorDimensionMetadataKey) shouldBe
+      128L
   }
 
   test("toDataType throws exception for unsupported array element type") {

--- a/src/test/scala/serde/SchemaUtilTest.scala
+++ b/src/test/scala/serde/SchemaUtilTest.scala
@@ -381,6 +381,59 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
     names shouldBe Seq("row_id", "timestamp")
   }
 
+  test("Milvus collection schema uses Binary for nullable dense vectors") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import io.milvus.grpc.common.KeyValuePair
+    import io.milvus.grpc.schema.{
+      CollectionSchema => MilvusCollectionSchema,
+      DataType => MilvusDataType,
+      FieldSchema => MilvusFieldSchema
+    }
+    import org.apache.arrow.vector.types.pojo.ArrowType
+
+    def vector(
+        name: String,
+        fieldId: Long,
+        dataType: MilvusDataType,
+        nullable: Boolean
+    ) = MilvusFieldSchema(
+      name = name,
+      fieldID = fieldId,
+      dataType = dataType,
+      nullable = nullable,
+      typeParams = Seq(KeyValuePair(key = "dim", value = "4"))
+    )
+
+    val schema = MilvusCollectionSchema(
+      fields = Seq(
+        vector("fixed", 100, MilvusDataType.FloatVector, nullable = false),
+        vector("nullable", 101, MilvusDataType.FloatVector, nullable = true)
+      )
+    )
+
+    val byLogicalName = MilvusSchemaUtil
+      .convertToArrowSchema(schema)
+      .getFields
+      .asScala
+      .map(field => field.getName -> field)
+      .toMap
+    byLogicalName("fixed").getType shouldBe new ArrowType.FixedSizeBinary(16)
+    byLogicalName("fixed").isNullable shouldBe false
+    byLogicalName("nullable").getType shouldBe new ArrowType.Binary()
+    byLogicalName("nullable").isNullable shouldBe true
+    byLogicalName("nullable").getMetadata.get("dim") shouldBe "4"
+
+    val byFieldId = MilvusSchemaUtil
+      .convertToArrowSchemaWithFieldIdNames(schema)
+      .getFields
+      .asScala
+      .map(field => field.getName -> field)
+      .toMap
+    byFieldId("100").getType shouldBe new ArrowType.FixedSizeBinary(16)
+    byFieldId("101").getType shouldBe new ArrowType.Binary()
+    byFieldId("101").getMetadata.get("dim") shouldBe "4"
+  }
+
   test(
     "useFieldIdAsName = false (V2 packed-parquet) preserves logical column names"
   ) {
@@ -411,6 +464,88 @@ class SchemaUtilTest extends AnyFunSuite with Matchers {
     byName("pk").getMetadata.get("PARQUET:field_id") shouldBe "100"
     byName("vec").getMetadata.get("PARQUET:field_id") shouldBe "101"
     byName("ts").getMetadata.get("PARQUET:field_id") shouldBe "1"
+  }
+
+  test("Milvus vector metadata produces exact internal Arrow types") {
+    import com.zilliz.spark.connector.MilvusSchemaUtil
+    import com.zilliz.spark.connector.serde.ArrowConverter
+    import io.milvus.grpc.schema.{DataType => MilvusDataType}
+    import org.apache.arrow.vector.types.pojo.ArrowType
+    import org.apache.spark.sql.types._
+
+    def vectorMetadata(dataType: MilvusDataType, dim: Option[Int]) = {
+      val builder = new MetadataBuilder()
+        .putLong(ArrowConverter.MilvusDataTypeMetadataKey, dataType.value)
+      dim.foreach(value =>
+        builder.putLong(
+          ArrowConverter.MilvusVectorDimensionMetadataKey,
+          value
+        )
+      )
+      builder.build()
+    }
+
+    val schema = StructType(
+      Seq(
+        StructField(
+          "float_vec",
+          BinaryType,
+          nullable = false,
+          vectorMetadata(MilvusDataType.FloatVector, Some(4))
+        ),
+        StructField(
+          "nullable_float_vec",
+          BinaryType,
+          nullable = true,
+          vectorMetadata(MilvusDataType.FloatVector, Some(4))
+        ),
+        StructField(
+          "binary_vec",
+          BinaryType,
+          nullable = false,
+          vectorMetadata(MilvusDataType.BinaryVector, Some(16))
+        ),
+        StructField(
+          "float16_vec",
+          BinaryType,
+          nullable = false,
+          vectorMetadata(MilvusDataType.Float16Vector, Some(4))
+        ),
+        StructField(
+          "bfloat16_vec",
+          BinaryType,
+          nullable = false,
+          vectorMetadata(MilvusDataType.BFloat16Vector, Some(4))
+        ),
+        StructField(
+          "int8_vec",
+          BinaryType,
+          nullable = false,
+          vectorMetadata(MilvusDataType.Int8Vector, Some(4))
+        ),
+        StructField(
+          "sparse_vec",
+          BinaryType,
+          nullable = true,
+          vectorMetadata(MilvusDataType.SparseFloatVector, None)
+        )
+      )
+    )
+
+    val arrowSchema = MilvusSchemaUtil.convertSparkSchemaToArrow(schema)
+    val fields =
+      arrowSchema.getFields.asScala.map(field => field.getName -> field).toMap
+
+    fields("float_vec").getType shouldBe new ArrowType.FixedSizeBinary(16)
+    fields("float_vec").isNullable shouldBe false
+    fields("nullable_float_vec").getType shouldBe new ArrowType.Binary()
+    fields("nullable_float_vec").isNullable shouldBe true
+    fields("nullable_float_vec").getMetadata.get("dim") shouldBe "4"
+    fields("binary_vec").getType shouldBe new ArrowType.FixedSizeBinary(2)
+    fields("float16_vec").getType shouldBe new ArrowType.FixedSizeBinary(8)
+    fields("bfloat16_vec").getType shouldBe new ArrowType.FixedSizeBinary(8)
+    fields("int8_vec").getType shouldBe new ArrowType.FixedSizeBinary(4)
+    fields("sparse_vec").getType shouldBe new ArrowType.Binary()
   }
 
   test("Handle nullable fields correctly") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -598,6 +598,21 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       ) == 105L
     )
     assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 128L
+    )
+    assert(
+      schema("float_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 4L
+    )
+    assert(
+      schema("int8_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 4L
+    )
+    assert(
       schema("json_payload").metadata.getLong(
         ArrowConverter.MilvusDataTypeMetadataKey
       ) == 23L
@@ -627,6 +642,11 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       schema("binary_vec").metadata.getLong(
         ArrowConverter.MilvusDataTypeMetadataKey
       ) == 100L
+    )
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 128L
     )
   }
 
@@ -661,6 +681,21 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
         ArrowConverter.MilvusDataTypeMetadataKey
       ) == 105L
     )
+    assert(
+      schema("binary_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 128L
+    )
+    assert(
+      schema("float_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 4L
+    )
+    assert(
+      schema("int8_vec").metadata.getLong(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      ) == 4L
+    )
   }
 
   test("snapshot mode does not overwrite existing milvus.data_type") {
@@ -688,6 +723,11 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       ) == 999L
     )
     assert(schema("binary_vec").metadata.getLong("custom.flag") == 7L)
+    assert(
+      !schema("binary_vec").metadata.contains(
+        ArrowConverter.MilvusVectorDimensionMetadataKey
+      )
+    )
     assert(
       !schema("legacy_bytes").metadata.contains(
         ArrowConverter.MilvusDataTypeMetadataKey


### PR DESCRIPTION
- accept common user input formats for dense and sparse vectors
- normalize vector values to Milvus internal byte layouts before joining
- preserve vector type, dimension, and nullability in Arrow schemas
- validate vector dimensions, ranges, and sparse entries
- add vector normalization and Arrow conversion tests