### PR TITLE
enhance: [backfill] decouple join pipeline from primary keys

### DIFF
--- a/docs/plans/2026-08-05-backfill-configurable-join-key.md
+++ b/docs/plans/2026-08-05-backfill-configurable-join-key.md
@@ -1,0 +1,845 @@
+# Configurable Join Keys for Backfill Implementation Plan
+
+**Goal:** Generalize the backfill job so callers can explicitly select a persisted physical field as the row join key, while preserving the current primary-key join as the default and leaving a clean extension point for future logical keys such as `(file path, row number)`.
+
+**Architecture:** Introduce a public join-key specification and a separately resolved runtime model. Phase 1 exposes only the existing primary-key strategy and a single persisted physical-field strategy. The resolved model is component-based and uses internal canonical join-column aliases, so the read, validation, and join pipeline can later accept multi-component logical keys without another rewrite. The per-segment writer path remains unchanged because it already depends only on `$segment_id`, `$row_offset`, and the fields being written.
+
+**Technology stack:** Scala, Spark SQL/DataFrame API, Spark DataSource V2, ScalaTest, sbt, scalafmt
+
+---
+
+## Current behavior and constraints
+
+The current implementation assumes the Milvus primary key throughout the pre-write pipeline:
+
+- `MilvusBackfill.run` resolves `(pkName, pkFieldId)` from the snapshot or client.
+- `applyColumnMapping` requires the mapped backfill data to contain the primary-key field. Without an explicit mapping, it requires a literal `pk` input column and renames it to the collection PK name.
+- Every mapped column except the PK is treated as a target field.
+- Backfill-side duplicate detection uses `countDistinct(pkName)`.
+- `readCollectionWithMetadata` always reads the PK field ID first.
+- Schema compatibility and all three merge modes join by `Seq(pkName)`.
+- Metrics and documentation describe matches as PK matches.
+
+The downstream writer does not need the PK. After the join, `processSegments` projects only `$segment_id`, `$row_offset`, target fields, and internal statistics flags. It repartitions by segment and restores physical row order using `$row_offset`. Therefore, the writer, V2/V3 dispatch, manifest handling, and result artifact generation are outside the main change surface.
+
+## Scope
+
+Phase 1 includes:
+
+- Preserve primary-key join behavior when no join-key option is supplied.
+- Add an explicit physical-field join strategy for persisted scalar fields present in the snapshot schema.
+- Permit an explicit physical join key even when the snapshot schema has no field marked as a primary key.
+- Support input-column renaming through the existing `columnMapping` mechanism.
+- Require exact type compatibility and a non-null, unique row key.
+- Make internal join execution component-based even though the phase-1 CLI accepts one physical field.
+- Keep the result JSON wire shape unchanged.
+
+Phase 1 does not include:
+
+- Logical keys synthesized from file metadata, row positions, expressions, or UDFs.
+- Joining directly on `$segment_id` / `$row_offset` as a public row identity.
+- Many-to-one or one-to-many join cardinality.
+- Updating the selected join-key field in the same backfill operation.
+- Expanding the currently unsupported client-only ADDFIELD path.
+- Changes to native readers, JNI, V2/V3 writers, or Milvus commit behavior.
+
+## Pull request split
+
+Implementation is split into two stacked pull requests. The split is based on
+review boundaries rather than the numbered tasks below.
+
+### PR1: Generalize the internal join pipeline without changing behavior
+
+Suggested title:
+
+```text
+refactor: decouple backfill join pipeline from primary keys
+```
+
+PR1 keeps the public configuration, CLI, result JSON, and default PK behavior
+unchanged. It introduces only the internal execution seam needed by PR2:
+
+- Private resolved join-key/component models using canonical internal aliases.
+- A prepared-input model that separates join columns from writer target fields.
+- Component-based source projection and join-key type compatibility checks.
+- `performJoin` accepting multiple internal join columns.
+- Generic backfill-side null/uniqueness validation while still validating the
+  existing PK input.
+- Regression tests proving all existing PK and merge-mode behavior is unchanged.
+- An internal multi-component join test proving the future logical-key seam.
+
+PR1 consists primarily of the internal portions of Tasks 1, 4, 5, 6, and 7.
+It must not add `BackfillConfig.joinKey` or the `--join-key` CLI flag.
+
+### PR2: Expose persisted physical join keys end to end
+
+Suggested title:
+
+```text
+feat: support physical join keys for backfill
+```
+
+PR2 is based on PR1 and delivers the complete user-visible feature:
+
+- Public `BackfillJoinKey.PrimaryKey` / `PhysicalField` configuration.
+- `BackfillConfig.joinKey`, defaulting to `PrimaryKey`.
+- The `--join-key` CLI flag.
+- Snapshot-schema resolution for persisted physical fields, including schemas
+  without a primary-key marker.
+- Physical-key column-mapping behavior.
+- Explicit source-side non-null/uniqueness validation and type restrictions.
+- End-to-end orchestration, logs, documentation, and the complete regression
+  suite.
+
+PR2 consists of the public portions of Tasks 1-3, the physical-key cases from
+Tasks 4-6, and Tasks 8-10. Configuration, CLI, resolver, validation, and user
+documentation must ship together so no merged state accepts a join-key option
+that is ignored or performs an unsafe non-unique join.
+
+Logical file/row keys remain a future, separate feature PR after their reader
+metadata and snapshot-stability contract is defined.
+
+Implementation status as of 2026-08-05:
+
+- PR1 implementation is present in the working tree and its unit/reader
+  regression suites pass.
+- PR2 has not started; no public join-key configuration or CLI flag is exposed.
+
+## Public behavior
+
+Programmatic configuration:
+
+```scala
+sealed trait BackfillJoinKey extends Serializable
+
+object BackfillJoinKey {
+  case object PrimaryKey extends BackfillJoinKey
+  final case class PhysicalField(name: String) extends BackfillJoinKey
+}
+
+case class BackfillConfig(
+    // existing fields ...
+    mode: String = MilvusOption.BackfillModeCoalesce,
+    joinKey: BackfillJoinKey = BackfillJoinKey.PrimaryKey
+)
+```
+
+CLI configuration:
+
+```text
+--join-key <snapshot-field-name>
+```
+
+Omitting `--join-key` selects `BackfillJoinKey.PrimaryKey` and preserves the current behavior.
+
+Examples:
+
+```bash
+# Existing behavior: input `pk` is mapped implicitly to the collection PK.
+spark-submit ... --parquet data.parquet --snapshot snapshot.json
+
+# The parquet already uses the physical field name.
+spark-submit ... \
+  --join-key external_row_id \
+  --parquet data.parquet \
+  --snapshot snapshot.json
+
+# The parquet key column has a different name.
+spark-submit ... \
+  --join-key external_row_id \
+  --column-mapping source_row_id:external_row_id,new_vec:embedding \
+  --parquet data.parquet \
+  --snapshot snapshot.json
+```
+
+Compatibility matrix:
+
+| Join configuration | Column mapping | Required input key | Result |
+|---|---|---|---|
+| Omitted/default PK | None | Literal `pk` | Existing implicit `pk -> <collection PK>` behavior |
+| Omitted/default PK | Present | One mapping target equals the collection PK | Existing explicit mapping behavior |
+| Physical field `k` | None | Literal `k` | All other columns are target fields |
+| Physical field `k` | Present | One mapping target equals `k` | The mapped key is consumed for joining, not written |
+
+---
+
+### Task 1: Add the join-key specification and runtime model
+
+**Files:**
+
+- Create: `src/main/scala/operations/backfill/BackfillJoinKey.scala`
+- Modify: `src/main/scala/operations/backfill/BackfillConfig.scala`
+- Test: `src/test/scala/operations/backfill/BackfillConfigTest.scala`
+
+**Step 1: Write failing model/default tests**
+
+Add tests covering:
+
+```scala
+test("backfill defaults to collection primary-key join") {
+  val config = BackfillConfig.forTest("c")
+  config.joinKey shouldBe BackfillJoinKey.PrimaryKey
+}
+
+test("backfill accepts an explicit physical-field join key") {
+  val config = BackfillConfig
+    .forTest("c")
+    .copy(joinKey = BackfillJoinKey.PhysicalField("external_row_id"))
+  config.validate() shouldBe Right(())
+}
+
+test("backfill rejects a blank physical-field join key") {
+  val config = BackfillConfig
+    .forTest("c")
+    .copy(joinKey = BackfillJoinKey.PhysicalField("  "))
+  config.validate().isLeft shouldBe true
+}
+```
+
+**Step 2: Run the tests and verify failure**
+
+Run:
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillConfigTest"
+```
+
+Expected: FAIL because the join-key model and config field do not exist.
+
+**Step 3: Implement the minimal public and resolved models**
+
+Create:
+
+```scala
+sealed trait BackfillJoinKey extends Product with Serializable
+
+object BackfillJoinKey {
+  case object PrimaryKey extends BackfillJoinKey
+  final case class PhysicalField(name: String) extends BackfillJoinKey
+}
+
+private[backfill] final case class ResolvedJoinComponent(
+    sourceColumn: String,
+    fieldId: Long,
+    sourceField: StructField,
+    internalColumn: String
+)
+
+private[backfill] final case class ResolvedJoinKey(
+    kind: String,
+    components: Seq[ResolvedJoinComponent]
+) {
+  require(components.nonEmpty, "resolved join key must have at least one component")
+  def sourceColumns: Seq[String] = components.map(_.sourceColumn)
+  def internalColumns: Seq[String] = components.map(_.internalColumn)
+}
+```
+
+Use deterministic reserved aliases such as `__bf_join_0__`. Keep the resolved representation as a sequence even though phase 1 creates exactly one component.
+
+Append `joinKey` to `BackfillConfig` with a default so existing named construction sites continue to compile. Extend `validate()` to reject blank physical-field names.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/BackfillJoinKey.scala src/main/scala/operations/backfill/BackfillConfig.scala src/test/scala/operations/backfill/BackfillConfigTest.scala
+git commit -m "enhance: add backfill join key model"
+```
+
+### Task 2: Add CLI parsing for an explicit physical join key
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/BackfillApp.scala`
+- Modify: `src/test/scala/operations/backfill/BackfillAppTest.scala`
+
+**Step 1: Write failing parser tests**
+
+Cover:
+
+- `--join-key external_row_id` is accepted.
+- The parsed value becomes `BackfillJoinKey.PhysicalField("external_row_id")` when building the config.
+- `--join-key` without a value produces the existing clear missing-value error.
+- A value containing only whitespace is rejected by config validation.
+- Omitting the flag keeps `PrimaryKey`.
+
+If config construction remains embedded in `main`, extract a package-visible helper such as:
+
+```scala
+private[backfill] def buildConfig(parsed: Map[String, String]): BackfillConfig
+```
+
+This avoids testing `main` through `System.exit` and gives future join-key CLI strategies one parser boundary.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillAppTest"
+```
+
+Expected: FAIL because `join-key` is not a known key/value flag.
+
+**Step 3: Implement CLI parsing**
+
+- Add `join-key` to `KvFlags`.
+- Map a supplied value to `BackfillJoinKey.PhysicalField(value.trim)`.
+- Map an omitted value to `BackfillJoinKey.PrimaryKey`.
+- Add `--join-key` to the usage documentation at the top of `BackfillApp`.
+
+Do not introduce a public `join-key-type` flag in phase 1. Future logical-key CLI syntax should be added separately after its metadata contract is defined.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/BackfillApp.scala src/test/scala/operations/backfill/BackfillAppTest.scala
+git commit -m "enhance: accept physical join key for backfill"
+```
+
+### Task 3: Resolve the configured join key from the snapshot schema
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Test: `src/test/scala/operations/backfill/MilvusBackfillTest.scala`
+
+**Step 1: Write failing resolver tests**
+
+Extract a package-visible pure helper:
+
+```scala
+private[backfill] def resolveJoinKey(
+    schema: CollectionSchema,
+    spec: BackfillJoinKey
+): Either[BackfillError, ResolvedJoinKey]
+```
+
+Cover:
+
+- `PrimaryKey` resolves the field marked `isPrimaryKey=true`.
+- `PrimaryKey` fails with the current clear error if no PK exists.
+- `PhysicalField("external_row_id")` resolves the exact snapshot field name and ID.
+- A physical field works when no snapshot field is marked as a PK.
+- A missing physical field fails and lists available field names.
+- Case mismatches fail instead of relying on Spark's case-insensitive resolution.
+- Unsupported physical key types fail before data is read.
+
+Phase-1 supported key types should be deliberately narrow and stable for equality joins:
+
+```text
+ByteType, ShortType, IntegerType, LongType, StringType, BinaryType
+```
+
+Reject floating-point, vector, array, map, struct, and JSON-like fields. Additional scalar types can be added later with explicit equality-semantics tests.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.MilvusBackfillTest"
+```
+
+Expected: FAIL because join-key resolution is still hard-coded to PK lookup.
+
+**Step 3: Implement the resolver**
+
+For `PrimaryKey`, retain the current snapshot lookup behavior. For `PhysicalField`, resolve directly from `metadata.collection.schema.fields`. Convert the selected field through `MilvusSnapshotReader.fieldToStructField` and assign its internal alias.
+
+In `run`, replace the early `(pkName, pkFieldId)` block with a resolved key. Because ADDFIELD already requires snapshot schema later in the method, do not expand client-only behavior in this task. Preserve the existing client-path error semantics outside the new resolver.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/MilvusBackfillTest.scala
+git commit -m "enhance: resolve configurable backfill join keys"
+```
+
+### Task 4: Separate input join columns from target fields
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Modify: `src/test/scala/operations/backfill/ColumnMappingTest.scala`
+
+**Step 1: Write failing input-preparation tests**
+
+Replace the PK-specific helper contract with a prepared-input contract:
+
+```scala
+private[backfill] final case class PreparedBackfillData(
+    dataFrame: DataFrame,
+    joinColumns: Seq[String],
+    targetFieldNames: Seq[String]
+)
+```
+
+Add tests covering:
+
+- Default PK plus no mapping still renames literal `pk` to the internal join alias.
+- Default PK plus explicit mapping finds the mapping entry targeting the real PK field.
+- Explicit physical key plus no mapping consumes the same-named parquet column as the join key.
+- Explicit physical key plus mapping consumes the source column whose mapping target equals the physical field name.
+- The consumed join column is excluded from `targetFieldNames`.
+- A missing join-key mapping fails with a join-key-specific message rather than a primary-key message.
+- At least one non-key target field remains required.
+- Duplicate mapping targets and rename chains/swaps retain their current behavior.
+- Internal names such as `__bf_join_0__` and `__bf_matched__` cannot collide with user target fields.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.ColumnMappingTest"
+```
+
+Expected: FAIL because `applyColumnMapping` still requires the PK and derives targets by excluding `pkName`.
+
+**Step 3: Implement prepared input projection**
+
+Refactor `applyColumnMapping` into a helper such as:
+
+```scala
+private[backfill] def prepareBackfillData(
+    df: DataFrame,
+    joinKey: ResolvedJoinKey,
+    joinSpec: BackfillJoinKey,
+    userMapping: Option[Map[String, String]]
+): Either[BackfillError, PreparedBackfillData]
+```
+
+Rules:
+
+1. Determine which raw parquet column supplies each join component.
+2. Project each join component to its internal alias.
+3. Project non-key mapping entries to Milvus target field names.
+4. Drop unlisted columns when a mapping is provided.
+5. Return target field names explicitly; do not infer them later by subtracting the PK.
+
+For the default PK/no-mapping path only, preserve the legacy literal `pk` alias. Do not apply that alias to an explicitly configured physical key.
+
+The selected join field is identity-only for the operation. Reject or consume it as the key; never include it in the writer target schema.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/ColumnMappingTest.scala
+git commit -m "refactor: separate backfill join keys from target fields"
+```
+
+### Task 5: Generalize source projection and schema compatibility
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Modify: `src/test/scala/operations/backfill/BackfillModeTest.scala`
+- Modify: `src/test/scala/operations/backfill/MilvusBackfillTest.scala`
+
+**Step 1: Write failing read-projection tests**
+
+Cover:
+
+- The source reader's `fieldIDs` option begins with the selected physical field ID rather than the PK field ID.
+- Snapshot read schema contains the selected physical join field, requested source-side target fields, `$segment_id`, and `$row_offset` in the expected order.
+- Repeated field IDs are removed defensively while preserving schema/field-ID order.
+- The physical source join column is normalized to the same internal alias used by the prepared backfill input.
+- Join compatibility validates every component and reports the physical field name and both Spark types.
+
+Expose a narrow test helper for building read options/schema rather than requiring a native reader integration test for every assertion.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillModeTest com.zilliz.spark.connector.operations.backfill.MilvusBackfillTest"
+```
+
+Expected: FAIL because the reader and validator accept only `pkFieldId` / `pkName`.
+
+**Step 3: Generalize the source read**
+
+Change `readCollectionWithMetadata` to accept `ResolvedJoinKey` rather than `pkFieldId`:
+
+```scala
+private def readCollectionWithMetadata(
+    spark: SparkSession,
+    config: BackfillConfig,
+    joinKey: ResolvedJoinKey,
+    snapshotMetadata: Option[SnapshotMetadata],
+    v2Segments: Seq[V2SegmentInfo],
+    extraReadFields: Seq[(String, Long, StructField)]
+): Either[BackfillError, DataFrame]
+```
+
+Build `ReaderFieldIDs` and the supplied Spark schema from:
+
+```text
+resolved join components ++ source-side target fields
+```
+
+After loading, rename the physical source key columns to their internal aliases. Continue validating the presence of `$segment_id` and `$row_offset` exactly as today.
+
+Rename `validateSchemaCompatibility` to `validateJoinKeyCompatibility` and compare all resolved components. Keep target-field compatibility in `validateMergeableFieldTypes` unchanged.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suites.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/BackfillModeTest.scala src/test/scala/operations/backfill/MilvusBackfillTest.scala
+git commit -m "enhance: read configured join fields for backfill"
+```
+
+### Task 6: Enforce row-key cardinality and null invariants
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Modify: `src/test/scala/operations/backfill/BackfillModeTest.scala`
+
+**Step 1: Write failing validation tests**
+
+Add a reusable helper that validates a DataFrame key using the internal join columns. Cover:
+
+- A unique, non-null key succeeds.
+- A duplicate key fails.
+- A null key fails with a distinct null-key message rather than being reported only as a duplicate.
+- Error messages identify whether the invalid side is `backfill data` or `source snapshot`.
+- Multi-component keys are handled correctly by the internal helper even though phase 1 does not expose them publicly.
+- A duplicate tuple fails while repeated individual component values in otherwise unique tuples succeed.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillModeTest"
+```
+
+Expected: FAIL because current validation is PK-specific and does not distinguish nulls from duplicates.
+
+**Step 3: Implement exact key validation**
+
+Use one exact aggregation per side:
+
+```scala
+val keyStruct = struct(joinColumns.map(col): _*)
+val hasNull = joinColumns.map(c => col(c).isNull).reduce(_ || _)
+
+df.agg(
+  count(lit(1)).as("rows"),
+  sum(when(hasNull, 1L).otherwise(0L)).as("null_key_rows"),
+  countDistinct(when(!hasNull, keyStruct)).as("distinct_valid_keys")
+)
+```
+
+The invariant is:
+
+```text
+null_key_rows == 0 && distinct_valid_keys == rows
+```
+
+The backfill input is already cached; retain that behavior. For an explicit physical source key, persist the source DataFrame with `MEMORY_AND_DISK`, validate it once, reuse it for the join, and unpersist it in the existing outer cleanup path. For the default PK strategy, the Milvus schema already defines the key invariant, so source-side uniqueness validation may be skipped to preserve current performance.
+
+Log row count and distinct join-key count using generic terminology. Preserve `totalBackfillDataRows` semantics.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/BackfillModeTest.scala
+git commit -m "enhance: validate backfill join key cardinality"
+```
+
+### Task 7: Generalize the join while preserving all merge modes
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Modify: `src/test/scala/operations/backfill/BackfillModeTest.scala`
+
+**Step 1: Write failing non-PK join tests**
+
+For each mode, build source data containing both a PK and a different physical row key, then join on the physical key:
+
+- `replace`: matched rows take file values and unmatched source rows receive null target values.
+- `coalesce`: non-null source values win, and file values fill source nulls.
+- `overwrite`: matched rows take file values including null, and unmatched rows retain source values.
+- Match and provenance flags retain their current meanings.
+- The output has exactly one row per source row.
+- The physical key and internal aliases are absent from the writer projection.
+
+Also add an internal two-component join test to prove the execution layer is ready for a future logical key.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillModeTest"
+```
+
+Expected: FAIL because `performJoin` accepts a single `pkName`.
+
+**Step 3: Generalize `performJoin`**
+
+Change its signature to:
+
+```scala
+private[backfill] def performJoin(
+    originalDF: DataFrame,
+    backfillDF: DataFrame,
+    joinColumns: Seq[String],
+    newFieldNames: Seq[String],
+    mode: String
+): DataFrame
+```
+
+Use the existing Spark using-column left join with the internal aliases:
+
+```scala
+originalDF.join(backfillWithFlag, joinColumns, "left")
+```
+
+Keep all coalesce, overwrite, replace, match-flag, and provenance logic otherwise unchanged. Update comments from `PK matched` to `join key matched`.
+
+Do not alter `processSegments`, writer row layout, V2/V3 logic, or output ordering.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suite.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/BackfillModeTest.scala
+git commit -m "enhance: join backfill data on configurable keys"
+```
+
+### Task 8: Integrate the resolved key through `run`
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/MilvusBackfill.scala`
+- Modify: `src/test/scala/operations/backfill/MilvusBackfillTest.scala`
+- Modify: `src/test/scala/operations/backfill/ColumnMappingTest.scala`
+
+**Step 1: Add integration-level regression tests**
+
+Cover the orchestration sequence without requiring native writes where possible:
+
+- Default configuration follows the same PK resolution, implicit `pk` mapping, target-field selection, and join behavior as before.
+- Explicit physical key resolves from a schema with no primary-key marker.
+- The selected field ID reaches reader options.
+- A differently named parquet key reaches the internal join alias through `columnMapping`.
+- The selected key is not present in `newFieldNameToId` or the writer target schema.
+- Missing key fields, unsupported key types, nulls, duplicates, and type mismatches fail before segment writes begin.
+- Existing vector normalization still applies only to target fields, not join fields.
+
+**Step 2: Run the tests and verify failure**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.MilvusBackfillTest com.zilliz.spark.connector.operations.backfill.ColumnMappingTest"
+```
+
+Expected: FAIL until `run` uses the new helpers end to end.
+
+**Step 3: Rewire `run`**
+
+The new orchestration order should be:
+
+1. Load snapshot metadata and V2 segment metadata.
+2. Resolve `BackfillJoinKey` into `ResolvedJoinKey`.
+3. Read raw backfill parquet.
+4. Prepare join columns and target fields through `prepareBackfillData`.
+5. Normalize vector target columns.
+6. Cache and validate the backfill input key.
+7. Resolve target field IDs and source-side merge fields.
+8. Read source rows using the resolved key fields.
+9. Validate the source key when required and validate key type compatibility.
+10. Join using internal component aliases.
+11. Pass the unchanged post-join contract to `processSegments`.
+
+Add a driver log entry such as:
+
+```text
+Backfill join key: kind=physical, fields=external_row_id, fieldIds=123
+```
+
+Do not add join-key fields to `BackfillResult.toJson` in this phase. The JSON is consumed as part of Milvus commit handling, and avoiding a wire-shape change keeps this feature isolated from downstream parser compatibility.
+
+**Step 4: Run the tests and verify success**
+
+Run the same targeted suites.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/MilvusBackfill.scala src/test/scala/operations/backfill/MilvusBackfillTest.scala src/test/scala/operations/backfill/ColumnMappingTest.scala
+git commit -m "enhance: integrate configurable backfill join keys"
+```
+
+### Task 9: Update documentation and metric terminology
+
+**Files:**
+
+- Modify: `src/main/scala/operations/backfill/README.md`
+- Modify: `docs/design-snapshot-backfill.md`
+- Modify: `docs/user-guide-snapshot-backfill.md`
+- Modify: `docs/backfill-result-json-format.md`
+- Modify: `src/main/scala/operations/backfill/BackfillResult.scala`
+- Modify: relevant tests under `src/test/scala/operations/backfill/`
+
+**Step 1: Update user-facing documentation**
+
+Document:
+
+- PK remains the default join strategy.
+- `--join-key` selects a persisted physical snapshot field.
+- The field must be non-null, unique, and type-compatible with the parquet key.
+- Mapping examples for same-name and renamed input keys.
+- The join key cannot be backfilled in the same operation.
+- Logical file/row keys are not yet supported.
+- `$row_offset` is used to restore segment write order and is not automatically a stable logical row identity.
+
+**Step 2: Generalize terminology without changing JSON names**
+
+Update comments and prose from `PK match` to `join-key match` around:
+
+- `MatchFlagCol`
+- `matchedRowCount`
+- `totalMatchedRows`
+- mode descriptions
+- result JSON documentation
+
+Keep the existing JSON field names because they are already generic enough. Do not add or rename serialized fields.
+
+**Step 3: Run documentation-adjacent tests**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillResultTest com.zilliz.spark.connector.operations.backfill.BackfillAppTest"
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/main/scala/operations/backfill/README.md docs/design-snapshot-backfill.md docs/user-guide-snapshot-backfill.md docs/backfill-result-json-format.md src/main/scala/operations/backfill/BackfillResult.scala src/test/scala/operations/backfill
+git commit -m "docs: describe configurable backfill join keys"
+```
+
+### Task 10: Format and run the complete backfill regression suite
+
+**Files:**
+
+- All files changed above
+
+**Step 1: Format**
+
+```bash
+sbt scalafmtAll
+```
+
+Expected: SUCCESS.
+
+**Step 2: Run focused tests**
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillConfigTest com.zilliz.spark.connector.operations.backfill.BackfillAppTest com.zilliz.spark.connector.operations.backfill.ColumnMappingTest com.zilliz.spark.connector.operations.backfill.BackfillModeTest com.zilliz.spark.connector.operations.backfill.BackfillResultTest com.zilliz.spark.connector.operations.backfill.MilvusBackfillTest com.zilliz.spark.connector.operations.backfill.VectorBackfillSupportTest"
+```
+
+Expected: PASS.
+
+**Step 3: Run the broader reader regression suites**
+
+The feature changes reader field projection, so also run:
+
+```bash
+sbt "testOnly com.zilliz.spark.connector.read.MilvusLoonPartitionReaderTest com.zilliz.spark.connector.read.MilvusPackedV2PartitionReaderTest com.zilliz.spark.connector.sources.MilvusScanClientSnapshotTest"
+```
+
+Expected: PASS.
+
+**Step 4: Check formatting and diff hygiene**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only intended files changed.
+
+---
+
+## Logical-key extension seam
+
+The phase-1 implementation must not model a join key as only a single schema field name inside the execution pipeline. A future logical key may need multiple source and input components and may not correspond to a Milvus field ID at all.
+
+A later extension can add a new public specification, for example:
+
+```scala
+final case class LogicalFileRow(
+    inputFileColumn: String,
+    inputRowNumberColumn: String
+) extends BackfillJoinKey
+```
+
+Its resolver would be responsible for:
+
+1. Requesting stable source metadata columns from the reader.
+2. Defining the snapshot/version scope in which file identity and row number are stable.
+3. Normalizing source and input components to `__bf_join_0__`, `__bf_join_1__`, and so on.
+4. Returning a multi-component `ResolvedJoinKey`.
+
+The following phase-1 components should then remain unchanged:
+
+- Key null/uniqueness validation.
+- Type compatibility validation.
+- `performJoin`.
+- Merge-mode semantics.
+- Per-segment repartitioning and `$row_offset` sorting.
+- V2/V3 writing and commit artifacts.
+
+Do not treat `$row_offset` alone as this future logical key. It currently identifies physical position within a segment read and is also used to restore write order; compaction, file replacement, or a different snapshot may change that position. File/row identity requires an explicit reader and snapshot-stability contract before it becomes a supported public join strategy.
+
+## Acceptance criteria
+
+- Existing jobs that omit `joinKey` or `--join-key` behave exactly as before.
+- Existing `pk` implicit mapping and explicit PK column mappings remain valid.
+- A snapshot-backed collection or external table can join on a configured persisted scalar field.
+- An explicit physical key works even when the schema has no primary-key marker.
+- Invalid, null, duplicate, missing, unsupported, or type-incompatible keys fail before any segment is written.
+- All merge modes preserve their existing matched/unmatched and null semantics.
+- The selected join field is not written as a target field.
+- Per-segment row counts and physical row order remain unchanged.
+- Result JSON remains backward compatible.
+- The internal join implementation accepts multiple resolved components, enabling a later logical file/row key without another join-layer redesign.

