### PR TITLE
fix: [backfill] include schema version in result JSON

### DIFF
--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -70,6 +70,7 @@ case class BackfillResult(
     executionTimeMs: Long,
     collectionId: Long,
     partitionId: Long,
+    schemaVersion: Int,
     newFieldNames: Seq[String],
     totalSourceRows: Long = 0L,
     totalBackfillDataRows: Long = 0L,
@@ -116,6 +117,7 @@ case class BackfillResult(
        |  Execution Time: ${executionTimeMs}ms
        |  Collection ID: $collectionId
        |  Partition ID: $partitionId
+       |  Schema Version: $schemaVersion
        |  New Fields: ${newFieldNames.mkString(", ")}
        |  Manifest Paths: ${manifestPaths.size} files
        |  StorageV2 Segments: $v2Count / ${segmentResults.size}
@@ -179,6 +181,7 @@ case class BackfillResult(
       "success" -> success,
       "collectionId" -> collectionId,
       "partitionId" -> partitionId,
+      "schemaVersion" -> schemaVersion,
       "segmentsProcessed" -> segmentsProcessed,
       "totalSourceRows" -> totalSourceRows,
       "totalBackfillDataRows" -> totalBackfillDataRows,
@@ -215,6 +218,7 @@ object BackfillResult {
       executionTimeMs: Long,
       collectionId: Long,
       partitionId: Long,
+      schemaVersion: Int,
       newFieldNames: Seq[String],
       totalBackfillDataRows: Long = 0L
   ): BackfillResult = {
@@ -243,6 +247,7 @@ object BackfillResult {
       executionTimeMs = executionTimeMs,
       collectionId = collectionId,
       partitionId = partitionId,
+      schemaVersion = schemaVersion,
       newFieldNames = newFieldNames,
       totalSourceRows = totalSource,
       totalBackfillDataRows = totalBackfillDataRows,
@@ -268,6 +273,7 @@ object BackfillResult {
       executionTimeMs = executionTimeMs,
       collectionId = collectionId,
       partitionId = partitionId,
+      schemaVersion = 0,
       newFieldNames = Seq.empty
     )
   }

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -384,6 +384,9 @@ object MilvusBackfill {
         executionTimeMs = executionTime,
         collectionId = collectionID,
         partitionId = if (partitionIDs.size == 1) partitionIDs.head else -1,
+        schemaVersion = snapshotMetadataOpt
+          .map(_.collection.schema.version)
+          .getOrElse(0),
         newFieldNames = newFieldNames,
         totalBackfillDataRows = backfillRowCount
       )

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -228,7 +228,8 @@ case class CollectionSchema(
       Boolean
     ] = None,
     @JsonProperty("enable_dynamic_field") enableDynamicField: Option[Boolean] =
-      None
+      None,
+    @JsonProperty("version") version: Int = 0
 ) {
   def getFieldByName(name: String): Option[Field] = {
     fields.find(_.name == name)

--- a/src/test/scala/operations/backfill/BackfillResultTest.scala
+++ b/src/test/scala/operations/backfill/BackfillResultTest.scala
@@ -1,0 +1,33 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class BackfillResultTest extends AnyFunSuite with Matchers {
+
+  test("result JSON contains snapshot collection schema version") {
+    val segment = SegmentBackfillResult(
+      segmentId = 10L,
+      rowCount = 3L,
+      manifestPaths = Seq("s3a://bucket/manifest/1"),
+      outputPath = "s3a://bucket/segment/10",
+      executionTimeMs = 5L,
+      committedVersion = 1L,
+      sourceRowCount = 3L,
+      matchedRowCount = 2L
+    )
+    val result = BackfillResult.success(
+      segmentResults = Map(10L -> segment),
+      executionTimeMs = 10L,
+      collectionId = 1L,
+      partitionId = 2L,
+      schemaVersion = 7,
+      newFieldNames = Seq("embedding")
+    )
+
+    val json = new ObjectMapper().readTree(result.toJson)
+
+    json.get("schemaVersion").asInt() shouldBe 7
+  }
+}

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -88,6 +88,7 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     // Verify schema basic info
     schema.name shouldBe "backfilltestcollection"
     schema.description shouldBe Some("Test collection for MilvusBackfill")
+    schema.version shouldBe 0
     schema.fields should have size 7
 
     // Verify schema properties
@@ -142,6 +143,32 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     timestampField.getFieldIDAsLong shouldBe 1L
     timestampField.dataType shouldBe 5 // Int64
     timestampField.description shouldBe Some("timestamp")
+  }
+
+  test("Parse collection schema version from snapshot JSON") {
+    val json = """
+    {
+      "snapshot_info": {
+        "name": "test",
+        "id": 1,
+        "collection_id": 1,
+        "partition_ids": [1],
+        "create_ts": 1
+      },
+      "collection": {
+        "schema": {
+          "name": "test",
+          "version": 7,
+          "fields": []
+        }
+      }
+    }
+    """
+
+    val metadata =
+      MilvusSnapshotReader.parseSnapshotMetadata(json).toOption.get
+
+    metadata.collection.schema.version shouldBe 7
   }
 
   test("Get primary key name from snapshot JSON") {


### PR DESCRIPTION
Parse the collection schema version from snapshot metadata and propagate it through the backfill result. Emit schemaVersion in the final JSON so DataCoord can reject stale backfill commits.

Keep legacy snapshots compatible by defaulting missing versions to zero, and add parsing and serialization coverage.

Related: milvus-io/milvus#51318