### PR TITLE
fix: [backfill] honor platform AssumeRole configuration

### DIFF
--- a/src/main/scala/loon/Properties.scala
+++ b/src/main/scala/loon/Properties.scala
@@ -18,6 +18,17 @@ object Properties {
   ): Option[String] =
     options.get(FsConfig.FsBucketName).map(_.trim).filter(_.nonEmpty)
 
+  private[loon] def normalizedAssumeRoleOptions(
+      options: scala.collection.Map[String, String]
+  ): Map[String, String] =
+    Seq(
+      FsConfig.FsRoleArn,
+      FsConfig.FsSessionName,
+      FsConfig.FsExternalId
+    ).flatMap { key =>
+      options.get(key).map(_.trim).filter(_.nonEmpty).map(key -> _)
+    }.toMap
+
   /** Filesystem configuration constants for Storage V2 (matching milvus-storage
     * C++ API)
     */
@@ -35,6 +46,9 @@ object Properties {
     val FsUseSSL = "fs.use_ssl"
     val FsSslCaCert = "fs.ssl_ca_cert"
     val FsUseIam = "fs.use_iam"
+    val FsRoleArn = "fs.role_arn"
+    val FsSessionName = "fs.session_name"
+    val FsExternalId = "fs.external_id"
     val FsUseVirtualHost = "fs.use_virtual_host"
     val FsRequestTimeoutMs = "fs.request_timeout_ms"
     val FsGcpNativeWithoutAuth = "fs.gcp_native_without_auth"
@@ -126,6 +140,9 @@ object Properties {
       .get(FsConfig.FsSslCaCert)
       .foreach(propsMap.put(FsConfig.FsSslCaCert, _))
     normalizedUseIamValue.foreach(propsMap.put(FsConfig.FsUseIam, _))
+    normalizedAssumeRoleOptions(milvusOption.options).foreach {
+      case (key, value) => propsMap.put(key, value)
+    }
     milvusOption.options
       .get(FsConfig.FsUseVirtualHost)
       .foreach(propsMap.put(FsConfig.FsUseVirtualHost, _))

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -108,17 +108,13 @@ object BackfillApp {
     spark.sparkContext.setLogLevel("WARN")
 
     try {
-      val config = baseConfig.withHadoopStorageAssumeRole(
-        spark.sparkContext.hadoopConfiguration,
-        spark.sparkContext.applicationId
-      )
-      MilvusBackfill.run(spark, parquetPath, snapshotPath, config) match {
+      MilvusBackfill.run(spark, parquetPath, snapshotPath, baseConfig) match {
         case Right(result) =>
           println(result.summary)
           println(result.segmentSummary)
           parsed.get("output-result").foreach { outputPath =>
             MilvusBackfill
-              .writeResultJson(spark, result, outputPath, config) match {
+              .writeResultJson(spark, result, outputPath, baseConfig) match {
               case Right(_) =>
                 println(s"Result JSON written to: $outputPath")
               case Left(err) =>

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -108,7 +108,7 @@ object BackfillApp {
     spark.sparkContext.setLogLevel("WARN")
 
     try {
-      val config = baseConfig.withHadoopS3AssumeRole(
+      val config = baseConfig.withHadoopStorageAssumeRole(
         spark.sparkContext.hadoopConfiguration,
         spark.sparkContext.applicationId
       )

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -11,7 +11,8 @@ import com.zilliz.spark.connector.MilvusOption
   * spark-connector-assembly.jar \ --parquet <path> --snapshot <path> \
   * --s3-endpoint <endpoint> --s3-bucket <bucket> \ --s3-access-key <key>
   * --s3-secret-key <secret> \ [--s3-root-path <path>] [--s3-region <region>]
-  * [--s3-use-ssl] \ [--batch-size <n>] [--output-result <path>] \ [--mode
+  * [--s3-cloud-provider aws|aliyun|gcp|azure|tencent|huawei] [--s3-use-ssl] \
+  * [--batch-size <n>] [--output-result <path>] \ [--mode
   * replace|coalesce|overwrite]
   *
   * --mode:
@@ -70,6 +71,10 @@ object BackfillApp {
       s3UseSSL = parsed.contains("s3-use-ssl"),
       s3RootPath = parsed.getOrElse("s3-root-path", "files"),
       s3Region = parsed.getOrElse("s3-region", "us-east-1"),
+      s3CloudProvider = parsed.getOrElse(
+        "s3-cloud-provider",
+        BackfillConfig.DefaultCloudProvider
+      ),
       s3UseIam = useIam,
       sourceS3Endpoint = parsed.get("source-s3-endpoint"),
       sourceS3AccessKey = parsed.get("source-s3-access-key"),
@@ -153,6 +158,7 @@ object BackfillApp {
     "s3-secret-key",
     "s3-root-path",
     "s3-region",
+    "s3-cloud-provider",
     "source-s3-endpoint",
     "source-s3-access-key",
     "source-s3-secret-key",

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -62,7 +62,7 @@ object BackfillApp {
       ) Some(false)
       else None
 
-    val config = BackfillConfig(
+    val baseConfig = BackfillConfig(
       s3Endpoint = s3Endpoint,
       s3BucketName = s3Bucket,
       s3AccessKey = s3AccessKey,
@@ -89,7 +89,7 @@ object BackfillApp {
     // user's log config hides INFO.
     if (!parsed.contains("mode")) {
       System.err.println(
-        s"[BackfillApp] --mode not set; defaulting to '${config.mode}' " +
+        s"[BackfillApp] --mode not set; defaulting to '${baseConfig.mode}' " +
           s"(fill-if-null). Pass '--mode ${MilvusOption.BackfillModeReplace}' " +
           "for the pre-#91 full-overwrite behavior, or " +
           s"'--mode ${MilvusOption.BackfillModeOverwrite}' to overwrite only " +
@@ -103,6 +103,10 @@ object BackfillApp {
     spark.sparkContext.setLogLevel("WARN")
 
     try {
+      val config = baseConfig.withHadoopS3AssumeRole(
+        spark.sparkContext.hadoopConfiguration,
+        spark.sparkContext.applicationId
+      )
       MilvusBackfill.run(spark, parquetPath, snapshotPath, config) match {
         case Right(result) =>
           println(result.summary)

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -1,5 +1,8 @@
 package com.zilliz.spark.connector.operations.backfill
 
+import org.apache.hadoop.conf.Configuration
+
+import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.MilvusOption
 
 /** Configuration for backfill operation
@@ -89,7 +92,14 @@ case class BackfillConfig(
     //   "replace" — parquet is the absolute source of truth: every source
     //     row's target field becomes the parquet value (null if the pk has
     //     no parquet match). Destructive on unmatched rows.
-    mode: String = MilvusOption.BackfillModeCoalesce
+    mode: String = MilvusOption.BackfillModeCoalesce,
+
+    // Optional main-storage AssumeRole settings. BackfillApp derives these
+    // from an existing Hadoop S3A configuration when the runtime platform has
+    // already selected a data role for the job.
+    s3RoleArn: Option[String] = None,
+    s3RoleSessionName: Option[String] = None,
+    s3ExternalId: Option[String] = None
 ) {
 
   /** Whether the merge path needs to read each target field from the source
@@ -103,6 +113,12 @@ case class BackfillConfig(
   /** Validate S3 and writer configuration (always required)
     */
   def validate(): Either[String, Unit] = {
+    val normalizedRoleArn = s3RoleArn.map(_.trim).filter(_.nonEmpty)
+    val hasRoleDetails =
+      s3RoleSessionName.exists(_.trim.nonEmpty) || s3ExternalId.exists(
+        _.trim.nonEmpty
+      )
+
     if (s3Endpoint.isEmpty) {
       Left("s3Endpoint cannot be empty")
     } else if (s3BucketName.isEmpty) {
@@ -126,6 +142,10 @@ case class BackfillConfig(
       Left(
         "s3AccessKey and s3SecretKey must both be set unless s3UseIam=true"
       )
+    } else if (normalizedRoleArn.nonEmpty && !s3UseIam) {
+      Left("s3RoleArn requires s3UseIam=true")
+    } else if (normalizedRoleArn.isEmpty && hasRoleDetails) {
+      Left("s3RoleSessionName and s3ExternalId require s3RoleArn")
     } else {
       // Same invariant for the source (input parquet) bucket. Any field
       // left as None falls back to the main credentials, which we already
@@ -166,30 +186,23 @@ case class BackfillConfig(
     * field to minimize data transfer for join operation
     */
   def getMilvusReadOptions: Map[String, String] = {
-    var options = Map(
-      "milvus.uri" -> milvusUri,
-      "milvus.token" -> milvusToken,
-      "milvus.database.name" -> databaseName,
-      "milvus.collection.name" -> collectionName,
-      MilvusOption.MilvusExtraColumns -> Seq(
-        MilvusOption.MilvusExtraColumnSegmentID,
-        MilvusOption.MilvusExtraColumnRowOffset
-      ).mkString(","),
-      "fs.address" -> s3Endpoint,
-      "fs.bucket_name" -> s3BucketName,
-      "fs.root_path" -> s3RootPath,
-      "fs.use_ssl" -> s3UseSSL.toString,
-      "fs.use_iam" -> s3UseIam.toString
-    )
-    // Only inject static credentials when NOT in IAM mode. Under IRSA the FFI
-    // must consult the AWS default credentials chain — passing fake AK/SK
-    // (or the "minioadmin" defaults from Properties.scala) breaks signing.
-    if (!s3UseIam) {
-      options = options ++ Map(
-        "fs.access_key_id" -> s3AccessKey,
-        "fs.access_key_value" -> s3SecretKey
+    var options = withS3Authentication(
+      Map(
+        "milvus.uri" -> milvusUri,
+        "milvus.token" -> milvusToken,
+        "milvus.database.name" -> databaseName,
+        "milvus.collection.name" -> collectionName,
+        MilvusOption.MilvusExtraColumns -> Seq(
+          MilvusOption.MilvusExtraColumnSegmentID,
+          MilvusOption.MilvusExtraColumnRowOffset
+        ).mkString(","),
+        "fs.address" -> s3Endpoint,
+        "fs.bucket_name" -> s3BucketName,
+        "fs.root_path" -> s3RootPath,
+        "fs.use_ssl" -> s3UseSSL.toString,
+        "fs.use_iam" -> s3UseIam.toString
       )
-    }
+    )
 
     // Add optional configurations
     partitionName.foreach(p =>
@@ -221,28 +234,21 @@ case class BackfillConfig(
       segmentId: Long,
       fieldNameToId: Map[String, Long] = Map.empty
   ): Map[String, String] = {
-    var opts = Map(
-      "fs.storage_type" -> "remote",
-      "fs.address" -> s3Endpoint,
-      "fs.bucket_name" -> s3BucketName,
-      "fs.root_path" -> s3RootPath,
-      "fs.use_ssl" -> s3UseSSL.toString,
-      "fs.use_iam" -> s3UseIam.toString,
-      "fs.region" -> s3Region,
-      "milvus.collection.name" -> s"segment_${segmentId}_backfill",
-      "milvus.writer.customPath" -> segmentBasePath,
-      "milvus.writer.commitType" -> "addfield",
-      "milvus.insertMaxBatchSize" -> batchSize.toString
-    )
-    // See getMilvusReadOptions: skip static credentials in IAM mode so the
-    // FFI defers to the AWS default credentials chain instead of signing
-    // with placeholder keys.
-    if (!s3UseIam) {
-      opts = opts ++ Map(
-        "fs.access_key_id" -> s3AccessKey,
-        "fs.access_key_value" -> s3SecretKey
+    var opts = withS3Authentication(
+      Map(
+        "fs.storage_type" -> "remote",
+        "fs.address" -> s3Endpoint,
+        "fs.bucket_name" -> s3BucketName,
+        "fs.root_path" -> s3RootPath,
+        "fs.use_ssl" -> s3UseSSL.toString,
+        "fs.use_iam" -> s3UseIam.toString,
+        "fs.region" -> s3Region,
+        "milvus.collection.name" -> s"segment_${segmentId}_backfill",
+        "milvus.writer.customPath" -> segmentBasePath,
+        "milvus.writer.commitType" -> "addfield",
+        "milvus.insertMaxBatchSize" -> batchSize.toString
       )
-    }
+    )
     // Pass field name -> field ID mapping for correct column naming
     if (fieldNameToId.nonEmpty) {
       opts = opts + ("milvus.writer.fieldIds" -> fieldNameToId
@@ -251,9 +257,97 @@ case class BackfillConfig(
     }
     opts
   }
+
+  private[backfill] def withHadoopS3AssumeRole(
+      hadoopConf: Configuration,
+      defaultSessionName: String
+  ): BackfillConfig = {
+    val provider = Option(
+      hadoopConf.getTrimmed(BackfillConfig.HadoopS3CredentialsProvider)
+    ).getOrElse("")
+    val configuredRoleArn = Option(
+      hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleArn)
+    ).filter(_.nonEmpty)
+
+    if (
+      !s3UseIam || s3RoleArn.exists(_.trim.nonEmpty) ||
+      !BackfillConfig.isAssumedRoleProvider(provider)
+    ) {
+      this
+    } else {
+      val roleArn = configuredRoleArn.getOrElse(
+        throw new IllegalArgumentException(
+          s"${BackfillConfig.HadoopS3AssumedRoleArn} must be set when " +
+            s"${BackfillConfig.HadoopS3CredentialsProvider} uses " +
+            BackfillConfig.HadoopS3AssumedRoleProvider
+        )
+      )
+      copy(
+        s3RoleArn = Some(roleArn),
+        s3RoleSessionName = Option(
+          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleSessionName)
+        ).filter(_.nonEmpty)
+          .map(BackfillConfig.normalizeRoleSessionName)
+          .orElse(
+            Some(BackfillConfig.normalizeRoleSessionName(defaultSessionName))
+          ),
+        s3ExternalId = Option(
+          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleExternalId)
+        ).filter(_.nonEmpty)
+      )
+    }
+  }
+
+  private def withS3Authentication(
+      options: Map[String, String]
+  ): Map[String, String] = {
+    val credentialOptions = if (s3UseIam) {
+      options
+    } else {
+      options ++ Map(
+        Properties.FsConfig.FsAccessKeyId -> s3AccessKey,
+        Properties.FsConfig.FsAccessKeyValue -> s3SecretKey
+      )
+    }
+
+    Seq(
+      Properties.FsConfig.FsRoleArn -> s3RoleArn,
+      Properties.FsConfig.FsSessionName -> s3RoleSessionName,
+      Properties.FsConfig.FsExternalId -> s3ExternalId
+    ).foldLeft(credentialOptions) { case (result, (key, value)) =>
+      value.map(_.trim).filter(_.nonEmpty) match {
+        case Some(normalized) => result + (key -> normalized)
+        case None             => result
+      }
+    }
+  }
 }
 
 object BackfillConfig {
+
+  private[backfill] val HadoopS3CredentialsProvider =
+    "fs.s3a.aws.credentials.provider"
+  private[backfill] val HadoopS3AssumedRoleArn =
+    "fs.s3a.assumed.role.arn"
+  private[backfill] val HadoopS3AssumedRoleSessionName =
+    "fs.s3a.assumed.role.session.name"
+  private[backfill] val HadoopS3AssumedRoleExternalId =
+    "fs.s3a.assumed.role.external.id"
+  private[backfill] val HadoopS3AssumedRoleProvider =
+    "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider"
+
+  private[backfill] def isAssumedRoleProvider(provider: String): Boolean =
+    provider
+      .split(',')
+      .exists(_.trim == HadoopS3AssumedRoleProvider)
+
+  private[backfill] def normalizeRoleSessionName(value: String): String = {
+    val normalized = Option(value)
+      .getOrElse("")
+      .replaceAll("[^A-Za-z0-9+=,.@-]", "-")
+    val nonEmpty = if (normalized.nonEmpty) normalized else "spark-backfill"
+    nonEmpty.take(64)
+  }
 
   /** Create a minimal config for testing
     */

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -31,6 +31,8 @@ import com.zilliz.spark.connector.MilvusOption
   *   Root path in S3 bucket
   * @param s3Region
   *   S3 region
+  * @param s3CloudProvider
+  *   Native storage provider for the Milvus storage bucket
   * @param batchSize
   *   Batch size for writing data
   * @param customOutputPath
@@ -52,6 +54,7 @@ case class BackfillConfig(
     s3UseSSL: Boolean = false,
     s3RootPath: String = "files",
     s3Region: String = "us-east-1",
+    s3CloudProvider: String = BackfillConfig.DefaultCloudProvider,
     // When true, both Milvus FFI and Spark Hadoop S3A use the default credentials
     // chain (env / web identity / instance profile) instead of static AK/SK.
     s3UseIam: Boolean = false,
@@ -123,6 +126,13 @@ case class BackfillConfig(
       Left("s3Endpoint cannot be empty")
     } else if (s3BucketName.isEmpty) {
       Left("s3BucketName cannot be empty")
+    } else if (
+      !BackfillConfig.AllowedCloudProviders.contains(s3CloudProvider.trim)
+    ) {
+      Left(
+        s"s3CloudProvider must be one of ${BackfillConfig.AllowedCloudProviders
+            .mkString("[", ", ", "]")} (got '$s3CloudProvider')"
+      )
     } else if (batchSize <= 0) {
       Left("batchSize must be positive")
     } else if (
@@ -200,6 +210,7 @@ case class BackfillConfig(
         "fs.bucket_name" -> s3BucketName,
         "fs.root_path" -> s3RootPath,
         "fs.use_ssl" -> s3UseSSL.toString,
+        Properties.FsConfig.FsCloudProvider -> s3CloudProvider.trim,
         "fs.use_iam" -> s3UseIam.toString
       )
     )
@@ -243,6 +254,7 @@ case class BackfillConfig(
         "fs.use_ssl" -> s3UseSSL.toString,
         "fs.use_iam" -> s3UseIam.toString,
         "fs.region" -> s3Region,
+        Properties.FsConfig.FsCloudProvider -> s3CloudProvider.trim,
         "milvus.collection.name" -> s"segment_${segmentId}_backfill",
         "milvus.writer.customPath" -> segmentBasePath,
         "milvus.writer.commitType" -> "addfield",
@@ -324,6 +336,10 @@ case class BackfillConfig(
 }
 
 object BackfillConfig {
+
+  private[backfill] val DefaultCloudProvider = "aws"
+  private[backfill] val AllowedCloudProviders =
+    Set("aws", "gcp", "aliyun", "azure", "tencent", "huawei")
 
   private[backfill] val HadoopS3CredentialsProvider =
     "fs.s3a.aws.credentials.provider"

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -274,12 +274,15 @@ case class BackfillConfig(
       hadoopConf: Configuration,
       defaultSessionName: String
   ): BackfillConfig = {
+    val provider = s3CloudProvider.trim
     if (!s3UseIam || s3RoleArn.exists(_.trim.nonEmpty)) {
       this
-    } else if (s3CloudProvider.trim == "aliyun") {
+    } else if (provider == "aws") {
+      withAwsS3AssumeRole(hadoopConf, defaultSessionName)
+    } else if (provider == "aliyun") {
       withAlibabaOssAssumeRole(hadoopConf, defaultSessionName)
     } else {
-      withAwsS3AssumeRole(hadoopConf, defaultSessionName)
+      this
     }
   }
 
@@ -287,34 +290,17 @@ case class BackfillConfig(
       hadoopConf: Configuration,
       defaultSessionName: String
   ): BackfillConfig = {
-    val provider = Option(
-      hadoopConf.getTrimmed(BackfillConfig.HadoopS3CredentialsProvider)
-    ).getOrElse("")
-    if (!BackfillConfig.isAssumedRoleProvider(provider)) {
-      return this
-    }
-
-    val roleArn = Option(
-      hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleArn)
-    ).filter(_.nonEmpty)
-      .getOrElse(
-        throw new IllegalArgumentException(
-          s"${BackfillConfig.HadoopS3AssumedRoleArn} must be set when " +
-            s"${BackfillConfig.HadoopS3CredentialsProvider} uses " +
-            BackfillConfig.HadoopS3AssumedRoleProvider
+    BackfillConfig
+      .resolveAwsS3AssumeRole(hadoopConf, s3BucketName)
+      .map { role =>
+        withNativeAssumeRole(
+          role.roleArn,
+          role.sessionName,
+          role.externalId,
+          defaultSessionName
         )
-      )
-    withNativeAssumeRole(
-      roleArn,
-      Option(
-        hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleSessionName)
-      ).filter(_.nonEmpty),
-      Option(
-        hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleExternalId)
-      )
-        .filter(_.nonEmpty),
-      defaultSessionName
-    )
+      }
+      .getOrElse(this)
   }
 
   private def withAlibabaOssAssumeRole(
@@ -398,6 +384,12 @@ case class BackfillConfig(
 
 object BackfillConfig {
 
+  private[backfill] final case class ResolvedAssumeRole(
+      roleArn: String,
+      sessionName: Option[String],
+      externalId: Option[String]
+  )
+
   private[backfill] val DefaultCloudProvider = "aws"
   private[backfill] val AllowedCloudProviders =
     Set("aws", "gcp", "aliyun", "azure", "tencent", "huawei")
@@ -432,6 +424,50 @@ object BackfillConfig {
     provider
       .split(',')
       .exists(_.trim == HadoopOssAssumedRoleProvider)
+
+  private[backfill] def resolveAwsS3AssumeRole(
+      hadoopConf: Configuration,
+      bucketName: String
+  ): Option[ResolvedAssumeRole] = {
+    val bucketPrefix = s"fs.s3a.bucket.$bucketName"
+
+    def getTrimmed(key: String): Option[String] =
+      Option(hadoopConf.getTrimmed(key)).filter(_.nonEmpty)
+
+    def bucketOrGlobal(bucketKey: String, globalKey: String): Option[String] =
+      getTrimmed(bucketKey).orElse(getTrimmed(globalKey))
+
+    val provider = bucketOrGlobal(
+      s"$bucketPrefix.aws.credentials.provider",
+      HadoopS3CredentialsProvider
+    )
+    if (!provider.exists(isAssumedRoleProvider)) return None
+
+    val roleArn = bucketOrGlobal(
+      s"$bucketPrefix.assumed.role.arn",
+      HadoopS3AssumedRoleArn
+    ).getOrElse {
+      throw new IllegalArgumentException(
+        s"Effective AWS S3A AssumeRole configuration for bucket '$bucketName' " +
+          s"requires either $bucketPrefix.assumed.role.arn or " +
+          s"$HadoopS3AssumedRoleArn"
+      )
+    }
+
+    Some(
+      ResolvedAssumeRole(
+        roleArn = roleArn,
+        sessionName = bucketOrGlobal(
+          s"$bucketPrefix.assumed.role.session.name",
+          HadoopS3AssumedRoleSessionName
+        ),
+        externalId = bucketOrGlobal(
+          s"$bucketPrefix.assumed.role.external.id",
+          HadoopS3AssumedRoleExternalId
+        )
+      )
+    )
+  }
 
   private[backfill] def normalizeRoleSessionName(value: String): String = {
     val normalized = Option(value)

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -116,6 +116,7 @@ case class BackfillConfig(
   /** Validate S3 and writer configuration (always required)
     */
   def validate(): Either[String, Unit] = {
+    val normalizedCloudProvider = s3CloudProvider.trim
     val normalizedRoleArn = s3RoleArn.map(_.trim).filter(_.nonEmpty)
     val hasRoleDetails =
       s3RoleSessionName.exists(_.trim.nonEmpty) || s3ExternalId.exists(
@@ -127,7 +128,7 @@ case class BackfillConfig(
     } else if (s3BucketName.isEmpty) {
       Left("s3BucketName cannot be empty")
     } else if (
-      !BackfillConfig.AllowedCloudProviders.contains(s3CloudProvider.trim)
+      !BackfillConfig.AllowedCloudProviders.contains(normalizedCloudProvider)
     ) {
       Left(
         s"s3CloudProvider must be one of ${BackfillConfig.AllowedCloudProviders
@@ -154,6 +155,17 @@ case class BackfillConfig(
       )
     } else if (normalizedRoleArn.nonEmpty && !s3UseIam) {
       Left("s3RoleArn requires s3UseIam=true")
+    } else if (
+      normalizedRoleArn.nonEmpty &&
+      !BackfillConfig.NativeAssumeRoleCloudProviders.contains(
+        normalizedCloudProvider
+      )
+    ) {
+      Left(
+        s"s3RoleArn is supported only when s3CloudProvider is one of " +
+          s"${BackfillConfig.NativeAssumeRoleCloudProviders.mkString("[", ", ", "]")} " +
+          s"(got '$s3CloudProvider')"
+      )
     } else if (normalizedRoleArn.isEmpty && hasRoleDetails) {
       Left("s3RoleSessionName and s3ExternalId require s3RoleArn")
     } else {
@@ -393,6 +405,7 @@ object BackfillConfig {
   private[backfill] val DefaultCloudProvider = "aws"
   private[backfill] val AllowedCloudProviders =
     Set("aws", "gcp", "aliyun", "azure", "tencent", "huawei")
+  private[backfill] val NativeAssumeRoleCloudProviders = Set("aws", "aliyun")
 
   private[backfill] val HadoopS3CredentialsProvider =
     "fs.s3a.aws.credentials.provider"

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -270,44 +270,105 @@ case class BackfillConfig(
     opts
   }
 
-  private[backfill] def withHadoopS3AssumeRole(
+  private[backfill] def withHadoopStorageAssumeRole(
+      hadoopConf: Configuration,
+      defaultSessionName: String
+  ): BackfillConfig = {
+    if (!s3UseIam || s3RoleArn.exists(_.trim.nonEmpty)) {
+      this
+    } else if (s3CloudProvider.trim == "aliyun") {
+      withAlibabaOssAssumeRole(hadoopConf, defaultSessionName)
+    } else {
+      withAwsS3AssumeRole(hadoopConf, defaultSessionName)
+    }
+  }
+
+  private def withAwsS3AssumeRole(
       hadoopConf: Configuration,
       defaultSessionName: String
   ): BackfillConfig = {
     val provider = Option(
       hadoopConf.getTrimmed(BackfillConfig.HadoopS3CredentialsProvider)
     ).getOrElse("")
-    val configuredRoleArn = Option(
+    if (!BackfillConfig.isAssumedRoleProvider(provider)) {
+      return this
+    }
+
+    val roleArn = Option(
       hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleArn)
     ).filter(_.nonEmpty)
-
-    if (
-      !s3UseIam || s3RoleArn.exists(_.trim.nonEmpty) ||
-      !BackfillConfig.isAssumedRoleProvider(provider)
-    ) {
-      this
-    } else {
-      val roleArn = configuredRoleArn.getOrElse(
+      .getOrElse(
         throw new IllegalArgumentException(
           s"${BackfillConfig.HadoopS3AssumedRoleArn} must be set when " +
             s"${BackfillConfig.HadoopS3CredentialsProvider} uses " +
             BackfillConfig.HadoopS3AssumedRoleProvider
         )
       )
-      copy(
-        s3RoleArn = Some(roleArn),
-        s3RoleSessionName = Option(
-          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleSessionName)
-        ).filter(_.nonEmpty)
-          .map(BackfillConfig.normalizeRoleSessionName)
-          .orElse(
-            Some(BackfillConfig.normalizeRoleSessionName(defaultSessionName))
-          ),
-        s3ExternalId = Option(
-          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleExternalId)
-        ).filter(_.nonEmpty)
+    withNativeAssumeRole(
+      roleArn,
+      Option(
+        hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleSessionName)
+      ).filter(_.nonEmpty),
+      Option(
+        hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleExternalId)
+      )
+        .filter(_.nonEmpty),
+      defaultSessionName
+    )
+  }
+
+  private def withAlibabaOssAssumeRole(
+      hadoopConf: Configuration,
+      defaultSessionName: String
+  ): BackfillConfig = {
+    val provider = Option(
+      hadoopConf.getTrimmed(BackfillConfig.HadoopOssCredentialsProvider)
+    ).getOrElse("")
+    val roleArn = Option(
+      hadoopConf.getTrimmed(BackfillConfig.HadoopOssAssumedRoleArn)
+    ).filter(_.nonEmpty)
+
+    if (roleArn.isEmpty && BackfillConfig.isOssAssumeRoleProvider(provider)) {
+      throw new IllegalArgumentException(
+        s"${BackfillConfig.HadoopOssAssumedRoleArn} must be set when " +
+          s"${BackfillConfig.HadoopOssCredentialsProvider} uses " +
+          BackfillConfig.HadoopOssAssumedRoleProvider
       )
     }
+
+    roleArn
+      .map { arn =>
+        withNativeAssumeRole(
+          arn,
+          Option(
+            hadoopConf.getTrimmed(
+              BackfillConfig.HadoopOssAssumedRoleSessionName
+            )
+          ).filter(_.nonEmpty),
+          Option(
+            hadoopConf.getTrimmed(BackfillConfig.HadoopOssAssumedRoleExternalId)
+          ).filter(_.nonEmpty),
+          defaultSessionName
+        )
+      }
+      .getOrElse(this)
+  }
+
+  private def withNativeAssumeRole(
+      roleArn: String,
+      sessionName: Option[String],
+      externalId: Option[String],
+      defaultSessionName: String
+  ): BackfillConfig = {
+    copy(
+      s3RoleArn = Some(roleArn),
+      s3RoleSessionName = sessionName
+        .map(BackfillConfig.normalizeRoleSessionName)
+        .orElse(
+          Some(BackfillConfig.normalizeRoleSessionName(defaultSessionName))
+        ),
+      s3ExternalId = externalId
+    )
   }
 
   private def withS3Authentication(
@@ -351,11 +412,26 @@ object BackfillConfig {
     "fs.s3a.assumed.role.external.id"
   private[backfill] val HadoopS3AssumedRoleProvider =
     "org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider"
+  private[backfill] val HadoopOssAssumedRoleArn =
+    "fs.oss.assumed.role.arn"
+  private[backfill] val HadoopOssCredentialsProvider =
+    "fs.oss.credentials.provider"
+  private[backfill] val HadoopOssAssumedRoleSessionName =
+    "fs.oss.assumed.role.session.name"
+  private[backfill] val HadoopOssAssumedRoleExternalId =
+    "fs.oss.assumed.role.external.id"
+  private[backfill] val HadoopOssAssumedRoleProvider =
+    "com.zilliz.cloud.hadoop.AliyunOSSRoleCredentialsProvider"
 
   private[backfill] def isAssumedRoleProvider(provider: String): Boolean =
     provider
       .split(',')
       .exists(_.trim == HadoopS3AssumedRoleProvider)
+
+  private[backfill] def isOssAssumeRoleProvider(provider: String): Boolean =
+    provider
+      .split(',')
+      .exists(_.trim == HadoopOssAssumedRoleProvider)
 
   private[backfill] def normalizeRoleSessionName(value: String): String = {
     val normalized = Option(value)

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -77,10 +77,24 @@ object MilvusBackfill {
       spark: SparkSession,
       backfillDataPath: String,
       snapshotPath: String,
-      config: BackfillConfig
+      initialConfig: BackfillConfig
   ): Either[BackfillError, BackfillResult] = {
 
     val startTime = System.currentTimeMillis()
+    val config =
+      try {
+        initialConfig.withHadoopStorageAssumeRole(
+          spark.sparkContext.hadoopConfiguration,
+          spark.sparkContext.applicationId
+        )
+      } catch {
+        case e: IllegalArgumentException =>
+          return Left(
+            SchemaValidationError(
+              s"Invalid Hadoop storage AssumeRole configuration: ${e.getMessage}"
+            )
+          )
+      }
 
     // Validate S3/writer configuration (always required)
     config.validate() match {
@@ -1830,38 +1844,8 @@ object MilvusBackfill {
 
     if (useIam) {
       val bucketProviderKey = s"$prefix.aws.credentials.provider"
-      val bucketProvider = Option(
-        hadoopConf.getTrimmed(bucketProviderKey)
-      ).getOrElse("")
-      val globalProvider = Option(
-        hadoopConf.getTrimmed(BackfillConfig.HadoopS3CredentialsProvider)
-      ).getOrElse("")
-      val bucketUsesAssumeRole =
-        BackfillConfig.isAssumedRoleProvider(bucketProvider)
-      val globalUsesAssumeRole =
-        BackfillConfig.isAssumedRoleProvider(globalProvider)
-
-      if (
-        bucketUsesAssumeRole && Option(
-          hadoopConf.getTrimmed(s"$prefix.assumed.role.arn")
-        ).forall(_.isEmpty)
-      ) {
-        throw new IllegalArgumentException(
-          s"$prefix.assumed.role.arn must be set when $bucketProviderKey uses " +
-            BackfillConfig.HadoopS3AssumedRoleProvider
-        )
-      }
-      if (
-        !bucketUsesAssumeRole && globalUsesAssumeRole && Option(
-          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleArn)
-        ).forall(_.isEmpty)
-      ) {
-        throw new IllegalArgumentException(
-          s"${BackfillConfig.HadoopS3AssumedRoleArn} must be set when " +
-            s"${BackfillConfig.HadoopS3CredentialsProvider} uses " +
-            BackfillConfig.HadoopS3AssumedRoleProvider
-        )
-      }
+      val assumedRole =
+        BackfillConfig.resolveAwsS3AssumeRole(hadoopConf, bucket)
 
       // Build an explicit IRSA/EKS-friendly provider chain instead of the
       // v1 DefaultAWSCredentialsProviderChain, which has historically been
@@ -1876,7 +1860,7 @@ object MilvusBackfill {
       // A managed runtime may already have selected an AssumeRole provider
       // globally for its data role or per bucket for an external volume. Do
       // not replace that security boundary with the pod's ambient identity.
-      if (!bucketUsesAssumeRole && !globalUsesAssumeRole) {
+      if (assumedRole.isEmpty) {
         hadoopConf.set(
           bucketProviderKey,
           Seq(

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1829,6 +1829,40 @@ object MilvusBackfill {
     )
 
     if (useIam) {
+      val bucketProviderKey = s"$prefix.aws.credentials.provider"
+      val bucketProvider = Option(
+        hadoopConf.getTrimmed(bucketProviderKey)
+      ).getOrElse("")
+      val globalProvider = Option(
+        hadoopConf.getTrimmed(BackfillConfig.HadoopS3CredentialsProvider)
+      ).getOrElse("")
+      val bucketUsesAssumeRole =
+        BackfillConfig.isAssumedRoleProvider(bucketProvider)
+      val globalUsesAssumeRole =
+        BackfillConfig.isAssumedRoleProvider(globalProvider)
+
+      if (
+        bucketUsesAssumeRole && Option(
+          hadoopConf.getTrimmed(s"$prefix.assumed.role.arn")
+        ).forall(_.isEmpty)
+      ) {
+        throw new IllegalArgumentException(
+          s"$prefix.assumed.role.arn must be set when $bucketProviderKey uses " +
+            BackfillConfig.HadoopS3AssumedRoleProvider
+        )
+      }
+      if (
+        !bucketUsesAssumeRole && globalUsesAssumeRole && Option(
+          hadoopConf.getTrimmed(BackfillConfig.HadoopS3AssumedRoleArn)
+        ).forall(_.isEmpty)
+      ) {
+        throw new IllegalArgumentException(
+          s"${BackfillConfig.HadoopS3AssumedRoleArn} must be set when " +
+            s"${BackfillConfig.HadoopS3CredentialsProvider} uses " +
+            BackfillConfig.HadoopS3AssumedRoleProvider
+        )
+      }
+
       // Build an explicit IRSA/EKS-friendly provider chain instead of the
       // v1 DefaultAWSCredentialsProviderChain, which has historically been
       // unreliable on EKS pods (it does not always pick up the projected
@@ -1839,14 +1873,19 @@ object MilvusBackfill {
       //   1. WebIdentityTokenCredentialsProvider — IRSA / GKE Workload Identity
       //   2. EnvironmentVariableCredentialsProvider — local dev / CI overrides
       //   3. IAMInstanceCredentialsProvider — EC2 / EKS node role fallback
-      hadoopConf.set(
-        s"$prefix.aws.credentials.provider",
-        Seq(
-          "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
-          "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
-          "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
-        ).mkString(",")
-      )
+      // A managed runtime may already have selected an AssumeRole provider
+      // globally for its data role or per bucket for an external volume. Do
+      // not replace that security boundary with the pod's ambient identity.
+      if (!bucketUsesAssumeRole && !globalUsesAssumeRole) {
+        hadoopConf.set(
+          bucketProviderKey,
+          Seq(
+            "com.amazonaws.auth.WebIdentityTokenCredentialsProvider",
+            "com.amazonaws.auth.EnvironmentVariableCredentialsProvider",
+            "org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider"
+          ).mkString(",")
+        )
+      }
     } else {
       hadoopConf.set(s"$prefix.access.key", accessKey)
       hadoopConf.set(s"$prefix.secret.key", secretKey)

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -55,9 +55,10 @@ spark-submit \
   `fs.s3a.bucket.<bucket>.*`) and the Milvus storage FFI.
 - **IAM / IRSA**: pass `--use-iam`, or simply omit both AK/SK. `BackfillApp`
   auto-enables `useIam` when both keys are empty, so no flag is required
-  under IRSA. In IAM mode the connector defers to
-  `DefaultAWSCredentialsProviderChain` (env vars / web identity token /
-  instance profile).
+  under IRSA. In IAM mode the connector honors an existing Hadoop S3A
+  `AssumedRoleCredentialProvider` configuration. A global main-storage role
+  is also forwarded to the Milvus storage FFI; otherwise both clients use
+  their default IAM chain (env vars / web identity token / instance profile).
 - **Different bucket for input parquet**: when the parquet file lives in a
   different bucket (or even region/account) from the Milvus storage bucket,
   use the `--source-s3-*` flags. They are written as per-bucket Hadoop S3A

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -35,6 +35,7 @@ spark-submit \
   --s3-endpoint  s3.us-west-2.amazonaws.com \
   --s3-bucket    milvus-bucket \
   --s3-region    us-west-2 \
+  [--s3-cloud-provider aws|aliyun|gcp|azure|tencent|huawei] \
   [--s3-access-key AKIA... --s3-secret-key ...] \
   [--s3-use-ssl] \
   [--use-iam] \
@@ -59,6 +60,9 @@ spark-submit \
   `AssumedRoleCredentialProvider` configuration. A global main-storage role
   is also forwarded to the Milvus storage FFI; otherwise both clients use
   their default IAM chain (env vars / web identity token / instance profile).
+- **Cloud provider**: omit `--s3-cloud-provider` for AWS. Pass `aliyun` when
+  the Milvus storage bucket is OSS so the native writer uses the Aliyun
+  credentials provider and AssumeRole flow.
 - **Different bucket for input parquet**: when the parquet file lives in a
   different bucket (or even region/account) from the Milvus storage bucket,
   use the `--source-s3-*` flags. They are written as per-bucket Hadoop S3A
@@ -83,6 +87,7 @@ spark-submit \
 | `--batch-size`    | `1024`      | Rows per Arrow batch flushed to the writer.                                  |
 | `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |
 | `--output-result` | *(none)*    | Path to write the result JSON.                                               |
+| `--s3-cloud-provider` | `aws` | Native storage provider for the Milvus storage bucket: `aws`, `aliyun`, `gcp`, `azure`, `tencent`, or `huawei`. |
 
 ## Vector columns
 
@@ -207,13 +212,15 @@ result match {
 
 - `s3Endpoint`, `s3BucketName` — Milvus storage bucket.
 - `s3AccessKey`, `s3SecretKey` — may be empty when `s3UseIam = true`.
+- `s3CloudProvider` — native storage provider for the Milvus storage bucket
+  (default `aws`).
 
 ### Optional
 
 - `milvusUri`, `milvusToken`, `databaseName`, `collectionName` — required
   only in client mode (no snapshot).
 - `partitionName` — backfill a specific partition.
-- `s3UseIam` — use the AWS default credentials chain instead of static AK/SK.
+- `s3UseIam` — use the provider IAM chain instead of static AK/SK.
 - `s3UseSSL`, `s3RootPath`, `s3Region` — standard S3 options.
 - `sourceS3Endpoint`, `sourceS3AccessKey`, `sourceS3SecretKey`,
   `sourceS3UseSSL`, `sourceS3UseIam`, `sourceS3Region` — overrides for the

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -56,10 +56,11 @@ spark-submit \
   `fs.s3a.bucket.<bucket>.*`) and the Milvus storage FFI.
 - **IAM / IRSA**: pass `--use-iam`, or simply omit both AK/SK. `BackfillApp`
   auto-enables `useIam` when both keys are empty, so no flag is required
-  under IRSA. In IAM mode the connector honors an existing Hadoop S3A
-  `AssumedRoleCredentialProvider` configuration. A global main-storage role
-  is also forwarded to the Milvus storage FFI; otherwise both clients use
-  their default IAM chain (env vars / web identity token / instance profile).
+  under IRSA. In IAM mode the connector honors the platform-injected Hadoop
+  AssumeRole configuration: `fs.s3a.assumed.role.*` on AWS and
+  `fs.oss.assumed.role.*` on Alibaba Cloud. A global main-storage role is also
+  forwarded to the Milvus storage FFI; otherwise both clients use their default
+  IAM chain (env vars / web identity token / instance profile).
 - **Cloud provider**: omit `--s3-cloud-provider` for AWS. Pass `aliyun` when
   the Milvus storage bucket is OSS so the native writer uses the Aliyun
   credentials provider and AssumeRole flow.

--- a/src/test/scala/loon/PropertiesTest.scala
+++ b/src/test/scala/loon/PropertiesTest.scala
@@ -25,6 +25,9 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     Properties.FsConfig.FsUseSSL shouldBe "fs.use_ssl"
     Properties.FsConfig.FsSslCaCert shouldBe "fs.ssl_ca_cert"
     Properties.FsConfig.FsUseIam shouldBe "fs.use_iam"
+    Properties.FsConfig.FsRoleArn shouldBe "fs.role_arn"
+    Properties.FsConfig.FsSessionName shouldBe "fs.session_name"
+    Properties.FsConfig.FsExternalId shouldBe "fs.external_id"
     Properties.FsConfig.FsUseVirtualHost shouldBe "fs.use_virtual_host"
     Properties.FsConfig.FsRequestTimeoutMs shouldBe "fs.request_timeout_ms"
     Properties.FsConfig.FsGcpNativeWithoutAuth shouldBe "fs.gcp_native_without_auth"
@@ -48,6 +51,9 @@ class PropertiesTest extends AnyFunSuite with Matchers {
       Properties.FsConfig.FsUseSSL,
       Properties.FsConfig.FsSslCaCert,
       Properties.FsConfig.FsUseIam,
+      Properties.FsConfig.FsRoleArn,
+      Properties.FsConfig.FsSessionName,
+      Properties.FsConfig.FsExternalId,
       Properties.FsConfig.FsUseVirtualHost,
       Properties.FsConfig.FsRequestTimeoutMs,
       Properties.FsConfig.FsGcpNativeWithoutAuth,
@@ -77,6 +83,9 @@ class PropertiesTest extends AnyFunSuite with Matchers {
       Properties.FsConfig.FsUseSSL,
       Properties.FsConfig.FsSslCaCert,
       Properties.FsConfig.FsUseIam,
+      Properties.FsConfig.FsRoleArn,
+      Properties.FsConfig.FsSessionName,
+      Properties.FsConfig.FsExternalId,
       Properties.FsConfig.FsUseVirtualHost,
       Properties.FsConfig.FsRequestTimeoutMs,
       Properties.FsConfig.FsGcpNativeWithoutAuth,
@@ -273,5 +282,20 @@ class PropertiesTest extends AnyFunSuite with Matchers {
     Properties.normalizedFsBucketNameValue(
       Map(Properties.FsConfig.FsBucketName -> "   ")
     ) shouldBe None
+  }
+
+  test("normalizedAssumeRoleOptions forwards only non-blank role settings") {
+    Properties.normalizedAssumeRoleOptions(
+      Map(
+        Properties.FsConfig.FsRoleArn ->
+          " arn:aws:iam::123456789012:role/data-role ",
+        Properties.FsConfig.FsSessionName -> " spark-job ",
+        Properties.FsConfig.FsExternalId -> "   "
+      )
+    ) shouldBe Map(
+      Properties.FsConfig.FsRoleArn ->
+        "arn:aws:iam::123456789012:role/data-role",
+      Properties.FsConfig.FsSessionName -> "spark-job"
+    )
   }
 }

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -261,6 +261,140 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     hc.get("fs.s3a.bucket.irsa-bucket.secret.key") shouldBe null
   }
 
+  test("configureHadoopS3ForPath preserves a bucket AssumeRole provider") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "external-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val prefix = "fs.s3a.bucket.external-bucket"
+    val providerKey = s"$prefix.aws.credentials.provider"
+    val roleArnKey = s"$prefix.assumed.role.arn"
+    val externalIdKey = s"$prefix.assumed.role.external.id"
+    hc.set(providerKey, BackfillConfig.HadoopS3AssumedRoleProvider)
+    hc.set(roleArnKey, "arn:aws:iam::123456789012:role/customer-role")
+    hc.set(externalIdKey, "external-id")
+
+    try {
+      MilvusBackfill.configureHadoopS3ForPath(
+        spark,
+        "s3a://external-bucket/data/input.parquet",
+        cfg,
+        isSource = true
+      )
+
+      hc.get(providerKey) shouldBe BackfillConfig.HadoopS3AssumedRoleProvider
+      hc.get(roleArnKey) shouldBe
+        "arn:aws:iam::123456789012:role/customer-role"
+      hc.get(externalIdKey) shouldBe "external-id"
+    } finally {
+      Seq(providerKey, roleArnKey, externalIdKey).foreach(hc.unset)
+    }
+  }
+
+  test("configureHadoopS3ForPath preserves a global AssumeRole provider") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "managed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val bucketProviderKey =
+      "fs.s3a.bucket.managed-bucket.aws.credentials.provider"
+    hc.unset(bucketProviderKey)
+    hc.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hc.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/data-role"
+    )
+
+    try {
+      MilvusBackfill.configureHadoopS3ForPath(
+        spark,
+        "s3a://managed-bucket/snapshot.json",
+        cfg,
+        isSource = false
+      )
+
+      hc.get(bucketProviderKey) shouldBe null
+      hc.get(BackfillConfig.HadoopS3CredentialsProvider) shouldBe
+        BackfillConfig.HadoopS3AssumedRoleProvider
+    } finally {
+      hc.unset(bucketProviderKey)
+      hc.unset(BackfillConfig.HadoopS3CredentialsProvider)
+      hc.unset(BackfillConfig.HadoopS3AssumedRoleArn)
+    }
+  }
+
+  test("configureHadoopS3ForPath rejects incomplete AssumeRole config") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "incomplete-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val providerKey =
+      "fs.s3a.bucket.incomplete-bucket.aws.credentials.provider"
+    hc.set(providerKey, BackfillConfig.HadoopS3AssumedRoleProvider)
+
+    try {
+      val error = intercept[IllegalArgumentException] {
+        MilvusBackfill.configureHadoopS3ForPath(
+          spark,
+          "s3a://incomplete-bucket/data",
+          cfg,
+          isSource = true
+        )
+      }
+      error.getMessage should include(
+        "fs.s3a.bucket.incomplete-bucket.assumed.role.arn"
+      )
+    } finally {
+      hc.unset(providerKey)
+    }
+  }
+
+  test("explicit static credentials replace a bucket AssumeRole provider") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "static-bucket",
+      s3AccessKey = "explicit-ak",
+      s3SecretKey = "explicit-sk"
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val prefix = "fs.s3a.bucket.static-bucket"
+    val providerKey = s"$prefix.aws.credentials.provider"
+    hc.set(providerKey, BackfillConfig.HadoopS3AssumedRoleProvider)
+
+    try {
+      MilvusBackfill.configureHadoopS3ForPath(
+        spark,
+        "s3a://static-bucket/data",
+        cfg,
+        isSource = false
+      )
+
+      hc.get(providerKey) shouldBe
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+      hc.get(s"$prefix.access.key") shouldBe "explicit-ak"
+      hc.get(s"$prefix.secret.key") shouldBe "explicit-sk"
+    } finally {
+      Seq(providerKey, s"$prefix.access.key", s"$prefix.secret.key").foreach(
+        hc.unset
+      )
+    }
+  }
+
   // ============ normalizeS3Scheme ============
 
   test("normalizeS3Scheme rewrites s3:// to s3a://") {
@@ -340,6 +474,31 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     opts.get("fs.access_key_id") shouldBe None
     opts.get("fs.access_key_value") shouldBe None
     opts("fs.use_iam") shouldBe "true"
+  }
+
+  test("Backfill native options include the configured AssumeRole settings") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "managed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true,
+      s3RoleArn = Some("arn:aws:iam::123456789012:role/data-role"),
+      s3RoleSessionName = Some("spark-job"),
+      s3ExternalId = Some("external-id")
+    )
+
+    Seq(
+      cfg.getMilvusReadOptions,
+      cfg.getS3WriteOptionsForBasePath("base/path", 1L)
+    ).foreach { opts =>
+      opts("fs.role_arn") shouldBe
+        "arn:aws:iam::123456789012:role/data-role"
+      opts("fs.session_name") shouldBe "spark-job"
+      opts("fs.external_id") shouldBe "external-id"
+      opts.get("fs.access_key_id") shouldBe None
+      opts.get("fs.access_key_value") shouldBe None
+    }
   }
 
   test(

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -40,6 +40,8 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       "minio:9000",
       "--s3-bucket",
       "a-bucket",
+      "--s3-cloud-provider",
+      "aliyun",
       "--s3-access-key",
       "ak",
       "--s3-secret-key",
@@ -52,6 +54,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     parsed("snapshot") shouldBe "/tmp/snap.json"
     parsed("s3-endpoint") shouldBe "minio:9000"
     parsed("s3-bucket") shouldBe "a-bucket"
+    parsed("s3-cloud-provider") shouldBe "aliyun"
     parsed("s3-access-key") shouldBe "ak"
     parsed("s3-secret-key") shouldBe "sk"
     parsed("s3-use-ssl") shouldBe "true"
@@ -478,12 +481,13 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
   test("Backfill native options include the configured AssumeRole settings") {
     val cfg = BackfillConfig(
-      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3Endpoint = "oss-cn-shanghai.aliyuncs.com",
       s3BucketName = "managed-bucket",
       s3AccessKey = "",
       s3SecretKey = "",
+      s3CloudProvider = "aliyun",
       s3UseIam = true,
-      s3RoleArn = Some("arn:aws:iam::123456789012:role/data-role"),
+      s3RoleArn = Some("acs:ram::123456789012:role/data-role"),
       s3RoleSessionName = Some("spark-job"),
       s3ExternalId = Some("external-id")
     )
@@ -493,9 +497,10 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       cfg.getS3WriteOptionsForBasePath("base/path", 1L)
     ).foreach { opts =>
       opts("fs.role_arn") shouldBe
-        "arn:aws:iam::123456789012:role/data-role"
+        "acs:ram::123456789012:role/data-role"
       opts("fs.session_name") shouldBe "spark-job"
       opts("fs.external_id") shouldBe "external-id"
+      opts("fs.cloud_provider") shouldBe "aliyun"
       opts.get("fs.access_key_id") shouldBe None
       opts.get("fs.access_key_value") shouldBe None
     }

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -367,6 +367,83 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     }
   }
 
+  test(
+    "configureHadoopS3ForPath accepts global provider with bucket role ARN"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "mixed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val prefix = "fs.s3a.bucket.mixed-bucket"
+    val bucketProviderKey = s"$prefix.aws.credentials.provider"
+    val bucketRoleArnKey = s"$prefix.assumed.role.arn"
+    hc.unset(bucketProviderKey)
+    hc.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hc.set(
+      bucketRoleArnKey,
+      "arn:aws:iam::123456789012:role/bucket-role"
+    )
+
+    try {
+      MilvusBackfill.configureHadoopS3ForPath(
+        spark,
+        "s3a://mixed-bucket/data",
+        cfg,
+        isSource = false
+      )
+
+      hc.get(bucketProviderKey) shouldBe null
+      hc.get(bucketRoleArnKey) shouldBe
+        "arn:aws:iam::123456789012:role/bucket-role"
+    } finally {
+      hc.unset(bucketProviderKey)
+      hc.unset(bucketRoleArnKey)
+      hc.unset(BackfillConfig.HadoopS3CredentialsProvider)
+    }
+  }
+
+  test(
+    "configureHadoopS3ForPath accepts bucket provider with global role ARN"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "mixed-bucket-2",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val prefix = "fs.s3a.bucket.mixed-bucket-2"
+    val bucketProviderKey = s"$prefix.aws.credentials.provider"
+    hc.set(bucketProviderKey, BackfillConfig.HadoopS3AssumedRoleProvider)
+    hc.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/global-role"
+    )
+
+    try {
+      MilvusBackfill.configureHadoopS3ForPath(
+        spark,
+        "s3a://mixed-bucket-2/data",
+        cfg,
+        isSource = false
+      )
+
+      hc.get(bucketProviderKey) shouldBe
+        BackfillConfig.HadoopS3AssumedRoleProvider
+    } finally {
+      hc.unset(bucketProviderKey)
+      hc.unset(BackfillConfig.HadoopS3AssumedRoleArn)
+    }
+  }
+
   test("explicit static credentials replace a bucket AssumeRole provider") {
     val cfg = BackfillConfig(
       s3Endpoint = "s3.us-west-2.amazonaws.com",
@@ -451,6 +528,35 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     opts.get("fs.access_key_id") shouldBe None
     opts.get("fs.access_key_value") shouldBe None
     opts("fs.use_iam") shouldBe "true"
+  }
+
+  test("MilvusBackfill.run derives Hadoop AssumeRole for embedded callers") {
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    val cfg = BackfillConfig(
+      s3Endpoint = "s3.us-west-2.amazonaws.com",
+      s3BucketName = "embedded-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+
+    try {
+      MilvusBackfill.run(spark, "file:///unused.parquet", "", cfg) match {
+        case Left(error) =>
+          error.message should include(
+            "Invalid Hadoop storage AssumeRole configuration"
+          )
+          error.message should include(BackfillConfig.HadoopS3AssumedRoleArn)
+        case Right(_) => fail("expected invalid Hadoop AssumeRole config")
+      }
+    } finally {
+      hc.unset(BackfillConfig.HadoopS3CredentialsProvider)
+      hc.unset(BackfillConfig.HadoopS3AssumedRoleArn)
+    }
   }
 
   test("getMilvusReadOptions includes AK/SK when s3UseIam=false") {

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -208,6 +208,36 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     )
   }
 
+  test(
+    "AssumeRole settings are accepted only for native AWS and Alibaba storage"
+  ) {
+    Seq("aws", "aliyun").foreach { provider =>
+      BackfillConfig(
+        s3Endpoint = "storage.example.com",
+        s3BucketName = "bucket",
+        s3AccessKey = "",
+        s3SecretKey = "",
+        s3CloudProvider = provider,
+        s3UseIam = true,
+        s3RoleArn = Some("role-arn")
+      ).validate() shouldBe Right(())
+    }
+
+    Seq("gcp", "azure", "tencent", "huawei").foreach { provider =>
+      val error = BackfillConfig(
+        s3Endpoint = "storage.example.com",
+        s3BucketName = "bucket",
+        s3AccessKey = "",
+        s3SecretKey = "",
+        s3CloudProvider = provider,
+        s3UseIam = true,
+        s3RoleArn = Some("role-arn")
+      ).validate().left.toOption.get
+
+      error should include("s3RoleArn is supported only")
+    }
+  }
+
   test("withHadoopStorageAssumeRole derives the AWS native main-storage role") {
     val hadoopConf = new Configuration(false)
     hadoopConf.set(

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.operations.backfill
 
+import org.apache.hadoop.conf.Configuration
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -169,6 +170,101 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       sourceS3UseIam = Some(true)
     )
     config.validate() shouldBe Right(())
+  }
+
+  test("AssumeRole settings require IAM mode and a role ARN") {
+    BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "ak",
+      s3SecretKey = "sk",
+      s3RoleArn = Some("arn:aws:iam::123456789012:role/data-role")
+    ).validate() shouldBe Left("s3RoleArn requires s3UseIam=true")
+
+    BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true,
+      s3RoleSessionName = Some("spark-job")
+    ).validate() shouldBe Left(
+      "s3RoleSessionName and s3ExternalId require s3RoleArn"
+    )
+  }
+
+  test("withHadoopS3AssumeRole derives the native main-storage role") {
+    val hadoopConf = new Configuration(false)
+    hadoopConf.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/data-role"
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleExternalId,
+      "external-id"
+    )
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+
+    val resolved = config.withHadoopS3AssumeRole(
+      hadoopConf,
+      "spark app/with invalid characters and a very long identifier 1234567890"
+    )
+
+    resolved.s3RoleArn shouldBe Some(
+      "arn:aws:iam::123456789012:role/data-role"
+    )
+    resolved.s3RoleSessionName.get should fullyMatch regex
+      "[A-Za-z0-9+=,.@-]{1,64}"
+    resolved.s3ExternalId shouldBe Some("external-id")
+    resolved.validate() shouldBe Right(())
+  }
+
+  test("withHadoopS3AssumeRole ignores non-AssumeRole config") {
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hadoopConf = new Configuration(false)
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/data-role"
+    )
+
+    config.withHadoopS3AssumeRole(hadoopConf, "spark-job") shouldBe config
+  }
+
+  test("withHadoopS3AssumeRole rejects an incomplete AssumeRole config") {
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+    val hadoopConf = new Configuration(false)
+
+    hadoopConf.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+
+    val error = intercept[IllegalArgumentException] {
+      config.withHadoopS3AssumeRole(hadoopConf, "spark-job")
+    }
+    error.getMessage should include(BackfillConfig.HadoopS3AssumedRoleArn)
   }
 
   test("Zero batchSize fails validation") {

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -282,6 +282,109 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     resolved.validate() shouldBe Right(())
   }
 
+  test(
+    "withHadoopStorageAssumeRole derives an AWS bucket-scoped native main-storage role"
+  ) {
+    val hadoopConf = new Configuration(false)
+    val prefix = "fs.s3a.bucket.bucket"
+    hadoopConf.set(
+      s"$prefix.aws.credentials.provider",
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hadoopConf.set(
+      s"$prefix.assumed.role.arn",
+      "arn:aws:iam::123456789012:role/bucket-role"
+    )
+    hadoopConf.set(s"$prefix.assumed.role.session.name", "bucket-session")
+    hadoopConf.set(s"$prefix.assumed.role.external.id", "bucket-external-id")
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+
+    val resolved = config.withHadoopStorageAssumeRole(
+      hadoopConf,
+      "spark-job"
+    )
+
+    resolved.s3RoleArn shouldBe Some(
+      "arn:aws:iam::123456789012:role/bucket-role"
+    )
+    resolved.s3RoleSessionName shouldBe Some("bucket-session")
+    resolved.s3ExternalId shouldBe Some("bucket-external-id")
+  }
+
+  test(
+    "withHadoopStorageAssumeRole resolves AWS provider and role from mixed scopes"
+  ) {
+    val hadoopConf = new Configuration(false)
+    val prefix = "fs.s3a.bucket.bucket"
+    hadoopConf.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hadoopConf.set(
+      s"$prefix.assumed.role.arn",
+      "arn:aws:iam::123456789012:role/bucket-role"
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleExternalId,
+      "global-external-id"
+    )
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+
+    val resolved = config.withHadoopStorageAssumeRole(
+      hadoopConf,
+      "spark-job"
+    )
+
+    resolved.s3RoleArn shouldBe Some(
+      "arn:aws:iam::123456789012:role/bucket-role"
+    )
+    resolved.s3RoleSessionName shouldBe Some("spark-job")
+    resolved.s3ExternalId shouldBe Some("global-external-id")
+  }
+
+  test(
+    "withHadoopStorageAssumeRole lets an AWS bucket provider use a global role ARN"
+  ) {
+    val hadoopConf = new Configuration(false)
+    val prefix = "fs.s3a.bucket.bucket"
+    hadoopConf.set(
+      s"$prefix.aws.credentials.provider",
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/global-role"
+    )
+    val config = BackfillConfig(
+      s3Endpoint = "s3.amazonaws.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3UseIam = true
+    )
+
+    val resolved = config.withHadoopStorageAssumeRole(
+      hadoopConf,
+      "spark-job"
+    )
+
+    resolved.s3RoleArn shouldBe Some(
+      "arn:aws:iam::123456789012:role/global-role"
+    )
+  }
+
   test("withHadoopStorageAssumeRole ignores missing Alibaba role config") {
     val config = BackfillConfig(
       s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
@@ -357,6 +460,30 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       config.withHadoopStorageAssumeRole(hadoopConf, "spark-job")
     }
     error.getMessage should include(BackfillConfig.HadoopS3AssumedRoleArn)
+  }
+
+  test(
+    "withHadoopStorageAssumeRole does not apply AWS S3A roles to other providers"
+  ) {
+    val hadoopConf = new Configuration(false)
+    hadoopConf.set(
+      BackfillConfig.HadoopS3CredentialsProvider,
+      BackfillConfig.HadoopS3AssumedRoleProvider
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopS3AssumedRoleArn,
+      "arn:aws:iam::123456789012:role/data-role"
+    )
+    val config = BackfillConfig(
+      s3Endpoint = "cos.ap-shanghai.myqcloud.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "tencent",
+      s3UseIam = true
+    )
+
+    config.withHadoopStorageAssumeRole(hadoopConf, "spark-job") shouldBe config
   }
 
   test("Zero batchSize fails validation") {

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -104,6 +104,21 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.validate() shouldBe Left("s3BucketName cannot be empty")
   }
 
+  test("Unsupported s3CloudProvider fails validation") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      s3CloudProvider = "oss"
+    )
+
+    config.validate() match {
+      case Left(error) => error should include("s3CloudProvider must be one of")
+      case Right(_)    => fail("expected invalid s3CloudProvider to fail")
+    }
+  }
+
   test("Empty s3AccessKey/s3SecretKey is allowed (IAM/IRSA mode)") {
     // Under IAM/IRSA the SDK falls back to the default AWS credentials chain,
     // so empty static credentials must NOT fail validation.
@@ -313,6 +328,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.s3UseSSL shouldBe false
     config.s3RootPath shouldBe "files"
     config.s3Region shouldBe "us-east-1"
+    config.s3CloudProvider shouldBe "aws"
     config.batchSize shouldBe 1024
     config.customOutputPath shouldBe None
   }
@@ -346,6 +362,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     options("fs.access_key_id") shouldBe "access123"
     options("fs.access_key_value") shouldBe "secret456"
     options("fs.use_ssl") shouldBe "true"
+    options("fs.cloud_provider") shouldBe "aws"
   }
 
   test("getMilvusReadOptions includes partitionName when set") {
@@ -393,6 +410,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       s3SecretKey = "secret456",
       s3RootPath = "files",
       s3Region = "us-west-2",
+      s3CloudProvider = "aliyun",
       s3UseSSL = true,
       batchSize = 2048
     )
@@ -411,6 +429,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     options("fs.access_key_value") shouldBe "secret456"
     options("fs.use_ssl") shouldBe "true"
     options("fs.region") shouldBe "us-west-2"
+    options("fs.cloud_provider") shouldBe "aliyun"
     options("milvus.collection.name") shouldBe "segment_789_backfill"
     options(
       "milvus.writer.customPath"

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -208,7 +208,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     )
   }
 
-  test("withHadoopS3AssumeRole derives the native main-storage role") {
+  test("withHadoopStorageAssumeRole derives the AWS native main-storage role") {
     val hadoopConf = new Configuration(false)
     hadoopConf.set(
       BackfillConfig.HadoopS3CredentialsProvider,
@@ -230,7 +230,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       s3UseIam = true
     )
 
-    val resolved = config.withHadoopS3AssumeRole(
+    val resolved = config.withHadoopStorageAssumeRole(
       hadoopConf,
       "spark app/with invalid characters and a very long identifier 1234567890"
     )
@@ -244,7 +244,82 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     resolved.validate() shouldBe Right(())
   }
 
-  test("withHadoopS3AssumeRole ignores non-AssumeRole config") {
+  test(
+    "withHadoopStorageAssumeRole derives the Alibaba native main-storage role"
+  ) {
+    val hadoopConf = new Configuration(false)
+    hadoopConf.set(
+      BackfillConfig.HadoopOssAssumedRoleArn,
+      "acs:ram::123456789012:role/spark-data-role"
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopOssAssumedRoleSessionName,
+      "spark-job"
+    )
+    hadoopConf.set(
+      BackfillConfig.HadoopOssAssumedRoleExternalId,
+      "external-id"
+    )
+    val config = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
+
+    val resolved = config.withHadoopStorageAssumeRole(
+      hadoopConf,
+      "unused-default-session"
+    )
+
+    resolved.s3RoleArn shouldBe Some(
+      "acs:ram::123456789012:role/spark-data-role"
+    )
+    resolved.s3RoleSessionName shouldBe Some("spark-job")
+    resolved.s3ExternalId shouldBe Some("external-id")
+    resolved.validate() shouldBe Right(())
+  }
+
+  test("withHadoopStorageAssumeRole ignores missing Alibaba role config") {
+    val config = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
+    val hadoopConf = new Configuration(false)
+
+    config.withHadoopStorageAssumeRole(hadoopConf, "spark-job") shouldBe config
+  }
+
+  test(
+    "withHadoopStorageAssumeRole rejects an incomplete Alibaba AssumeRole config"
+  ) {
+    val config = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
+    val hadoopConf = new Configuration(false)
+    hadoopConf.set(
+      BackfillConfig.HadoopOssCredentialsProvider,
+      BackfillConfig.HadoopOssAssumedRoleProvider
+    )
+
+    val error = intercept[IllegalArgumentException] {
+      config.withHadoopStorageAssumeRole(hadoopConf, "spark-job")
+    }
+    error.getMessage should include(BackfillConfig.HadoopOssAssumedRoleArn)
+  }
+
+  test("withHadoopStorageAssumeRole ignores non-AssumeRole AWS config") {
     val config = BackfillConfig(
       s3Endpoint = "s3.amazonaws.com",
       s3BucketName = "bucket",
@@ -258,10 +333,12 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
       "arn:aws:iam::123456789012:role/data-role"
     )
 
-    config.withHadoopS3AssumeRole(hadoopConf, "spark-job") shouldBe config
+    config.withHadoopStorageAssumeRole(hadoopConf, "spark-job") shouldBe config
   }
 
-  test("withHadoopS3AssumeRole rejects an incomplete AssumeRole config") {
+  test(
+    "withHadoopStorageAssumeRole rejects an incomplete AWS AssumeRole config"
+  ) {
     val config = BackfillConfig(
       s3Endpoint = "s3.amazonaws.com",
       s3BucketName = "bucket",
@@ -277,7 +354,7 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     )
 
     val error = intercept[IllegalArgumentException] {
-      config.withHadoopS3AssumeRole(hadoopConf, "spark-job")
+      config.withHadoopStorageAssumeRole(hadoopConf, "spark-job")
     }
     error.getMessage should include(BackfillConfig.HadoopS3AssumedRoleArn)
   }


### PR DESCRIPTION
## Summary

- Preserve platform-injected Hadoop S3A `AssumedRoleCredentialProvider` settings, including global Data Role and per-bucket External Volume roles.
- Preserve platform-injected Alibaba OSS AssumeRole settings and forward the global main-storage role from `fs.oss.assumed.role.*` to milvus-storage Native.
- Forward the global main-storage role to milvus-storage Native through `fs.role_arn`, `fs.session_name`, and `fs.external_id`.
- Add `--s3-cloud-provider` so Backfill can select the native storage provider (`aws` by default, `aliyun` for OSS).
- Fail fast when AWS S3A or Alibaba OSS role-provider configuration is incomplete, instead of silently falling back to the pod identity.
- Keep existing static AK/SK and plain IAM/IRSA behavior unchanged.

## Design

The platform remains responsible for selecting and injecting roles. Backfill consumes the existing Hadoop configuration and mirrors the global main-storage role to Native storage:

- AWS: `fs.s3a.assumed.role.*` -> `fs.role_arn`, `fs.session_name`, `fs.external_id`
- Alibaba Cloud: `fs.oss.assumed.role.*` -> `fs.role_arn`, `fs.session_name`, `fs.external_id`

Only the global role is forwarded to Native because Native reads and writes Milvus main storage. Per-bucket customer roles remain scoped to Hadoop reads of the corresponding input bucket.

## Validation

- `sbt scalafmtCheckAll`
- `sbt "testOnly com.zilliz.spark.connector.operations.backfill.BackfillConfigTest com.zilliz.spark.connector.operations.backfill.BackfillAppTest"`
- `git diff --check`