--- a/src/main/scala/operations/backfill/BackfillJoinKey.scala
+++ b/src/main/scala/operations/backfill/BackfillJoinKey.scala
@@ -1,0 +1,74 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.DataFrame
+
+/** One source-side component of the key used to match collection rows with
+  * backfill data.
+  *
+  * The current public behavior resolves exactly one component: the collection
+  * primary key. Keeping the runtime representation component-based lets the
+  * execution pipeline support a future composite or logical key without
+  * changing its read, validation, or join contracts again.
+  */
+private[backfill] final case class ResolvedJoinComponent(
+    sourceColumn: String,
+    fieldId: Long,
+    sourceField: Option[StructField],
+    internalColumn: String
+)
+
+private[backfill] final case class ResolvedJoinKey(
+    kind: String,
+    components: Seq[ResolvedJoinComponent]
+) {
+  require(components.nonEmpty, "resolved join key must not be empty")
+
+  val sourceColumns: Seq[String] = components.map(_.sourceColumn)
+  val internalColumns: Seq[String] = components.map(_.internalColumn)
+  val fieldIds: Seq[Long] = components.map(_.fieldId)
+}
+
+private[backfill] object ResolvedJoinKey {
+  private val InternalColumnPrefix = "__bf_join_"
+
+  def internalColumn(index: Int): String =
+    s"$InternalColumnPrefix${index}__"
+
+  def primaryKey(
+      name: String,
+      fieldId: Long,
+      sourceField: Option[StructField]
+  ): ResolvedJoinKey =
+    ResolvedJoinKey(
+      kind = "primary_key",
+      components = Seq(
+        ResolvedJoinComponent(
+          sourceColumn = name,
+          fieldId = fieldId,
+          sourceField = sourceField,
+          internalColumn = internalColumn(0)
+        )
+      )
+    )
+}
+
+/** Backfill input after column mapping has separated identity columns from
+  * fields that will be written.
+  */
+private[backfill] final case class PreparedBackfillData(
+    dataFrame: DataFrame,
+    joinColumns: Seq[String],
+    targetFieldNames: Seq[String]
+)
+
+private[backfill] final case class JoinKeyStats(
+    rowCount: Long,
+    nullKeyRowCount: Long,
+    distinctValidKeyCount: Long
+)
+
+private[backfill] final case class SourceReadProjection(
+    fieldIds: Seq[Long],
+    schema: StructType
+)

--- a/src/main/scala/operations/backfill/BackfillJoinKey.scala
+++ b/src/main/scala/operations/backfill/BackfillJoinKey.scala
@@ -27,13 +27,37 @@ private[backfill] final case class ResolvedJoinKey(
   val sourceColumns: Seq[String] = components.map(_.sourceColumn)
   val internalColumns: Seq[String] = components.map(_.internalColumn)
   val fieldIds: Seq[Long] = components.map(_.fieldId)
+
+  /** Assign deterministic private aliases that do not collide with user or
+    * collection columns under Spark's configured name resolver.
+    */
+  def withCollisionFreeInternalColumns(
+      occupiedNames: Seq[String],
+      resolver: (String, String) => Boolean
+  ): ResolvedJoinKey = {
+    var allocatedNames = occupiedNames
+    val allocatedComponents = components.zipWithIndex.map {
+      case (component, index) =>
+        var collisionOrdinal = 0
+        var candidate =
+          ResolvedJoinKey.internalColumn(index, collisionOrdinal)
+        while (allocatedNames.exists(resolver(_, candidate))) {
+          collisionOrdinal += 1
+          candidate = ResolvedJoinKey.internalColumn(index, collisionOrdinal)
+        }
+        allocatedNames = allocatedNames :+ candidate
+        component.copy(internalColumn = candidate)
+    }
+    copy(components = allocatedComponents)
+  }
 }
 
 private[backfill] object ResolvedJoinKey {
   private val InternalColumnPrefix = "__bf_join_"
 
-  def internalColumn(index: Int): String =
-    s"$InternalColumnPrefix${index}__"
+  def internalColumn(index: Int, collisionOrdinal: Int = 0): String =
+    if (collisionOrdinal == 0) s"$InternalColumnPrefix${index}__"
+    else s"$InternalColumnPrefix${index}_${collisionOrdinal}__"
 
   def primaryKey(
       name: String,
@@ -58,9 +82,11 @@ private[backfill] object ResolvedJoinKey {
   */
 private[backfill] final case class PreparedBackfillData(
     dataFrame: DataFrame,
-    joinColumns: Seq[String],
+    joinKey: ResolvedJoinKey,
     targetFieldNames: Seq[String]
-)
+) {
+  val joinColumns: Seq[String] = joinKey.internalColumns
+}
 
 private[backfill] final case class JoinKeyStats(
     rowCount: Long,

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -141,7 +141,7 @@ object MilvusBackfill {
       // Step 3: Resolve the current primary-key join into the generic runtime
       // join-key model. PR1 intentionally keeps PK as the only public behavior;
       // PR2 will add explicit physical-field resolution on top of this seam.
-      val joinKey = snapshotMetadataOpt match {
+      val baseJoinKey = snapshotMetadataOpt match {
         case Some(metadata) =>
           val pkField = metadata.collection.schema.fields
             .find(_.isPrimaryKey.getOrElse(false))
@@ -184,13 +184,17 @@ object MilvusBackfill {
       // depends on the collection's PK name.
       val preparedBackfill = prepareBackfillData(
         rawBackfillDF,
-        joinKey,
-        config.columnMapping
+        baseJoinKey,
+        config.columnMapping,
+        snapshotMetadataOpt.toSeq.flatMap(
+          _.collection.schema.fields.map(_.name)
+        )
       ) match {
         case Left(error) => return Left(error)
         case Right(data) => data
       }
       val mappedBackfillDF = preparedBackfill.dataFrame
+      val joinKey = preparedBackfill.joinKey
 
       val newFieldNames = preparedBackfill.targetFieldNames
 
@@ -584,7 +588,8 @@ object MilvusBackfill {
   private[backfill] def prepareBackfillData(
       df: DataFrame,
       joinKey: ResolvedJoinKey,
-      userMapping: Option[Map[String, String]]
+      userMapping: Option[Map[String, String]],
+      collectionFieldNames: Seq[String] = Seq.empty
   ): Either[BackfillError, PreparedBackfillData] = {
     // The existing mapping contract identifies the first (currently only)
     // component through the collection PK target. Any additional internal
@@ -602,39 +607,36 @@ object MilvusBackfill {
           )
         )
       } else {
-        val reservedCollisions = joinKey.internalColumns.filter(name =>
-          mappedColumns.contains(name) && !joinKey.sourceColumns.contains(name)
+        val caseSensitive = df.sparkSession.conf
+          .get("spark.sql.caseSensitive", "false")
+          .toBoolean
+        val resolver: (String, String) => Boolean =
+          if (caseSensitive) (left, right) => left == right
+          else (left, right) => left.equalsIgnoreCase(right)
+        val allocatedJoinKey = joinKey.withCollisionFreeInternalColumns(
+          mappedColumns ++ collectionFieldNames,
+          resolver
         )
-        if (reservedCollisions.nonEmpty) {
-          Left(
-            SchemaValidationError(
-              s"Backfill parquet contains columns reserved for internal join use: " +
-                reservedCollisions.mkString(", ") +
-                ". Rename the columns (or use --column-mapping) and retry."
-            )
+        val keyAliases =
+          allocatedJoinKey.components.map(c => c.sourceColumn -> c).toMap
+        val normalized = mapped.select(
+          mappedColumns.map { name =>
+            keyAliases.get(name) match {
+              case Some(component) =>
+                mapped.col(name).as(component.internalColumn)
+              case None => mapped.col(name)
+            }
+          }: _*
+        )
+        val targetFieldNames =
+          mappedColumns.filterNot(allocatedJoinKey.sourceColumns.contains)
+        Right(
+          PreparedBackfillData(
+            dataFrame = normalized,
+            joinKey = allocatedJoinKey,
+            targetFieldNames = targetFieldNames
           )
-        } else {
-          val keyAliases =
-            joinKey.components.map(c => c.sourceColumn -> c).toMap
-          val normalized = mapped.select(
-            mappedColumns.map { name =>
-              keyAliases.get(name) match {
-                case Some(component) =>
-                  mapped.col(name).as(component.internalColumn)
-                case None => mapped.col(name)
-              }
-            }: _*
-          )
-          val targetFieldNames =
-            mappedColumns.filterNot(joinKey.sourceColumns.contains)
-          Right(
-            PreparedBackfillData(
-              dataFrame = normalized,
-              joinColumns = joinKey.internalColumns,
-              targetFieldNames = targetFieldNames
-            )
-          )
-        }
+        )
       }
     }
   }

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -37,9 +37,9 @@ object MilvusBackfill {
   private val logger = LoggerFactory.getLogger(getClass)
 
   /** Marker column added to the backfill side before the left join so we can
-    * count how many source rows found a PK match (non-null marker → matched).
-    * Kept on the DataFrame all the way down to the per-segment partition
-    * function, and stripped from the projection written to parquet.
+    * count how many source rows found a join-key match (non-null marker →
+    * matched). Kept on the DataFrame all the way down to the per-segment
+    * partition function, and stripped from the projection written to parquet.
     */
   private[backfill] val MatchFlagCol = "__bf_matched__"
   private[backfill] val SegmentIdCol = MilvusOption.MilvusExtraColumnSegmentID
@@ -50,7 +50,7 @@ object MilvusBackfill {
     * records whether the written value came from the source side and another
     * whether it came from the backfill data file. Semantics differ per mode:
     *   - coalesce: usedSrc = src non-null; usedBf = src null AND bf non-null
-    *   - overwrite: usedSrc = pk unmatched; usedBf = pk matched
+    *   - overwrite: usedSrc = join key unmatched; usedBf = join key matched
     * Used by the writer to tally the per-field `usedSourceByField` /
     * `usedDataFileByField` counts surfaced in `SegmentBackfillResult`.
     */
@@ -138,8 +138,10 @@ object MilvusBackfill {
     }
 
     try {
-      // Step 3: Get PK field info
-      val (pkName, pkFieldId) = snapshotMetadataOpt match {
+      // Step 3: Resolve the current primary-key join into the generic runtime
+      // join-key model. PR1 intentionally keeps PK as the only public behavior;
+      // PR2 will add explicit physical-field resolution on top of this seam.
+      val joinKey = snapshotMetadataOpt match {
         case Some(metadata) =>
           val pkField = metadata.collection.schema.fields
             .find(_.isPrimaryKey.getOrElse(false))
@@ -150,10 +152,15 @@ object MilvusBackfill {
                 )
               )
             )
-          (pkField.name, pkField.getFieldIDAsLong)
+          ResolvedJoinKey.primaryKey(
+            pkField.name,
+            pkField.getFieldIDAsLong,
+            Some(MilvusSnapshotReader.fieldToStructField(pkField))
+          )
         case None =>
           client.getPkField(config.databaseName, config.collectionName) match {
-            case scala.util.Success((name, id)) => (name, id)
+            case scala.util.Success((name, id)) =>
+              ResolvedJoinKey.primaryKey(name, id, None)
             case scala.util.Failure(e) =>
               return Left(
                 ConnectionError(
@@ -171,23 +178,21 @@ object MilvusBackfill {
           case Right(df)   => df
         }
 
-      // Reproject via the column mapping (or legacy implicit mapping) so that
-      // downstream code can assume the DataFrame's column names match the
-      // Milvus schema exactly — in particular, the pk column is named pkName.
-      val mappedBackfillDF = applyColumnMapping(
+      // Reproject via the existing PK column-mapping contract, then separate
+      // the join component from fields that will be written. The join column is
+      // normalized to an internal alias so downstream execution no longer
+      // depends on the collection's PK name.
+      val preparedBackfill = prepareBackfillData(
         rawBackfillDF,
-        pkName,
+        joinKey,
         config.columnMapping
       ) match {
         case Left(error) => return Left(error)
-        case Right(df)   => df
+        case Right(data) => data
       }
+      val mappedBackfillDF = preparedBackfill.dataFrame
 
-      // Extract new field names (all post-mapping columns except the PK).
-      val newFieldNames = mappedBackfillDF.schema.fields
-        .map(_.name)
-        .filterNot(_ == pkName)
-        .toSeq
+      val newFieldNames = preparedBackfill.targetFieldNames
 
       // Reject a backfill column named MatchFlagCol: the join adds a
       // lit(true) marker under that name, which would silently overwrite a
@@ -261,40 +266,26 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
-      // Cache so the upcoming count / distinct-PK aggregation doesn't force
+      // Cache so the upcoming join-key aggregation doesn't force
       // a second parquet scan when performJoin consumes the DF later. The
       // count also eagerly validates every normalized vector row.
       backfillDF.cache()
       cachedBackfillDF = backfillDF
 
-      // One aggregation over the cached DF gives us both totals: the raw
-      // input row count (reported in the result / logs for debugging low
-      // match rates) and the distinct-PK count (used below to fail fast on
-      // duplicates — see rationale there).
-      val countsRow = backfillDF
-        .agg(count(lit(1)), countDistinct(col(pkName)))
-        .head()
-      val backfillRowCount = countsRow.getLong(0)
-      val distinctPkCount = countsRow.getLong(1)
+      val joinKeyStats = validateJoinKeyCardinality(
+        backfillDF,
+        joinKey.internalColumns,
+        joinKey.sourceColumns,
+        side = "Backfill parquet"
+      ) match {
+        case Left(error)  => return Left(error)
+        case Right(stats) => stats
+      }
+      val backfillRowCount = joinKeyStats.rowCount
       logger.info(
         s"Backfill data file rows: $backfillRowCount " +
-          s"(distinct ${pkName}: $distinctPkCount)"
+          s"(distinct join keys: ${joinKeyStats.distinctValidKeyCount})"
       )
-
-      // Duplicate PKs on the backfill side cause each source row with a
-      // matching PK to be emitted once per duplicate by the left join,
-      // inflating per-segment rowCount / sourceRowCount / matchedRowCount.
-      // Rather than silently report misleading metrics, fail fast so the
-      // user can dedupe upstream.
-      if (distinctPkCount != backfillRowCount) {
-        return Left(
-          SchemaValidationError(
-            s"Backfill parquet contains duplicate primary-key values " +
-              s"(rows=$backfillRowCount, distinct ${pkName}=$distinctPkCount). " +
-              "Deduplicate the input (e.g. dropDuplicates on the PK) and retry."
-          )
-        )
-      }
 
       val targetVectorFields = targetFieldsByName.collect {
         case (name, field) if VectorBackfillSupport.isVectorField(field) =>
@@ -341,7 +332,7 @@ object MilvusBackfill {
       val originalDF = readCollectionWithMetadata(
         spark,
         config,
-        pkFieldId,
+        joinKey,
         snapshotMetadataOpt,
         v2Segments,
         extraReadFields
@@ -350,8 +341,8 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
-      // Validate schema compatibility
-      validateSchemaCompatibility(originalDF, backfillDF, pkName) match {
+      // Validate join-key schema compatibility.
+      validateJoinKeyCompatibility(originalDF, backfillDF, joinKey) match {
         case Left(error) => return Left(error)
         case Right(_)    => // Continue
       }
@@ -360,7 +351,7 @@ object MilvusBackfill {
       val joinedDF = performJoin(
         originalDF,
         backfillDF,
-        pkName,
+        joinKey.internalColumns,
         newFieldNames,
         config.mode
       )
@@ -583,19 +574,147 @@ object MilvusBackfill {
     Right(renamed)
   }
 
+  /** Apply the existing PK mapping contract, then normalize identity columns to
+    * private join aliases and return target fields explicitly.
+    *
+    * PR1 still resolves exactly one primary-key component. The sequence-based
+    * shape is intentional so the read and join stages do not need another
+    * signature change when a later PR adds physical or composite keys.
+    */
+  private[backfill] def prepareBackfillData(
+      df: DataFrame,
+      joinKey: ResolvedJoinKey,
+      userMapping: Option[Map[String, String]]
+  ): Either[BackfillError, PreparedBackfillData] = {
+    // The existing mapping contract identifies the first (currently only)
+    // component through the collection PK target. Any additional internal
+    // components must already be present after mapping; this keeps the helper
+    // sequence-shaped without exposing composite keys publicly in PR1.
+    val keyColumn = joinKey.sourceColumns.head
+    applyColumnMapping(df, keyColumn, userMapping).flatMap { mapped =>
+      val mappedColumns = mapped.columns.toSeq
+      val missingKeys = joinKey.sourceColumns.filterNot(mappedColumns.contains)
+      if (missingKeys.nonEmpty) {
+        Left(
+          SchemaValidationError(
+            s"Backfill data is missing join-key columns after column mapping: " +
+              missingKeys.mkString(", ")
+          )
+        )
+      } else {
+        val reservedCollisions = joinKey.internalColumns.filter(name =>
+          mappedColumns.contains(name) && !joinKey.sourceColumns.contains(name)
+        )
+        if (reservedCollisions.nonEmpty) {
+          Left(
+            SchemaValidationError(
+              s"Backfill parquet contains columns reserved for internal join use: " +
+                reservedCollisions.mkString(", ") +
+                ". Rename the columns (or use --column-mapping) and retry."
+            )
+          )
+        } else {
+          val keyAliases =
+            joinKey.components.map(c => c.sourceColumn -> c).toMap
+          val normalized = mapped.select(
+            mappedColumns.map { name =>
+              keyAliases.get(name) match {
+                case Some(component) =>
+                  mapped.col(name).as(component.internalColumn)
+                case None => mapped.col(name)
+              }
+            }: _*
+          )
+          val targetFieldNames =
+            mappedColumns.filterNot(joinKey.sourceColumns.contains)
+          Right(
+            PreparedBackfillData(
+              dataFrame = normalized,
+              joinColumns = joinKey.internalColumns,
+              targetFieldNames = targetFieldNames
+            )
+          )
+        }
+      }
+    }
+  }
+
+  /** Build the ordered field-ID/schema projection used by snapshot reads.
+    * Deduplication happens on the pair before either side is emitted so the
+    * supplied Spark schema always stays aligned with `ReaderFieldIDs`.
+    */
+  private[backfill] def buildSourceReadProjection(
+      joinKey: ResolvedJoinKey,
+      extraReadFields: Seq[
+        (String, Long, org.apache.spark.sql.types.StructField)
+      ]
+  ): Either[BackfillError, SourceReadProjection] = {
+    val missingSchemas = joinKey.components.filter(_.sourceField.isEmpty)
+    if (missingSchemas.nonEmpty) {
+      Left(
+        SchemaValidationError(
+          s"Missing snapshot schema for join-key fields: " +
+            missingSchemas.map(_.sourceColumn).mkString(", ")
+        )
+      )
+    } else {
+      val requested =
+        joinKey.components.map(c => (c.fieldId, c.sourceField.get)) ++
+          extraReadFields.map { case (_, fieldId, field) => (fieldId, field) }
+      val deduped = requested
+        .foldLeft(
+          (
+            Vector.empty[(Long, org.apache.spark.sql.types.StructField)],
+            Set.empty[Long]
+          )
+        ) { case ((fields, seen), item @ (fieldId, _)) =>
+          if (seen.contains(fieldId)) (fields, seen)
+          else (fields :+ item, seen + fieldId)
+        }
+        ._1
+
+      Right(
+        SourceReadProjection(
+          fieldIds = deduped.map(_._1),
+          schema = org.apache.spark.sql.types.StructType(deduped.map(_._2))
+        )
+      )
+    }
+  }
+
+  /** Normalize source-side join columns in one projection. A sequential
+    * `withColumnRenamed` chain can corrupt swaps or rename chains when a source
+    * field happens to use another component's internal name.
+    */
+  private[backfill] def normalizeSourceJoinColumns(
+      df: DataFrame,
+      joinKey: ResolvedJoinKey
+  ): DataFrame = {
+    val sourceAliases =
+      joinKey.components.map(c => c.sourceColumn -> c.internalColumn).toMap
+    df.select(
+      df.columns.toSeq.map { name =>
+        sourceAliases.get(name) match {
+          case Some(alias) => df.col(name).as(alias)
+          case None        => df.col(name)
+        }
+      }: _*
+    )
+  }
+
   /** Read collection data with $segment_id and $row_offset metadata $segment_id
     * and $row_offset are used to match with the original sequence of rows for
     * each segment
     *
-    * @param pkFieldId
-    *   Primary key field ID to read only PK field
+    * @param joinKey
+    *   Resolved source fields used to match backfill input rows
     * @param snapshotMetadata
     *   Optional snapshot metadata for offline reading (no client connection)
     */
   private def readCollectionWithMetadata(
       spark: SparkSession,
       config: BackfillConfig,
-      pkFieldId: Long,
+      joinKey: ResolvedJoinKey,
       snapshotMetadata: Option[SnapshotMetadata],
       v2Segments: Seq[com.zilliz.spark.connector.read.V2SegmentInfo],
       extraReadFields: Seq[
@@ -604,7 +723,7 @@ object MilvusBackfill {
   ): Either[BackfillError, DataFrame] = {
     try {
       var options = config.getMilvusReadOptions
-      val allFieldIds = pkFieldId +: extraReadFields.map(_._2)
+      val allFieldIds = (joinKey.fieldIds ++ extraReadFields.map(_._2)).distinct
       options =
         options + (MilvusOption.ReaderFieldIDs -> allFieldIds.mkString(","))
       options = options + (MilvusOption.ReadApplyDeletes -> "false")
@@ -663,40 +782,25 @@ object MilvusBackfill {
 
       // Build schema from snapshot if available (for snapshot mode)
       val df = snapshotMetadata match {
-        case Some(metadata) =>
-          // For snapshot mode, only include the PK field we need to read (not all user fields)
-          // FFI reader will only read the columns specified in the schema
-          val pkField = metadata.collection.schema.fields
-            .find(_.getFieldIDAsLong == pkFieldId)
-          val pkSchema = pkField match {
-            case Some(field) =>
-              // Create schema with only the PK field
-              import org.apache.spark.sql.types._
-              StructType(Seq(MilvusSnapshotReader.fieldToStructField(field)))
-            case None =>
-              // Fallback: use full schema if PK field not found
-              logger.warn(
-                s"PK field with ID $pkFieldId not found in snapshot schema, using full schema"
-              )
-              MilvusSnapshotReader.toSparkSchema(
-                metadata.collection.schema,
-                includeSystemFields = false
-              )
-          }
-
-          // Extend with any extra fields requested (coalesce / overwrite
-          // modes). Field order in the schema must match the ReaderFieldIDs
-          // order.
-          val withExtras = extraReadFields.foldLeft(pkSchema) {
-            case (acc, (_, _, field)) => acc.add(field)
-          }
+        case Some(_) =>
+          // The supplied schema and ReaderFieldIDs must stay in the same order.
+          // PR1 resolves the PK into one component; the component sequence also
+          // supports future physical/composite key resolvers.
+          val projection =
+            buildSourceReadProjection(joinKey, extraReadFields) match {
+              case Left(error)  => return Left(error)
+              case Right(value) => value
+            }
+          options =
+            options + (MilvusOption.ReaderFieldIDs -> projection.fieldIds
+              .mkString(","))
 
           logger.info(
-            s"Reading with schema: ${withExtras.fieldNames.mkString(", ")}"
+            s"Reading with schema: ${projection.schema.fieldNames.mkString(", ")}"
           )
 
           spark.read
-            .schema(withExtras)
+            .schema(projection.schema)
             .format("com.zilliz.spark.connector.sources.MilvusDataSource")
             .options(options)
             .load()
@@ -707,6 +811,17 @@ object MilvusBackfill {
             .format("com.zilliz.spark.connector.sources.MilvusDataSource")
             .options(options)
             .load()
+      }
+
+      val missingSourceJoinColumns =
+        joinKey.sourceColumns.filterNot(df.columns.contains)
+      if (missingSourceJoinColumns.nonEmpty) {
+        return Left(
+          ConnectionError(
+            message = s"Failed to read collection join-key columns: " +
+              missingSourceJoinColumns.mkString(", ")
+          )
+        )
       }
 
       if (
@@ -721,7 +836,7 @@ object MilvusBackfill {
         )
       }
 
-      Right(df)
+      Right(normalizeSourceJoinColumns(df, joinKey))
     } catch {
       case e: Exception =>
         logger.error(
@@ -776,53 +891,135 @@ object MilvusBackfill {
     }
   }
 
-  /** Validate schema compatibility between original and new field data
+  /** Validate that a DataFrame contains a non-null, unique join key.
+    *
+    * A duplicate on the backfill side would fan one source row out into
+    * multiple joined rows and corrupt per-segment row counts. Nulls are
+    * reported separately because Spark equi-joins never match null keys.
     */
-  private def validateSchemaCompatibility(
-      originalDF: DataFrame,
-      backfillDF: DataFrame,
-      pkName: String
-  ): Either[BackfillError, Unit] = {
+  private[backfill] def validateJoinKeyCardinality(
+      df: DataFrame,
+      joinColumns: Seq[String],
+      displayColumns: Seq[String],
+      side: String
+  ): Either[BackfillError, JoinKeyStats] = {
+    if (joinColumns.isEmpty) {
+      return Left(SchemaValidationError("Join key must not be empty"))
+    }
+
+    val missing = joinColumns.filterNot(df.columns.contains)
+    if (missing.nonEmpty) {
+      return Left(
+        SchemaValidationError(
+          s"$side is missing internal join-key columns: ${missing.mkString(", ")}"
+        )
+      )
+    }
+
     try {
-      // Find the primary key field in original data
-      val pkField = originalDF.schema.fields
-        .find(_.name == pkName)
-        .getOrElse {
-          return Left(
-            SchemaValidationError(
-              s"Original collection data must have primary key field '$pkName'"
-            )
-          )
-        }
-
-      // Find the pk field in new field data (post-mapping column name = pkName)
-      val newPkField = backfillDF.schema.fields
-        .find(_.name == pkName)
-        .getOrElse {
-          return Left(
-            SchemaValidationError(
-              s"Backfill data must have PK field '$pkName' (after column mapping)"
-            )
-          )
-        }
-
-      // Validate types match
-      if (pkField.dataType != newPkField.dataType) {
-        return Left(
-          SchemaValidationError(
-            s"Primary key type mismatch: original=${pkField.dataType}, new=${newPkField.dataType}"
+      val hasNull = joinColumns.map(name => col(name).isNull).reduce(_ || _)
+      val keyValue = struct(joinColumns.map(col): _*)
+      val counts = df
+        .agg(
+          count(lit(1)).as("__bf_key_rows__"),
+          coalesce(
+            sum(when(hasNull, lit(1L)).otherwise(lit(0L))),
+            lit(0L)
+          ).as("__bf_null_key_rows__"),
+          countDistinct(when(!hasNull, keyValue)).as(
+            "__bf_distinct_valid_keys__"
           )
         )
+        .head()
+
+      val stats = JoinKeyStats(
+        rowCount = counts.getAs[Long]("__bf_key_rows__"),
+        nullKeyRowCount = counts.getAs[Long]("__bf_null_key_rows__"),
+        distinctValidKeyCount = counts.getAs[Long](
+          "__bf_distinct_valid_keys__"
+        )
+      )
+      val display = displayColumns.mkString("(", ", ", ")")
+
+      if (stats.nullKeyRowCount > 0) {
+        Left(
+          SchemaValidationError(
+            s"$side contains ${stats.nullKeyRowCount} row(s) with null join key " +
+              s"$display. Join keys must be non-null."
+          )
+        )
+      } else if (stats.distinctValidKeyCount != stats.rowCount) {
+        Left(
+          SchemaValidationError(
+            s"$side contains duplicate join-key values " +
+              s"(columns=$display, rows=${stats.rowCount}, " +
+              s"distinct=${stats.distinctValidKeyCount}). " +
+              "Deduplicate the input on the join key and retry."
+          )
+        )
+      } else {
+        Right(stats)
+      }
+    } catch {
+      case e: Exception =>
+        Left(
+          SchemaValidationError(
+            s"Failed to validate $side join key: ${e.getMessage}",
+            Some(e)
+          )
+        )
+    }
+  }
+
+  /** Validate join-key schema compatibility between source and backfill data.
+    */
+  private[backfill] def validateJoinKeyCompatibility(
+      originalDF: DataFrame,
+      backfillDF: DataFrame,
+      joinKey: ResolvedJoinKey
+  ): Either[BackfillError, Unit] = {
+    try {
+      joinKey.components.foreach { component =>
+        val sourceField = originalDF.schema.fields
+          .find(_.name == component.internalColumn)
+          .getOrElse {
+            return Left(
+              SchemaValidationError(
+                s"Original collection data must have join-key field " +
+                  s"'${component.sourceColumn}'"
+              )
+            )
+          }
+
+        val backfillField = backfillDF.schema.fields
+          .find(_.name == component.internalColumn)
+          .getOrElse {
+            return Left(
+              SchemaValidationError(
+                s"Backfill data must have join-key field " +
+                  s"'${component.sourceColumn}' after column mapping"
+              )
+            )
+          }
+
+        if (sourceField.dataType != backfillField.dataType) {
+          return Left(
+            SchemaValidationError(
+              s"Join-key type mismatch for '${component.sourceColumn}': " +
+                s"original=${sourceField.dataType}, new=${backfillField.dataType}"
+            )
+          )
+        }
       }
 
       Right(())
 
     } catch {
       case e: Exception =>
-        logger.error("Failed to validate schema compatibility", e)
+        logger.error("Failed to validate join-key schema compatibility", e)
         Left(
           SchemaValidationError(
-            s"Failed to validate schema compatibility: ${e.getMessage}"
+            s"Failed to validate join-key schema compatibility: ${e.getMessage}"
           )
         )
     }
@@ -830,22 +1027,22 @@ object MilvusBackfill {
 
   /** Merge original (source) rows with backfill rows per `mode`.
     *
-    *   - replace: left join on PK; backfill value replaces source (source only
-    *     contributes PK + segment tracking columns). Unmatched source rows end
-    *     up with null target columns.
+    *   - replace: left join on the resolved key; backfill value replaces source
+    *     (source only contributes join + segment tracking columns). Unmatched
+    *     source rows end up with null target columns.
     *   - coalesce: source side carries the target fields; after the left join,
     *     compute `coalesce(src, backfill)` per field (source wins when
     *     non-null, otherwise use backfill). Unmatched source rows keep their
     *     original target values.
     *   - overwrite: source side carries the target fields; after the left join,
     *     compute `when(matched, backfill).otherwise(src)` per field (file wins
-    *     when the pk matched, even if the file value is null). Unmatched source
-    *     rows keep their original target values.
+    *     when the join key matched, even if the file value is null). Unmatched
+    *     source rows keep their original target values.
     */
   private[backfill] def performJoin(
       originalDF: DataFrame,
       backfillDF: DataFrame,
-      pkName: String,
+      joinColumns: Seq[String],
       newFieldNames: Seq[String],
       mode: String
   ): DataFrame = {
@@ -860,7 +1057,7 @@ object MilvusBackfill {
           (df, n) =>
             df.withColumnRenamed(n, n + suffix)
         }
-        val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
+        val joined = originalDF.join(renamedBackfill, joinColumns, "left")
         // Attach per-field provenance flags BEFORE the coalesce rewrites `n`,
         // so the flags bind to the unresolved source-side `n` attribute. This
         // keeps the flags accurate even though the later coalesce shadows the
@@ -885,7 +1082,7 @@ object MilvusBackfill {
           (df, n) =>
             df.withColumnRenamed(n, n + suffix)
         }
-        val joined = originalDF.join(renamedBackfill, Seq(pkName), "left")
+        val joined = originalDF.join(renamedBackfill, joinColumns, "left")
         // Match flag is null for unmatched left rows, non-null for matched.
         // Using it (rather than `bf.isNotNull`) preserves overwrite's "file
         // wins, null included" semantics when the file explicitly stores null.
@@ -902,10 +1099,10 @@ object MilvusBackfill {
         }
 
       case MilvusOption.BackfillModeReplace =>
-        // Use the using-column join form: both sides share the pkName column
-        // (guaranteed by applyColumnMapping), so Spark collapses it into one,
+        // Use the using-column join form: both sides share the internal join
+        // columns, so Spark collapses them into one,
         // avoiding ambiguous-reference errors downstream.
-        originalDF.join(backfillWithFlag, Seq(pkName), "left")
+        originalDF.join(backfillWithFlag, joinColumns, "left")
 
       case other =>
         // Defensive: validate() rejects anything else, but keep a clear error

--- a/src/test/scala/operations/backfill/BackfillModeTest.scala
+++ b/src/test/scala/operations/backfill/BackfillModeTest.scala
@@ -140,6 +140,209 @@ class BackfillModeTest
     spark.createDataFrame(spark.sparkContext.parallelize(javaRows), schema)
   }
 
+  test("join-key cardinality accepts unique non-null keys") {
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1), Row(2))),
+      StructType(Seq(StructField("join_key", IntegerType, nullable = false)))
+    )
+
+    MilvusBackfill.validateJoinKeyCardinality(
+      df,
+      Seq("join_key"),
+      Seq("pk"),
+      "Backfill parquet"
+    ) shouldBe Right(JoinKeyStats(2L, 0L, 2L))
+  }
+
+  test("join-key cardinality rejects null keys separately from duplicates") {
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(Int.box(1)), Row(null))),
+      StructType(Seq(StructField("join_key", IntegerType, nullable = true)))
+    )
+
+    val err = MilvusBackfill
+      .validateJoinKeyCardinality(
+        df,
+        Seq("join_key"),
+        Seq("pk"),
+        "Backfill parquet"
+      )
+      .left
+      .toOption
+      .get
+
+    err.message should include("null join key")
+    err.message should include("(pk)")
+  }
+
+  test("join-key cardinality rejects duplicate keys") {
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1), Row(1))),
+      StructType(Seq(StructField("join_key", IntegerType, nullable = false)))
+    )
+
+    val err = MilvusBackfill
+      .validateJoinKeyCardinality(
+        df,
+        Seq("join_key"),
+        Seq("pk"),
+        "Backfill parquet"
+      )
+      .left
+      .toOption
+      .get
+
+    err.message should include("duplicate join-key values")
+    err.message should include("distinct=1")
+  }
+
+  test("join-key cardinality validates composite tuples") {
+    val unique = spark.createDataFrame(
+      spark.sparkContext.parallelize(
+        Seq(Row(1, "a"), Row(1, "b"), Row(2, "a"))
+      ),
+      StructType(
+        Seq(
+          StructField("k1", IntegerType, nullable = false),
+          StructField("k2", StringType, nullable = false)
+        )
+      )
+    )
+    val duplicate = unique.union(unique.limit(1))
+
+    MilvusBackfill.validateJoinKeyCardinality(
+      unique,
+      Seq("k1", "k2"),
+      Seq("file", "row"),
+      "Backfill parquet"
+    ) shouldBe Right(JoinKeyStats(3L, 0L, 3L))
+
+    MilvusBackfill
+      .validateJoinKeyCardinality(
+        duplicate,
+        Seq("k1", "k2"),
+        Seq("file", "row"),
+        "Backfill parquet"
+      )
+      .isLeft shouldBe true
+  }
+
+  test("source read projection keeps field IDs aligned with schema order") {
+    val pkField = StructField("pk", IntegerType, nullable = false)
+    val joinKey = ResolvedJoinKey.primaryKey("pk", 100L, Some(pkField))
+    val projection = MilvusBackfill
+      .buildSourceReadProjection(
+        joinKey,
+        Seq(
+          ("pk", 100L, pkField),
+          ("f1", 101L, StructField("f1", StringType, nullable = true))
+        )
+      )
+      .toOption
+      .get
+
+    projection.fieldIds shouldBe Seq(100L, 101L)
+    projection.schema.fieldNames.toSeq shouldBe Seq("pk", "f1")
+  }
+
+  test("source join normalization preserves rename swaps in one projection") {
+    val joinKey = ResolvedJoinKey(
+      kind = "test_swap",
+      components = Seq(
+        ResolvedJoinComponent("a", 100L, None, "b"),
+        ResolvedJoinComponent("b", 101L, None, "a")
+      )
+    )
+    val source = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row("A", "B", 10L))),
+      StructType(
+        Seq(
+          StructField("a", StringType, nullable = false),
+          StructField("b", StringType, nullable = false),
+          StructField(MilvusBackfill.SegmentIdCol, LongType, nullable = false)
+        )
+      )
+    )
+
+    val normalized = MilvusBackfill.normalizeSourceJoinColumns(source, joinKey)
+    val row = normalized.collect().head
+
+    row.getAs[String]("b") shouldBe "A"
+    row.getAs[String]("a") shouldBe "B"
+    row.getAs[Long](MilvusBackfill.SegmentIdCol) shouldBe 10L
+  }
+
+  test("join-key compatibility checks normalized component types") {
+    val internal = ResolvedJoinKey.internalColumn(0)
+    val joinKey = ResolvedJoinKey.primaryKey("pk", 100L, None)
+    val source = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1))),
+      StructType(Seq(StructField(internal, IntegerType, nullable = false)))
+    )
+    val matching = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1))),
+      StructType(Seq(StructField(internal, IntegerType, nullable = false)))
+    )
+    val mismatched = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1L))),
+      StructType(Seq(StructField(internal, LongType, nullable = false)))
+    )
+
+    MilvusBackfill.validateJoinKeyCompatibility(
+      source,
+      matching,
+      joinKey
+    ) shouldBe Right(())
+
+    val err = MilvusBackfill
+      .validateJoinKeyCompatibility(source, mismatched, joinKey)
+      .left
+      .toOption
+      .get
+    err.message should include("Join-key type mismatch")
+    err.message should include("pk")
+  }
+
+  test("performJoin supports multiple resolved join components") {
+    val original = spark.createDataFrame(
+      spark.sparkContext.parallelize(
+        Seq(Row(1, "a", 10L, 0L), Row(1, "b", 10L, 1L))
+      ),
+      StructType(
+        Seq(
+          StructField("k1", IntegerType, nullable = false),
+          StructField("k2", StringType, nullable = false),
+          StructField(MilvusBackfill.SegmentIdCol, LongType, nullable = false),
+          StructField(MilvusBackfill.RowOffsetCol, LongType, nullable = false)
+        )
+      )
+    )
+    val backfill = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(1, "a", "matched"))),
+      StructType(
+        Seq(
+          StructField("k1", IntegerType, nullable = false),
+          StructField("k2", StringType, nullable = false),
+          StructField("value", StringType, nullable = true)
+        )
+      )
+    )
+
+    val joined = MilvusBackfill.performJoin(
+      original,
+      backfill,
+      Seq("k1", "k2"),
+      Seq("value"),
+      MilvusOption.BackfillModeReplace
+    )
+
+    joined
+      .orderBy("k2")
+      .collect()
+      .map(r => (r.getAs[String]("k2"), Option(r.getAs[String]("value"))))
+      .toSeq shouldBe Seq(("a", Some("matched")), ("b", None))
+  }
+
   test("replace mode: source has only PK, backfill values win") {
     val originalSchema = StructType(
       Seq(
@@ -164,7 +367,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeReplace
     )
@@ -214,7 +417,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeCoalesce
     )
@@ -350,7 +553,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeCoalesce
     )
@@ -395,7 +598,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeCoalesce
     )
@@ -439,7 +642,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeOverwrite
     )
@@ -497,7 +700,7 @@ class BackfillModeTest
     val joined = MilvusBackfill.performJoin(
       original,
       backfill,
-      "pk",
+      Seq("pk"),
       Seq("f1", "f2"),
       MilvusOption.BackfillModeOverwrite
     )

--- a/src/test/scala/operations/backfill/ColumnMappingTest.scala
+++ b/src/test/scala/operations/backfill/ColumnMappingTest.scala
@@ -99,6 +99,16 @@ class ColumnMappingTest
     )
   }
 
+  private def withCaseSensitiveAnalysis[T](enabled: Boolean)(body: => T): T = {
+    val previous = spark.conf.get("spark.sql.caseSensitive", "false")
+    spark.conf.set("spark.sql.caseSensitive", enabled.toString)
+    try {
+      body
+    } finally {
+      spark.conf.set("spark.sql.caseSensitive", previous)
+    }
+  }
+
   test("applyColumnMapping: explicit mapping renames, drops unlisted columns") {
     val df = buildDf(
       Seq("pk", "vec", "extra"),
@@ -269,26 +279,88 @@ class ColumnMappingTest
     prepared.targetFieldNames shouldBe Seq("embedding")
   }
 
-  test("prepareBackfillData rejects internal join-column collisions") {
+  test("prepareBackfillData preserves a target named like the default alias") {
+    val defaultAlias = ResolvedJoinKey.internalColumn(0)
+    val allocatedAlias = ResolvedJoinKey.internalColumn(0, 1)
     val df = buildDf(
-      Seq("pk", ResolvedJoinKey.internalColumn(0), "vec"),
+      Seq("pk", defaultAlias, "vec"),
       Seq(Seq(1, "reserved", "v1"))
     )
 
-    val err = MilvusBackfill
+    val prepared = MilvusBackfill
       .prepareBackfillData(df, resolvedPk("id"), None)
-      .left
       .toOption
       .get
 
-    err shouldBe a[SchemaValidationError]
-    err.message should include("reserved for internal join use")
+    prepared.joinColumns shouldBe Seq(allocatedAlias)
+    prepared.joinKey.internalColumns shouldBe Seq(allocatedAlias)
+    prepared.targetFieldNames shouldBe Seq(defaultAlias, "vec")
+    prepared.dataFrame.columns.toSeq shouldBe Seq(
+      allocatedAlias,
+      defaultAlias,
+      "vec"
+    )
+    val row = prepared.dataFrame.collect().head
+    row.getAs[Int](allocatedAlias) shouldBe 1
+    row.getAs[String](defaultAlias) shouldBe "reserved"
+  }
+
+  test("prepareBackfillData avoids case variants under the default resolver") {
+    withCaseSensitiveAnalysis(false) {
+      val caseVariant = "__BF_JOIN_0__"
+      val allocatedAlias = ResolvedJoinKey.internalColumn(0, 1)
+      val df = buildDf(
+        Seq("pk", caseVariant, "vec"),
+        Seq(Seq(1, "target", "v1"))
+      )
+
+      val prepared = MilvusBackfill
+        .prepareBackfillData(df, resolvedPk("id"), None)
+        .toOption
+        .get
+
+      prepared.joinColumns shouldBe Seq(allocatedAlias)
+      prepared.targetFieldNames shouldBe Seq(caseVariant, "vec")
+      MilvusBackfill
+        .validateJoinKeyCardinality(
+          prepared.dataFrame,
+          prepared.joinColumns,
+          Seq("id"),
+          "Backfill parquet"
+        )
+        .isRight shouldBe true
+    }
+  }
+
+  test("prepareBackfillData honors Spark's case-sensitive resolver") {
+    withCaseSensitiveAnalysis(true) {
+      val caseVariant = "__BF_JOIN_0__"
+      val defaultAlias = ResolvedJoinKey.internalColumn(0)
+      val df = buildDf(
+        Seq("pk", caseVariant, "vec"),
+        Seq(Seq(1, "target", "v1"))
+      )
+
+      val prepared = MilvusBackfill
+        .prepareBackfillData(df, resolvedPk("id"), None)
+        .toOption
+        .get
+
+      prepared.joinColumns shouldBe Seq(defaultAlias)
+      prepared.targetFieldNames shouldBe Seq(caseVariant, "vec")
+      prepared.dataFrame.columns.toSeq shouldBe Seq(
+        defaultAlias,
+        caseVariant,
+        "vec"
+      )
+    }
   }
 
   test(
     "prepareBackfillData permits a collection PK named like the internal alias"
   ) {
     val internal = ResolvedJoinKey.internalColumn(0)
+    val allocatedAlias = ResolvedJoinKey.internalColumn(0, 1)
     val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
 
     val prepared = MilvusBackfill
@@ -296,8 +368,28 @@ class ColumnMappingTest
       .toOption
       .get
 
-    prepared.dataFrame.columns.toSeq shouldBe Seq(internal, "vec")
+    prepared.joinColumns shouldBe Seq(allocatedAlias)
+    prepared.dataFrame.columns.toSeq shouldBe Seq(allocatedAlias, "vec")
     prepared.targetFieldNames shouldBe Seq("vec")
+  }
+
+  test("prepareBackfillData avoids collection-only field-name collisions") {
+    val defaultAlias = ResolvedJoinKey.internalColumn(0)
+    val allocatedAlias = ResolvedJoinKey.internalColumn(0, 1)
+    val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
+
+    val prepared = MilvusBackfill
+      .prepareBackfillData(
+        df,
+        resolvedPk("id"),
+        None,
+        collectionFieldNames = Seq(defaultAlias)
+      )
+      .toOption
+      .get
+
+    prepared.joinColumns shouldBe Seq(allocatedAlias)
+    prepared.dataFrame.columns.toSeq shouldBe Seq(allocatedAlias, "vec")
   }
 
   test("prepareBackfillData normalizes multiple internal join components") {

--- a/src/test/scala/operations/backfill/ColumnMappingTest.scala
+++ b/src/test/scala/operations/backfill/ColumnMappingTest.scala
@@ -216,4 +216,122 @@ class ColumnMappingTest
     err shouldBe a[SchemaValidationError]
     err.message should include("non-PK")
   }
+
+  // ============ prepareBackfillData ============
+
+  private def resolvedPk(name: String): ResolvedJoinKey =
+    ResolvedJoinKey.primaryKey(name, 100L, None)
+
+  test(
+    "prepareBackfillData keeps legacy pk mapping but uses internal join alias"
+  ) {
+    val df = buildDf(
+      Seq("pk", "vec"),
+      Seq(Seq(1, "v1"), Seq(2, "v2"))
+    )
+
+    val prepared = MilvusBackfill
+      .prepareBackfillData(df, resolvedPk("id"), None)
+      .toOption
+      .get
+
+    prepared.joinColumns shouldBe Seq(ResolvedJoinKey.internalColumn(0))
+    prepared.targetFieldNames shouldBe Seq("vec")
+    prepared.dataFrame.columns.toSeq shouldBe Seq(
+      ResolvedJoinKey.internalColumn(0),
+      "vec"
+    )
+    prepared.dataFrame
+      .orderBy(ResolvedJoinKey.internalColumn(0))
+      .collect()
+      .map(r => (r.getInt(0), r.getString(1)))
+      .toSeq shouldBe Seq((1, "v1"), (2, "v2"))
+  }
+
+  test(
+    "prepareBackfillData separates explicitly mapped PK from target fields"
+  ) {
+    val df = buildDf(
+      Seq("source_id", "vec", "drop_me"),
+      Seq(Seq("1", "v1", "x"))
+    )
+    val mapping = Some(Map("source_id" -> "id", "vec" -> "embedding"))
+
+    val prepared = MilvusBackfill
+      .prepareBackfillData(df, resolvedPk("id"), mapping)
+      .toOption
+      .get
+
+    prepared.dataFrame.columns.toSeq shouldBe Seq(
+      ResolvedJoinKey.internalColumn(0),
+      "embedding"
+    )
+    prepared.targetFieldNames shouldBe Seq("embedding")
+  }
+
+  test("prepareBackfillData rejects internal join-column collisions") {
+    val df = buildDf(
+      Seq("pk", ResolvedJoinKey.internalColumn(0), "vec"),
+      Seq(Seq(1, "reserved", "v1"))
+    )
+
+    val err = MilvusBackfill
+      .prepareBackfillData(df, resolvedPk("id"), None)
+      .left
+      .toOption
+      .get
+
+    err shouldBe a[SchemaValidationError]
+    err.message should include("reserved for internal join use")
+  }
+
+  test(
+    "prepareBackfillData permits a collection PK named like the internal alias"
+  ) {
+    val internal = ResolvedJoinKey.internalColumn(0)
+    val df = buildDf(Seq("pk", "vec"), Seq(Seq(1, "v1")))
+
+    val prepared = MilvusBackfill
+      .prepareBackfillData(df, resolvedPk(internal), None)
+      .toOption
+      .get
+
+    prepared.dataFrame.columns.toSeq shouldBe Seq(internal, "vec")
+    prepared.targetFieldNames shouldBe Seq("vec")
+  }
+
+  test("prepareBackfillData normalizes multiple internal join components") {
+    val joinKey = ResolvedJoinKey(
+      kind = "test_composite",
+      components = Seq(
+        ResolvedJoinComponent(
+          "id",
+          100L,
+          None,
+          ResolvedJoinKey.internalColumn(0)
+        ),
+        ResolvedJoinComponent(
+          "row_number",
+          101L,
+          None,
+          ResolvedJoinKey.internalColumn(1)
+        )
+      )
+    )
+    val df = buildDf(
+      Seq("pk", "row_number", "vec"),
+      Seq(Seq(1, "7", "v1"))
+    )
+
+    val prepared = MilvusBackfill
+      .prepareBackfillData(df, joinKey, None)
+      .toOption
+      .get
+
+    prepared.joinColumns shouldBe Seq(
+      ResolvedJoinKey.internalColumn(0),
+      ResolvedJoinKey.internalColumn(1)
+    )
+    prepared.targetFieldNames shouldBe Seq("vec")
+  }
 }


### PR DESCRIPTION
- model resolved join keys as component sequences with internal aliases
- separate backfill join columns from fields written to storage
- generalize source projection, key validation, and merge joins
- preserve the existing PK-only configuration and result JSON contract
- add composite-key seam tests and document the PR1/PR2 split