### PR TITLE
fix(backfill): support Alibaba OSS paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,6 +182,7 @@ lazy val root = (project in file("."))
       avro,
       hadoopCommon,
       hadoopAws,
+      hadoopAliyun,
       awsSdkS3,
       awsSdkS3Transfer,
       awsSdkCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,8 @@ object Dependencies {
     "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "provided,test" exclude ("javax.activation", "activation")
   lazy val hadoopAws =
     "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "provided,test" exclude("software.amazon.awssdk", "bundle")
+  lazy val hadoopAliyun =
+    "org.apache.hadoop" % "hadoop-aliyun" % hadoopVersion % "provided,test"
   lazy val awsSdkS3 =
     "software.amazon.awssdk" % "s3" % "2.30.38" // doc: https://javadoc.io/doc/software.amazon.awssdk/s3/2.30.38/index.html
   lazy val awsSdkS3Transfer = 

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -421,6 +421,7 @@ object BackfillConfig {
     "fs.oss.assumed.role.arn"
   private[backfill] val HadoopOssCredentialsProvider =
     "fs.oss.credentials.provider"
+  private[backfill] val HadoopOssSecurityToken = "fs.oss.securityToken"
   private[backfill] val HadoopOssAssumedRoleSessionName =
     "fs.oss.assumed.role.session.name"
   private[backfill] val HadoopOssAssumedRoleExternalId =

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -463,11 +463,11 @@ object MilvusBackfill {
     // and per-bucket fs.s3a.bucket.<b>.* config is only honored by
     // S3AFileSystem. Force the s3a scheme so the credentials we just wrote
     // actually take effect.
-    val path = normalizeS3Scheme(rawPath)
+    val path = normalizeObjectStorageScheme(rawPath)
     try {
       // Ensure Hadoop S3A is configured for the source bucket (may differ
       // from the Milvus storage bucket) before reading the parquet.
-      configureHadoopS3ForPath(spark, path, config, isSource = true)
+      configureHadoopStorageForPath(spark, path, config, isSource = true)
       val df = spark.read.parquet(path)
 
       // Minimum shape check; pk presence and field-count checks are enforced
@@ -1590,9 +1590,9 @@ object MilvusBackfill {
       // Register S3A bucket credentials so V2SegmentLoader can read AVRO +
       // parquet footers from minio / S3. The main bucket (not the source
       // parquet bucket) holds the snapshot.
-      configureHadoopS3ForPath(
+      configureHadoopStorageForPath(
         spark,
-        s"s3a://${config.s3BucketName}/",
+        storagePath(config, ""),
         config,
         isSource = false
       )
@@ -1603,7 +1603,10 @@ object MilvusBackfill {
           config.s3BucketName,
           hadoopConf,
           manifestSchemaVersion = metadata.manifestSchemaVersion,
-          applyDeletes = false
+          applyDeletes = false,
+          storageScheme =
+            if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss"
+            else "s3a"
         ) match {
         case Right(segs) =>
           // Workaround for Milvus snapshot not yet exposing FieldBinlog.child_fields:
@@ -1707,7 +1710,8 @@ object MilvusBackfill {
     val allocator: () => Long = () => logIdCounter.incrementAndGet()
 
     val outputRoot =
-      s"s3a://${config.s3BucketName}/${config.s3RootPath.stripSuffix("/")}/insert_log/" +
+      s"${if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss"
+        else "s3a"}://${config.s3BucketName}/${config.s3RootPath.stripSuffix("/")}/insert_log/" +
         s"$collectionID/$partitionID/$segmentID"
 
     // Reuse the same MilvusOption plumbing the V3 writer uses — the new V2
@@ -1927,9 +1931,9 @@ object MilvusBackfill {
     // Same s3:// → s3a:// normalization as readSnapshotJson /
     // readBackfillData. Without it, an s3:// URL would route to the legacy
     // S3FileSystem which ignores fs.s3a.bucket.<b>.* config.
-    val outputPath = normalizeS3Scheme(rawOutputPath)
+    val outputPath = normalizeObjectStorageScheme(rawOutputPath)
     try {
-      configureHadoopS3ForPath(spark, outputPath, config, isSource = false)
+      configureHadoopStorageForPath(spark, outputPath, config, isSource = false)
       val hadoopPath = new Path(outputPath)
       val fs = hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
       val out = fs.create(hadoopPath, true)
@@ -1969,6 +1973,90 @@ object MilvusBackfill {
     if (path == null) null
     else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
     else path
+  }
+
+  private[backfill] def normalizeObjectStorageScheme(path: String): String =
+    normalizeS3Scheme(path)
+
+  private[backfill] def storagePath(
+      config: BackfillConfig,
+      suffix: String
+  ): String = {
+    val scheme =
+      if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss://"
+      else "s3a://"
+    scheme + config.s3BucketName + "/" + suffix.stripPrefix("/")
+  }
+
+  private[backfill] def configureHadoopStorageForPath(
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = {
+    val normalized = normalizeObjectStorageScheme(path)
+    if (normalized != null && normalized.startsWith("oss://")) {
+      configureHadoopOssForPath(spark, normalized, config, isSource)
+    } else {
+      configureHadoopS3ForPath(spark, normalized, config, isSource)
+    }
+  }
+
+  private[backfill] def configureHadoopOssForPath(
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = {
+    if (path == null || !path.startsWith("oss://")) return
+    val withoutScheme = path.stripPrefix("oss://")
+    val slash = withoutScheme.indexOf('/')
+    val bucket =
+      if (slash < 0) withoutScheme else withoutScheme.substring(0, slash)
+    if (bucket.isEmpty) return
+
+    val endpoint =
+      if (isSource) config.sourceS3Endpoint.getOrElse(config.s3Endpoint)
+      else config.s3Endpoint
+    val accessKey =
+      if (isSource) config.sourceS3AccessKey.getOrElse(config.s3AccessKey)
+      else config.s3AccessKey
+    val secretKey =
+      if (isSource) config.sourceS3SecretKey.getOrElse(config.s3SecretKey)
+      else config.s3SecretKey
+    val useSSL =
+      if (isSource) config.sourceS3UseSSL.getOrElse(config.s3UseSSL)
+      else config.s3UseSSL
+    val useIam =
+      if (isSource) config.sourceS3UseIam.getOrElse(config.s3UseIam)
+      else config.s3UseIam
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    hadoopConf.set(
+      "fs.oss.impl",
+      "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem"
+    )
+    if (endpoint != null && endpoint.nonEmpty)
+      hadoopConf.set("fs.oss.endpoint", endpoint)
+    hadoopConf.set("fs.oss.connection.secure.enabled", useSSL.toString)
+    if (useIam) {
+      val provider = Option(
+        hadoopConf.getTrimmed(BackfillConfig.HadoopOssCredentialsProvider)
+      ).filter(_.nonEmpty)
+      if (provider.isEmpty) {
+        throw new IllegalArgumentException(
+          s"${BackfillConfig.HadoopOssCredentialsProvider} must be configured for OSS IAM access"
+        )
+      }
+      hadoopConf.unset("fs.oss.accessKeyId")
+      hadoopConf.unset("fs.oss.accessKeySecret")
+    } else {
+      hadoopConf.set("fs.oss.accessKeyId", accessKey)
+      hadoopConf.set("fs.oss.accessKeySecret", secretKey)
+      hadoopConf.set(
+        BackfillConfig.HadoopOssCredentialsProvider,
+        "org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider"
+      )
+    }
   }
 
   /** Configure Hadoop S3A credentials for the bucket referenced by `path`.
@@ -2101,12 +2189,14 @@ object MilvusBackfill {
     try {
       // Check if it's an S3 path
       if (
-        snapshotPath.startsWith("s3://") || snapshotPath.startsWith("s3a://")
+        snapshotPath.startsWith("s3://") || snapshotPath.startsWith(
+          "s3a://"
+        ) || snapshotPath.startsWith("oss://")
       ) {
 
         // Construct full S3 path (ensure s3a:// scheme for Hadoop)
         val s3Path = if (snapshotPath.startsWith("s3://")) {
-          normalizeS3Scheme(snapshotPath)
+          normalizeObjectStorageScheme(snapshotPath)
         } else {
           snapshotPath
         }
@@ -2114,7 +2204,7 @@ object MilvusBackfill {
         // Configure S3 settings on Spark's Hadoop Configuration (per-bucket
         // so that snapshot bucket and backfill source bucket can use
         // different credentials in the same Spark session).
-        configureHadoopS3ForPath(spark, s3Path, config, isSource = false)
+        configureHadoopStorageForPath(spark, s3Path, config, isSource = false)
 
         // Use Spark's DataFrame API to read the file (avoids Hadoop version issues)
         val df = spark.read.text(s3Path)

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -4,7 +4,8 @@ import scala.collection.mutable
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.DataWriter
 import org.apache.spark.sql.functions._
@@ -36,6 +37,11 @@ import com.zilliz.spark.connector.write.{
 object MilvusBackfill {
 
   private val logger = LoggerFactory.getLogger(getClass)
+
+  private[backfill] final case class BackfillSource(
+      dataFrame: DataFrame,
+      checkpointRDD: Option[RDD[Row]]
+  )
 
   /** Marker column added to the backfill side before the left join so we can
     * count how many source rows found a join-key match (non-null marker →
@@ -104,9 +110,11 @@ object MilvusBackfill {
       case Right(_) => // Continue
     }
 
-    // Tracked so we can unpersist in the outer finally, even on mid-flight
-    // failure (the cache is taken right after column mapping, below).
-    var cachedSourceDF: DataFrame = null
+    // OSS source reads use a local-checkpointed RDD to sever the external
+    // storage lineage while scoped credentials are installed. Keep the actual
+    // persisted RDD so its blocks can be released after the transformed
+    // backfill DataFrame is materialized, including on failure.
+    var sourceCheckpointRDD: Option[RDD[Row]] = None
     var cachedBackfillDF: DataFrame = null
 
     logger.info(s"Backfill mode: ${config.mode}")
@@ -191,9 +199,9 @@ object MilvusBackfill {
       val rawBackfillDF =
         readBackfillData(spark, backfillDataPath, config) match {
           case Left(error) => return Left(error)
-          case Right(df) =>
-            cachedSourceDF = df
-            df
+          case Right(source) =>
+            sourceCheckpointRDD = source.checkpointRDD
+            source.dataFrame
         }
 
       // Reproject via the existing PK column-mapping contract, then separate
@@ -304,8 +312,8 @@ object MilvusBackfill {
         case Right(stats) => stats
       }
       val backfillRowCount = joinKeyStats.rowCount
-      cachedSourceDF.unpersist()
-      cachedSourceDF = null
+      sourceCheckpointRDD.foreach(_.unpersist())
+      sourceCheckpointRDD = None
       logger.info(
         s"Backfill data file rows: $backfillRowCount " +
           s"(distinct join keys: ${joinKeyStats.distinctValidKeyCount})"
@@ -455,12 +463,12 @@ object MilvusBackfill {
             logger.warn("Failed to unpersist backfill DataFrame", e)
         }
       }
-      if (cachedSourceDF != null) {
+      sourceCheckpointRDD.foreach { checkpointRDD =>
         try {
-          cachedSourceDF.unpersist()
+          checkpointRDD.unpersist()
         } catch {
           case e: Exception =>
-            logger.warn("Failed to unpersist source backfill DataFrame", e)
+            logger.warn("Failed to unpersist source checkpoint RDD", e)
         }
       }
     }
@@ -472,15 +480,16 @@ object MilvusBackfill {
       spark: SparkSession,
       rawPath: String,
       config: BackfillConfig
-  ): Either[BackfillError, DataFrame] = {
+  ): Either[BackfillError, BackfillSource] = {
     // Hadoop 3.4.1 has separate s3:// and s3a:// FileSystem implementations
     // and per-bucket fs.s3a.bucket.<b>.* config is only honored by
     // S3AFileSystem. Force the s3a scheme so the credentials we just wrote
     // actually take effect.
     val path = normalizeObjectStorageScheme(rawPath, config)
     try {
-      // Ensure Hadoop S3A is configured for the source bucket (may differ
-      // from the Milvus storage bucket) before reading the parquet.
+      // Configure the source bucket before reading the parquet. OSS must be
+      // fully materialized while this temporary credential scope is active;
+      // S3A uses persistent per-bucket configuration and does not need it.
       Right(withScopedHadoopStorage(spark, path, config, isSource = true) {
         // Materialize while source-bucket credentials are installed. Spark
         // evaluates DataFrame reads lazily, so returning an unmaterialized DF
@@ -491,11 +500,11 @@ object MilvusBackfill {
             "Backfill parquet is empty (no columns)"
           )
         }
-        // A normal cache keeps the source lineage and may re-read OSS after
-        // eviction, when the scoped source credentials have already been
-        // restored. Eager local checkpointing materializes the input and
-        // truncates that external-storage lineage before leaving this scope.
-        df.localCheckpoint(eager = true)
+        if (path.startsWith("oss://")) {
+          localCheckpointBackfillData(spark, df)
+        } else {
+          BackfillSource(df, None)
+        }
       })
     } catch {
       case e: Exception =>
@@ -507,6 +516,31 @@ object MilvusBackfill {
             cause = Some(e)
           )
         )
+    }
+  }
+
+  private[backfill] def localCheckpointBackfillData(
+      spark: SparkSession,
+      dataFrame: DataFrame
+  ): BackfillSource = {
+    // Copy external Rows before checkpointing because Spark's physical plans
+    // may reuse mutable row objects. The checkpoint severs the OSS lineage,
+    // and retaining this exact RDD gives run() a reliable cleanup handle.
+    val checkpointRDD = dataFrame.rdd.map(_.copy())
+    checkpointRDD.localCheckpoint()
+    try {
+      checkpointRDD.count()
+      BackfillSource(
+        spark.createDataFrame(checkpointRDD, dataFrame.schema),
+        Some(checkpointRDD)
+      )
+    } catch {
+      case e: Exception =>
+        try checkpointRDD.unpersist()
+        catch {
+          case cleanupError: Exception => e.addSuppressed(cleanupError)
+        }
+        throw e
     }
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -296,11 +296,14 @@ object MilvusBackfill {
         case Right(df)   => df
       }
 
-      // Cache so the upcoming join-key aggregation doesn't force
-      // a second parquet scan when performJoin consumes the DF later. The
-      // count also eagerly validates every normalized vector row.
-      backfillDF.cache()
-      cachedBackfillDF = backfillDF
+      // Non-OSS sources retain their recoverable external-storage lineage, so
+      // cache the transformed DataFrame to avoid a second scan. OSS sources
+      // instead retain the single local-checkpoint RDD until every consumer
+      // completes; caching this derived DataFrame would hold two full copies.
+      if (sourceCheckpointRDD.isEmpty) {
+        backfillDF.cache()
+        cachedBackfillDF = backfillDF
+      }
 
       val joinKeyStats = validateJoinKeyCardinality(
         backfillDF,
@@ -312,8 +315,6 @@ object MilvusBackfill {
         case Right(stats) => stats
       }
       val backfillRowCount = joinKeyStats.rowCount
-      sourceCheckpointRDD.foreach(_.unpersist())
-      sourceCheckpointRDD = None
       logger.info(
         s"Backfill data file rows: $backfillRowCount " +
           s"(distinct join keys: ${joinKeyStats.distinctValidKeyCount})"
@@ -2059,6 +2060,7 @@ object MilvusBackfill {
     "fs.oss.connection.secure.enabled",
     "fs.oss.accessKeyId",
     "fs.oss.accessKeySecret",
+    BackfillConfig.HadoopOssSecurityToken,
     BackfillConfig.HadoopOssCredentialsProvider
   )
 
@@ -2164,6 +2166,7 @@ object MilvusBackfill {
     } else {
       hadoopConf.set("fs.oss.accessKeyId", accessKey)
       hadoopConf.set("fs.oss.accessKeySecret", secretKey)
+      hadoopConf.unset(BackfillConfig.HadoopOssSecurityToken)
       // hadoop-aliyun constructs AliyunCredentialsProvider itself from the
       // accessKeyId/accessKeySecret properties. The class has no (URI,
       // Configuration) or no-arg constructor, so configuring it explicitly

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.operations.backfill
 
+import scala.collection.mutable
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.Path
@@ -105,6 +106,7 @@ object MilvusBackfill {
 
     // Tracked so we can unpersist in the outer finally, even on mid-flight
     // failure (the cache is taken right after column mapping, below).
+    var cachedSourceDF: DataFrame = null
     var cachedBackfillDF: DataFrame = null
 
     logger.info(s"Backfill mode: ${config.mode}")
@@ -189,7 +191,9 @@ object MilvusBackfill {
       val rawBackfillDF =
         readBackfillData(spark, backfillDataPath, config) match {
           case Left(error) => return Left(error)
-          case Right(df)   => df
+          case Right(df) =>
+            cachedSourceDF = df
+            df
         }
 
       // Reproject via the existing PK column-mapping contract, then separate
@@ -300,6 +304,8 @@ object MilvusBackfill {
         case Right(stats) => stats
       }
       val backfillRowCount = joinKeyStats.rowCount
+      cachedSourceDF.unpersist()
+      cachedSourceDF = null
       logger.info(
         s"Backfill data file rows: $backfillRowCount " +
           s"(distinct join keys: ${joinKeyStats.distinctValidKeyCount})"
@@ -449,6 +455,14 @@ object MilvusBackfill {
             logger.warn("Failed to unpersist backfill DataFrame", e)
         }
       }
+      if (cachedSourceDF != null) {
+        try {
+          cachedSourceDF.unpersist()
+        } catch {
+          case e: Exception =>
+            logger.warn("Failed to unpersist source backfill DataFrame", e)
+        }
+      }
     }
   }
 
@@ -463,25 +477,26 @@ object MilvusBackfill {
     // and per-bucket fs.s3a.bucket.<b>.* config is only honored by
     // S3AFileSystem. Force the s3a scheme so the credentials we just wrote
     // actually take effect.
-    val path = normalizeObjectStorageScheme(rawPath)
+    val path = normalizeObjectStorageScheme(rawPath, config)
     try {
       // Ensure Hadoop S3A is configured for the source bucket (may differ
       // from the Milvus storage bucket) before reading the parquet.
-      configureHadoopStorageForPath(spark, path, config, isSource = true)
-      val df = spark.read.parquet(path)
-
-      // Minimum shape check; pk presence and field-count checks are enforced
-      // after column mapping is applied (see applyColumnMapping).
-      if (df.columns.isEmpty) {
-        return Left(
-          DataReadError(
-            path = path,
-            message = "Backfill parquet is empty (no columns)"
+      Right(withScopedHadoopStorage(spark, path, config, isSource = true) {
+        // Materialize while source-bucket credentials are installed. Spark
+        // evaluates DataFrame reads lazily, so returning an unmaterialized DF
+        // would allow later main-bucket configuration to leak into this read.
+        val df = spark.read.parquet(path)
+        if (df.columns.isEmpty) {
+          throw new IllegalArgumentException(
+            "Backfill parquet is empty (no columns)"
           )
-        )
-      }
-
-      Right(df)
+        }
+        // A normal cache keeps the source lineage and may re-read OSS after
+        // eviction, when the scoped source credentials have already been
+        // restored. Eager local checkpointing materializes the input and
+        // truncates that external-storage lineage before leaving this scope.
+        df.localCheckpoint(eager = true)
+      })
     } catch {
       case e: Exception =>
         logger.error(s"Failed to read Parquet file from $path", e)
@@ -1587,16 +1602,20 @@ object MilvusBackfill {
   ]] = {
     if (metadata.manifestList.isEmpty) return Right(Seq.empty)
     try {
-      // Register S3A bucket credentials so V2SegmentLoader can read AVRO +
-      // parquet footers from minio / S3. The main bucket (not the source
-      // parquet bucket) holds the snapshot.
+      // Configure a private Hadoop view so V2SegmentLoader can read AVRO and
+      // parquet footers without mutating the Spark session's shared OSS
+      // credentials. The main bucket (not the source bucket) holds these
+      // snapshot artifacts.
+      val hadoopConf = new org.apache.hadoop.conf.Configuration(
+        spark.sparkContext.hadoopConfiguration
+      )
       configureHadoopStorageForPath(
-        spark,
+        hadoopConf,
         storagePath(config, ""),
         config,
         isSource = false
       )
-      val hadoopConf = spark.sparkContext.hadoopConfiguration
+      hadoopConf.set("fs.oss.impl.disable.cache", "true")
       com.zilliz.spark.connector.read.V2SegmentLoader
         .loadV2Segments(
           metadata.manifestList,
@@ -1604,9 +1623,7 @@ object MilvusBackfill {
           hadoopConf,
           manifestSchemaVersion = metadata.manifestSchemaVersion,
           applyDeletes = false,
-          storageScheme =
-            if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss"
-            else "s3a"
+          storageScheme = storageScheme(config)
         ) match {
         case Right(segs) =>
           // Workaround for Milvus snapshot not yet exposing FieldBinlog.child_fields:
@@ -1709,10 +1726,10 @@ object MilvusBackfill {
     val logIdCounter = new java.util.concurrent.atomic.AtomicLong(logIdBase)
     val allocator: () => Long = () => logIdCounter.incrementAndGet()
 
-    val outputRoot =
-      s"${if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss"
-        else "s3a"}://${config.s3BucketName}/${config.s3RootPath.stripSuffix("/")}/insert_log/" +
-        s"$collectionID/$partitionID/$segmentID"
+    val outputRoot = storagePath(
+      config,
+      s"${config.s3RootPath.stripSuffix("/")}/insert_log/$collectionID/$partitionID/$segmentID"
+    )
 
     // Reuse the same MilvusOption plumbing the V3 writer uses — the new V2
     // writer talks to S3 via Arrow's filesystem (inside milvus-storage), so
@@ -1931,18 +1948,20 @@ object MilvusBackfill {
     // Same s3:// → s3a:// normalization as readSnapshotJson /
     // readBackfillData. Without it, an s3:// URL would route to the legacy
     // S3FileSystem which ignores fs.s3a.bucket.<b>.* config.
-    val outputPath = normalizeObjectStorageScheme(rawOutputPath)
+    val outputPath = normalizeObjectStorageScheme(rawOutputPath, config)
     try {
-      configureHadoopStorageForPath(spark, outputPath, config, isSource = false)
-      val hadoopPath = new Path(outputPath)
-      val fs = hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
-      val out = fs.create(hadoopPath, true)
-      try {
-        out.write(
-          result.toJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
-        )
-      } finally {
-        out.close()
+      withScopedHadoopStorage(spark, outputPath, config, isSource = false) {
+        val hadoopPath = new Path(outputPath)
+        val fs =
+          hadoopPath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+        val out = fs.create(hadoopPath, true)
+        try {
+          out.write(
+            result.toJson.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+          )
+        } finally {
+          out.close()
+        }
       }
       logger.info(s"Backfill result JSON written to: $outputPath")
       Right(())
@@ -1975,17 +1994,78 @@ object MilvusBackfill {
     else path
   }
 
-  private[backfill] def normalizeObjectStorageScheme(path: String): String =
-    normalizeS3Scheme(path)
+  private[backfill] def normalizeObjectStorageScheme(
+      path: String,
+      config: BackfillConfig
+  ): String = {
+    if (path == null) null
+    else if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) {
+      if (path.startsWith("s3://")) "oss://" + path.stripPrefix("s3://")
+      else if (path.startsWith("s3a://")) "oss://" + path.stripPrefix("s3a://")
+      else path
+    } else normalizeS3Scheme(path)
+  }
+
+  private[backfill] def storageScheme(config: BackfillConfig): String =
+    if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss"
+    else "s3a"
 
   private[backfill] def storagePath(
       config: BackfillConfig,
       suffix: String
   ): String = {
-    val scheme =
-      if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun")) "oss://"
-      else "s3a://"
-    scheme + config.s3BucketName + "/" + suffix.stripPrefix("/")
+    storageScheme(config) + "://" + config.s3BucketName + "/" + suffix
+      .stripPrefix("/")
+  }
+
+  private val OssHadoopKeys = Seq(
+    "fs.oss.impl",
+    "fs.oss.impl.disable.cache",
+    "fs.oss.endpoint",
+    "fs.oss.connection.secure.enabled",
+    "fs.oss.accessKeyId",
+    "fs.oss.accessKeySecret",
+    BackfillConfig.HadoopOssCredentialsProvider
+  )
+
+  private[backfill] def withScopedHadoopStorage[T](
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  )(operation: => T): T = {
+    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    if (path == null || !path.startsWith("oss://")) {
+      configureHadoopStorageForPath(hadoopConf, path, config, isSource)
+      return operation
+    }
+
+    val previous = mutable.LinkedHashMap.empty[String, Option[String]]
+    OssHadoopKeys.foreach(key => previous.put(key, Option(hadoopConf.get(key))))
+    try {
+      configureHadoopStorageForPath(hadoopConf, path, config, isSource)
+      hadoopConf.set("fs.oss.impl.disable.cache", "true")
+      operation
+    } finally {
+      previous.foreach {
+        case (key, Some(value)) => hadoopConf.set(key, value)
+        case (key, None)        => hadoopConf.unset(key)
+      }
+    }
+  }
+
+  private[backfill] def configureHadoopStorageForPath(
+      hadoopConf: org.apache.hadoop.conf.Configuration,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = {
+    val normalized = path
+    if (normalized != null && normalized.startsWith("oss://")) {
+      configureHadoopOssForPath(hadoopConf, normalized, config, isSource)
+    } else {
+      configureHadoopS3ForPath(hadoopConf, normalized, config, isSource)
+    }
   }
 
   private[backfill] def configureHadoopStorageForPath(
@@ -1993,17 +2073,15 @@ object MilvusBackfill {
       path: String,
       config: BackfillConfig,
       isSource: Boolean
-  ): Unit = {
-    val normalized = normalizeObjectStorageScheme(path)
-    if (normalized != null && normalized.startsWith("oss://")) {
-      configureHadoopOssForPath(spark, normalized, config, isSource)
-    } else {
-      configureHadoopS3ForPath(spark, normalized, config, isSource)
-    }
-  }
+  ): Unit = configureHadoopStorageForPath(
+    spark.sparkContext.hadoopConfiguration,
+    normalizeObjectStorageScheme(path, config),
+    config,
+    isSource
+  )
 
   private[backfill] def configureHadoopOssForPath(
-      spark: SparkSession,
+      hadoopConf: org.apache.hadoop.conf.Configuration,
       path: String,
       config: BackfillConfig,
       isSource: Boolean
@@ -2030,14 +2108,14 @@ object MilvusBackfill {
     val useIam =
       if (isSource) config.sourceS3UseIam.getOrElse(config.s3UseIam)
       else config.s3UseIam
-    val hadoopConf = spark.sparkContext.hadoopConfiguration
     hadoopConf.set(
       "fs.oss.impl",
       "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem"
     )
     if (endpoint != null && endpoint.nonEmpty)
       hadoopConf.set("fs.oss.endpoint", endpoint)
-    hadoopConf.set("fs.oss.connection.secure.enabled", useSSL.toString)
+    if (useSSL) hadoopConf.set("fs.oss.connection.secure.enabled", "true")
+    else hadoopConf.unset("fs.oss.connection.secure.enabled")
     if (useIam) {
       val provider = Option(
         hadoopConf.getTrimmed(BackfillConfig.HadoopOssCredentialsProvider)
@@ -2052,12 +2130,25 @@ object MilvusBackfill {
     } else {
       hadoopConf.set("fs.oss.accessKeyId", accessKey)
       hadoopConf.set("fs.oss.accessKeySecret", secretKey)
-      hadoopConf.set(
-        BackfillConfig.HadoopOssCredentialsProvider,
-        "org.apache.hadoop.fs.aliyun.oss.AliyunCredentialsProvider"
-      )
+      // hadoop-aliyun constructs AliyunCredentialsProvider itself from the
+      // accessKeyId/accessKeySecret properties. The class has no (URI,
+      // Configuration) or no-arg constructor, so configuring it explicitly
+      // causes filesystem initialization to fail.
+      hadoopConf.unset(BackfillConfig.HadoopOssCredentialsProvider)
     }
   }
+
+  private[backfill] def configureHadoopOssForPath(
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = configureHadoopOssForPath(
+    spark.sparkContext.hadoopConfiguration,
+    path,
+    config,
+    isSource
+  )
 
   /** Configure Hadoop S3A credentials for the bucket referenced by `path`.
     *
@@ -2072,7 +2163,7 @@ object MilvusBackfill {
     *   when a particular field is unset.
     */
   private[backfill] def configureHadoopS3ForPath(
-      spark: SparkSession,
+      hadoopConf: org.apache.hadoop.conf.Configuration,
       path: String,
       config: BackfillConfig,
       isSource: Boolean
@@ -2110,7 +2201,6 @@ object MilvusBackfill {
       if (isSource) config.sourceS3Region.getOrElse(config.s3Region)
       else config.s3Region
 
-    val hadoopConf = spark.sparkContext.hadoopConfiguration
     val prefix = s"fs.s3a.bucket.$bucket"
 
     // Endpoint + path style + SSL are safe to set in both IAM and static modes
@@ -2174,6 +2264,18 @@ object MilvusBackfill {
     )
   }
 
+  private[backfill] def configureHadoopS3ForPath(
+      spark: SparkSession,
+      path: String,
+      config: BackfillConfig,
+      isSource: Boolean
+  ): Unit = configureHadoopS3ForPath(
+    spark.sparkContext.hadoopConfiguration,
+    path,
+    config,
+    isSource
+  )
+
   /** Read snapshot JSON content from S3 or local file system. Returns the JSON
     * string.
     */
@@ -2195,20 +2297,20 @@ object MilvusBackfill {
       ) {
 
         // Construct full S3 path (ensure s3a:// scheme for Hadoop)
-        val s3Path = if (snapshotPath.startsWith("s3://")) {
-          normalizeObjectStorageScheme(snapshotPath)
-        } else {
-          snapshotPath
-        }
+        val s3Path = normalizeObjectStorageScheme(snapshotPath, config)
 
         // Configure S3 settings on Spark's Hadoop Configuration (per-bucket
         // so that snapshot bucket and backfill source bucket can use
         // different credentials in the same Spark session).
-        configureHadoopStorageForPath(spark, s3Path, config, isSource = false)
-
-        // Use Spark's DataFrame API to read the file (avoids Hadoop version issues)
-        val df = spark.read.text(s3Path)
-        val json = df.collect().map(_.getString(0)).mkString("\n")
+        val json = withScopedHadoopStorage(
+          spark,
+          s3Path,
+          config,
+          isSource = false
+        ) {
+          // Use Spark's DataFrame API to read the file (avoids Hadoop version issues)
+          spark.read.text(s3Path).collect().map(_.getString(0)).mkString("\n")
+        }
 
         Right(json)
 

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -59,17 +59,23 @@ spark-submit \
   under IRSA. In IAM mode the connector honors the platform-injected Hadoop
   AssumeRole configuration: `fs.s3a.assumed.role.*` on AWS and
   `fs.oss.assumed.role.*` on Alibaba Cloud. A global main-storage role is also
-  forwarded to the Milvus storage FFI; otherwise both clients use their default
-  IAM chain (env vars / web identity token / instance profile).
+  forwarded to the Milvus storage FFI. Alibaba OSS IAM mode requires the
+  managed runtime to inject `fs.oss.credentials.provider`; hadoop-aliyun has
+  no generic ECS/env default provider chain for this path and fails fast when
+  that property is absent.
 - **Cloud provider**: omit `--s3-cloud-provider` for AWS. Pass `aliyun` when
   the Milvus storage bucket is OSS so the native writer uses the Aliyun
-  credentials provider and AssumeRole flow.
+  credentials provider and AssumeRole flow. For Alibaba, `s3://` and `s3a://`
+  CLI paths are normalized to `oss://`; using explicit `oss://` is preferred.
+  The Spark runtime image must provide `hadoop-aliyun` 3.4.1; it is declared
+  as a provided dependency to avoid conflicting with Spark's Hadoop runtime.
 - **Different bucket for input parquet**: when the parquet file lives in a
   different bucket (or even region/account) from the Milvus storage bucket,
-  use the `--source-s3-*` flags. They are written as per-bucket Hadoop S3A
-  config, so each bucket can independently use static AK/SK or IAM in the
-  same Spark session. Any unset `--source-*` falls back to the main
-  credentials.
+  use the `--source-s3-*` flags. AWS uses per-bucket S3A configuration. OSS
+  access is scoped to each source or target operation and restores the managed
+  role configuration afterwards, so static source credentials cannot replace
+  the target bucket's IAM provider. Any unset `--source-*` falls back to the
+  main credentials.
 
 ### Required flags
 

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -25,10 +25,11 @@ import org.apache.spark.internal.Logging
   * The resulting `Seq[V2SegmentInfo]` is the runtime view consumed by
   * `MilvusPackedV2InputPartition` / `MilvusPackedV2PartitionReader`.
   *
-  * Path resolution: AVRO and parquet paths that milvus writes are
+  * Path resolution: AVRO and parquet paths that Milvus writes are
   * bucket-relative (`files/snapshots/...`). When `bucket` is non-empty we
-  * prefix `s3a://{bucket}/` so Hadoop picks the S3A filesystem. Fully qualified
-  * `s3a://...` / `s3://...` URIs pass through.
+  * prefix `{storageScheme}://{bucket}/`. The default remains `s3a` for the
+  * connector DataSource and tools; Alibaba callers must explicitly pass
+  * `storageScheme = "oss"` with a matching Hadoop OSS configuration.
   */
 object V2SegmentLoader extends Logging {
 
@@ -207,7 +208,11 @@ object V2SegmentLoader extends Logging {
     }
   }
 
-  /** Prefix `bucket` when `path` has no scheme; preserve explicit schemes. */
+  /** Prefix `bucket` when `path` has no scheme; preserve explicit schemes.
+    * `storageScheme` is intentionally explicit for non-S3 providers because the
+    * generic connector read path does not yet derive a provider from its public
+    * options.
+    */
   def resolvePath(
       path: String,
       bucket: String,

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -108,37 +108,37 @@ object V2SegmentLoader extends Logging {
       applyDeletes: Boolean = true,
       storageScheme: String = "s3a"
   ): Either[Throwable, Option[V2SegmentInfo]] = {
-    val isL0 = entry.segmentLevel == 1L
-    val hasDeltaLogs = entry.deltaLogFiles.exists(_.binlogs.nonEmpty)
+    val resolvedEntry = resolveEntryPaths(entry, bucket, storageScheme)
+    val isL0 = resolvedEntry.segmentLevel == 1L
 
-    if (entry.storageVersion != 2L) {
+    if (resolvedEntry.storageVersion != 2L) {
       logInfo(
-        s"skipping segment ${entry.segmentId}: storage_version=${entry.storageVersion} " +
+        s"skipping segment ${resolvedEntry.segmentId}: storage_version=${resolvedEntry.storageVersion} " +
           s"(!= 2); V2SegmentLoader only handles StorageV2"
       )
       Right(None)
     } else if (isL0 && !applyDeletes) {
       logInfo(
-        s"skipping StorageV2 L0 delete-only segment ${entry.segmentId} because applyDeletes=false"
+        s"skipping StorageV2 L0 delete-only segment ${resolvedEntry.segmentId} because applyDeletes=false"
       )
       Right(None)
     } else if (
-      entry.binlogFiles.isEmpty ||
-      entry.binlogFiles.forall(_.binlogs.isEmpty)
+      resolvedEntry.binlogFiles.isEmpty ||
+      resolvedEntry.binlogFiles.forall(_.binlogs.isEmpty)
     ) {
       logWarning(
-        s"segment ${entry.segmentId} has no binlog files with entries; " +
+        s"segment ${resolvedEntry.segmentId} has no binlog files with entries; " +
           s"emitting as empty column-group list"
       )
       Right(
         Some(
           V2SegmentInfo(
-            segmentId = entry.segmentId,
-            partitionId = entry.partitionId,
-            numOfRows = entry.numOfRows,
-            storageVersion = entry.storageVersion,
+            segmentId = resolvedEntry.segmentId,
+            partitionId = resolvedEntry.partitionId,
+            numOfRows = resolvedEntry.numOfRows,
+            storageVersion = resolvedEntry.storageVersion,
             columnGroups = Seq.empty,
-            deltaLogs = entry.deltaLogFiles
+            deltaLogs = resolvedEntry.deltaLogFiles
               .flatMap(_.binlogs)
               .sortBy(_.logId)
               .map(log =>
@@ -161,7 +161,7 @@ object V2SegmentLoader extends Logging {
         // from multiple write sessions, each advertising only its own
         // session's groups — see MilvusParquetFooterReader.readFieldIdsFromSchema.
         val groupFieldIdListPerEntry: Seq[Seq[Long]] =
-          entry.binlogFiles.map { afb =>
+          resolvedEntry.binlogFiles.map { afb =>
             if (afb.binlogs.isEmpty) {
               // The top-level guard above only rejects the all-empty case.
               // A partial-empty entry alongside populated ones points at a
@@ -169,35 +169,34 @@ object V2SegmentLoader extends Logging {
               // from, and the downstream V2ColumnGroup would be a silent
               // empty shell). Fail loudly with slot/segment context.
               throw new IllegalStateException(
-                s"segment ${entry.segmentId} has an empty binlog_files entry " +
+                s"segment ${resolvedEntry.segmentId} has an empty binlog_files entry " +
                   s"(slot ${afb.slotFieldId}) while other entries are populated; " +
                   "cannot recover field ids for this column group — refusing to " +
                   "emit an empty V2ColumnGroup from a partial manifest"
               )
             }
-            val samplePath =
-              resolvePath(afb.binlogs.head.logPath, bucket, storageScheme)
+            val samplePath = afb.binlogs.head.logPath
             MilvusParquetFooterReader
               .readFieldIdsFromSchema(samplePath, hadoopConf) match {
               case Right(ids) => ids
               case Left(err) =>
                 throw new RuntimeException(
                   s"failed to read field ids from parquet $samplePath " +
-                    s"(segment ${entry.segmentId}, slot ${afb.slotFieldId}): " +
+                    s"(segment ${resolvedEntry.segmentId}, slot ${afb.slotFieldId}): " +
                     err.getMessage,
                   err
                 )
             }
           }
         MilvusSegmentManifestReader.toV2SegmentInfo(
-          entry,
+          resolvedEntry,
           groupFieldIdListPerEntry
         ) match {
           case Right(seg) => Right(Some(seg))
           case Left(err) =>
             Left(
               new RuntimeException(
-                s"failed to build V2SegmentInfo for segment ${entry.segmentId}: " +
+                s"failed to build V2SegmentInfo for segment ${resolvedEntry.segmentId}: " +
                   err.getMessage,
                 err
               )
@@ -207,6 +206,28 @@ object V2SegmentLoader extends Logging {
         case NonFatal(e) => Left(e)
       }
     }
+  }
+
+  private def resolveEntryPaths(
+      entry: AvroManifestEntry,
+      bucket: String,
+      storageScheme: String
+  ): AvroManifestEntry = {
+    def resolveFieldBinlogs(
+        fieldBinlogs: Seq[AvroFieldBinlogEntry]
+    ): Seq[AvroFieldBinlogEntry] =
+      fieldBinlogs.map(fieldBinlog =>
+        fieldBinlog.copy(binlogs =
+          fieldBinlog.binlogs.map(log =>
+            log.copy(logPath = resolvePath(log.logPath, bucket, storageScheme))
+          )
+        )
+      )
+
+    entry.copy(
+      binlogFiles = resolveFieldBinlogs(entry.binlogFiles),
+      deltaLogFiles = resolveFieldBinlogs(entry.deltaLogFiles)
+    )
   }
 
   /** Prefix `bucket` when `path` has no scheme; rewrite S3 aliases to the

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -29,7 +29,8 @@ import org.apache.spark.internal.Logging
   * bucket-relative (`files/snapshots/...`). When `bucket` is non-empty we
   * prefix `{storageScheme}://{bucket}/`. The default remains `s3a` for the
   * connector DataSource and tools; Alibaba callers must explicitly pass
-  * `storageScheme = "oss"` with a matching Hadoop OSS configuration.
+  * `storageScheme = "oss"` with a matching Hadoop OSS configuration. Explicit
+  * `s3://` and `s3a://` paths are aliases rewritten to the requested scheme.
   */
 object V2SegmentLoader extends Logging {
 
@@ -208,23 +209,25 @@ object V2SegmentLoader extends Logging {
     }
   }
 
-  /** Prefix `bucket` when `path` has no scheme; preserve explicit schemes.
-    * `storageScheme` is intentionally explicit for non-S3 providers because the
-    * generic connector read path does not yet derive a provider from its public
-    * options.
+  /** Prefix `bucket` when `path` has no scheme; rewrite S3 aliases to the
+    * requested scheme and preserve other explicit schemes. `storageScheme` is
+    * intentionally explicit for non-S3 providers because the generic connector
+    * read path does not yet derive a provider from its public options.
     */
   def resolvePath(
       path: String,
       bucket: String,
       storageScheme: String = "s3a"
   ): String = {
+    val scheme = storageScheme.stripSuffix("://")
     if (path == null) path
-    else if (path.startsWith("s3a://") || path.startsWith("oss://")) path
-    else if (path.startsWith("s3://")) {
-      val scheme = storageScheme.stripSuffix("://")
+    else if (path.startsWith("s3a://"))
+      s"$scheme://" + path.stripPrefix("s3a://")
+    else if (path.startsWith("s3://"))
       s"$scheme://" + path.stripPrefix("s3://")
-    } else if (bucket != null && bucket.nonEmpty)
-      s"${storageScheme.stripSuffix("://")}://$bucket/${path.stripPrefix("/")}"
+    else if (path.contains("://")) path
+    else if (bucket != null && bucket.nonEmpty)
+      s"$scheme://$bucket/${path.stripPrefix("/")}"
     else path
   }
 

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -52,12 +52,13 @@ object V2SegmentLoader extends Logging {
       bucket: String,
       hadoopConf: Configuration,
       manifestSchemaVersion: Int = 1,
-      applyDeletes: Boolean = true
+      applyDeletes: Boolean = true,
+      storageScheme: String = "s3a"
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
     try {
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
       manifestPaths.foreach { rawPath =>
-        val avroPath = resolvePath(rawPath, bucket)
+        val avroPath = resolvePath(rawPath, bucket, storageScheme)
         val avroBytes = readAllBytes(hadoopConf, avroPath)
         val entry =
           MilvusSegmentManifestReader
@@ -73,7 +74,8 @@ object V2SegmentLoader extends Logging {
           entry,
           bucket,
           hadoopConf,
-          applyDeletes
+          applyDeletes,
+          storageScheme
         ) match {
           case Right(Some(seg)) => out += seg
           case Right(None)      => // skipped (storage version != 2)
@@ -101,7 +103,8 @@ object V2SegmentLoader extends Logging {
       entry: AvroManifestEntry,
       bucket: String,
       hadoopConf: Configuration,
-      applyDeletes: Boolean = true
+      applyDeletes: Boolean = true,
+      storageScheme: String = "s3a"
   ): Either[Throwable, Option[V2SegmentInfo]] = {
     val isL0 = entry.segmentLevel == 1L
     val hasDeltaLogs = entry.deltaLogFiles.exists(_.binlogs.nonEmpty)
@@ -170,7 +173,8 @@ object V2SegmentLoader extends Logging {
                   "emit an empty V2ColumnGroup from a partial manifest"
               )
             }
-            val samplePath = resolvePath(afb.binlogs.head.logPath, bucket)
+            val samplePath =
+              resolvePath(afb.binlogs.head.logPath, bucket, storageScheme)
             MilvusParquetFooterReader
               .readFieldIdsFromSchema(samplePath, hadoopConf) match {
               case Right(ids) => ids
@@ -203,13 +207,19 @@ object V2SegmentLoader extends Logging {
     }
   }
 
-  /** Prefix `bucket` when `path` has no scheme; pass through s3a:// / s3://. */
-  def resolvePath(path: String, bucket: String): String = {
+  /** Prefix `bucket` when `path` has no scheme; preserve explicit schemes. */
+  def resolvePath(
+      path: String,
+      bucket: String,
+      storageScheme: String = "s3a"
+  ): String = {
     if (path == null) path
-    else if (path.startsWith("s3a://")) path
-    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
-    else if (bucket != null && bucket.nonEmpty)
-      s"s3a://$bucket/${path.stripPrefix("/")}"
+    else if (path.startsWith("s3a://") || path.startsWith("oss://")) path
+    else if (path.startsWith("s3://")) {
+      val scheme = storageScheme.stripSuffix("://")
+      s"$scheme://" + path.stripPrefix("s3://")
+    } else if (bucket != null && bucket.nonEmpty)
+      s"${storageScheme.stripSuffix("://")}://$bucket/${path.stripPrefix("/")}"
     else path
   }
 

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -494,10 +494,27 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     MilvusBackfill.normalizeS3Scheme(null) shouldBe null
   }
 
-  test("normalizeObjectStorageScheme preserves OSS paths") {
+  test("normalizeObjectStorageScheme selects OSS aliases for Alibaba") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "managed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
     MilvusBackfill.normalizeObjectStorageScheme(
-      "oss://bucket/files/snapshot.json"
-    ) shouldBe "oss://bucket/files/snapshot.json"
+      "s3a://managed-bucket/files/snapshot.json",
+      cfg
+    ) shouldBe "oss://managed-bucket/files/snapshot.json"
+    MilvusBackfill.normalizeObjectStorageScheme(
+      "s3://managed-bucket/files/snapshot.json",
+      cfg
+    ) shouldBe "oss://managed-bucket/files/snapshot.json"
+    MilvusBackfill.normalizeObjectStorageScheme(
+      "oss://managed-bucket/files/snapshot.json",
+      cfg
+    ) shouldBe "oss://managed-bucket/files/snapshot.json"
   }
 
   test("storagePath selects OSS for Alibaba") {
@@ -542,7 +559,105 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       hc.get("fs.oss.accessKeyId") shouldBe null
       hc.get("fs.oss.accessKeySecret") shouldBe null
     } finally {
-      hc.unset(BackfillConfig.HadoopOssCredentialsProvider)
+      Seq(
+        BackfillConfig.HadoopOssCredentialsProvider,
+        "fs.oss.impl",
+        "fs.oss.endpoint",
+        "fs.oss.connection.secure.enabled",
+        "fs.oss.accessKeyId",
+        "fs.oss.accessKeySecret"
+      ).foreach(hc.unset)
+    }
+  }
+
+  test(
+    "configureHadoopOssForPath uses built-in static credential construction"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou.aliyuncs.com",
+      s3BucketName = "static-bucket",
+      s3AccessKey = "static-ak",
+      s3SecretKey = "static-sk",
+      s3CloudProvider = "aliyun",
+      s3UseIam = false
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.set(
+      BackfillConfig.HadoopOssCredentialsProvider,
+      BackfillConfig.HadoopOssAssumedRoleProvider
+    )
+    try {
+      MilvusBackfill.configureHadoopOssForPath(
+        spark,
+        "oss://static-bucket/files/data.parquet",
+        cfg,
+        isSource = false
+      )
+      hc.get("fs.oss.accessKeyId") shouldBe "static-ak"
+      hc.get("fs.oss.accessKeySecret") shouldBe "static-sk"
+      hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe null
+      hc.get("fs.oss.connection.secure.enabled") shouldBe null
+      val uri = new java.net.URI("oss://static-bucket/files/data.parquet")
+      val provider = org.apache.hadoop.fs.aliyun.oss.AliyunOSSUtils
+        .getCredentialsProvider(uri, hc)
+      provider should not be null
+      provider.getCredentials.getAccessKeyId shouldBe "static-ak"
+      provider.getCredentials.getSecretAccessKey shouldBe "static-sk"
+    } finally {
+      Seq(
+        BackfillConfig.HadoopOssCredentialsProvider,
+        "fs.oss.impl",
+        "fs.oss.endpoint",
+        "fs.oss.connection.secure.enabled",
+        "fs.oss.accessKeyId",
+        "fs.oss.accessKeySecret"
+      ).foreach(hc.unset)
+    }
+  }
+
+  test("withScopedHadoopStorage restores managed OSS configuration") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou.aliyuncs.com",
+      s3BucketName = "static-source",
+      s3AccessKey = "main-ak",
+      s3SecretKey = "main-sk",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true,
+      sourceS3AccessKey = Some("source-ak"),
+      sourceS3SecretKey = Some("source-sk"),
+      sourceS3UseIam = Some(false)
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val provider = BackfillConfig.HadoopOssAssumedRoleProvider
+    hc.set(BackfillConfig.HadoopOssCredentialsProvider, provider)
+    hc.set("fs.oss.endpoint", "managed-endpoint")
+    try {
+      MilvusBackfill.withScopedHadoopStorage(
+        spark,
+        "oss://static-source/input.parquet",
+        cfg,
+        isSource = true
+      ) {
+        hc.get("fs.oss.accessKeyId") shouldBe "source-ak"
+        hc.get("fs.oss.accessKeySecret") shouldBe "source-sk"
+        hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe null
+      }
+      hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe provider
+      hc.get("fs.oss.endpoint") shouldBe "managed-endpoint"
+      hc.get("fs.oss.accessKeyId") shouldBe null
+      hc.get("fs.oss.accessKeySecret") shouldBe null
+      hc.get("fs.oss.impl") shouldBe null
+      hc.get("fs.oss.impl.disable.cache") shouldBe null
+    } finally {
+      Seq(
+        BackfillConfig.HadoopOssCredentialsProvider,
+        "fs.oss.impl",
+        "fs.oss.impl.disable.cache",
+        "fs.oss.endpoint",
+        "fs.oss.connection.secure.enabled",
+        "fs.oss.accessKeyId",
+        "fs.oss.accessKeySecret"
+      ).foreach(hc.unset)
     }
   }
 

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -494,6 +494,58 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     MilvusBackfill.normalizeS3Scheme(null) shouldBe null
   }
 
+  test("normalizeObjectStorageScheme preserves OSS paths") {
+    MilvusBackfill.normalizeObjectStorageScheme(
+      "oss://bucket/files/snapshot.json"
+    ) shouldBe "oss://bucket/files/snapshot.json"
+  }
+
+  test("storagePath selects OSS for Alibaba") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "managed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
+    MilvusBackfill.storagePath(
+      cfg,
+      "files"
+    ) shouldBe "oss://managed-bucket/files"
+  }
+
+  test("configureHadoopOssForPath preserves managed IAM provider") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "oss-cn-hangzhou-internal.aliyuncs.com",
+      s3BucketName = "managed-bucket",
+      s3AccessKey = "",
+      s3SecretKey = "",
+      s3CloudProvider = "aliyun",
+      s3UseIam = true
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    val provider = BackfillConfig.HadoopOssAssumedRoleProvider
+    hc.set(BackfillConfig.HadoopOssCredentialsProvider, provider)
+    try {
+      MilvusBackfill.configureHadoopOssForPath(
+        spark,
+        "oss://managed-bucket/files/snapshot.json",
+        cfg,
+        isSource = false
+      )
+      hc.get(
+        "fs.oss.impl"
+      ) shouldBe "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem"
+      hc.get("fs.oss.endpoint") shouldBe "oss-cn-hangzhou-internal.aliyuncs.com"
+      hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe provider
+      hc.get("fs.oss.accessKeyId") shouldBe null
+      hc.get("fs.oss.accessKeySecret") shouldBe null
+    } finally {
+      hc.unset(BackfillConfig.HadoopOssCredentialsProvider)
+    }
+  }
+
   // ============ parseArgs whitelist ============
 
   test("parseArgs rejects unknown flags (typo guard)") {

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -545,6 +545,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     val hc = spark.sparkContext.hadoopConfiguration
     val provider = BackfillConfig.HadoopOssAssumedRoleProvider
     hc.set(BackfillConfig.HadoopOssCredentialsProvider, provider)
+    hc.set(BackfillConfig.HadoopOssSecurityToken, "managed-token")
     try {
       MilvusBackfill.configureHadoopOssForPath(
         spark,
@@ -557,11 +558,13 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       ) shouldBe "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem"
       hc.get("fs.oss.endpoint") shouldBe "oss-cn-hangzhou-internal.aliyuncs.com"
       hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe provider
+      hc.get(BackfillConfig.HadoopOssSecurityToken) shouldBe "managed-token"
       hc.get("fs.oss.accessKeyId") shouldBe null
       hc.get("fs.oss.accessKeySecret") shouldBe null
     } finally {
       Seq(
         BackfillConfig.HadoopOssCredentialsProvider,
+        BackfillConfig.HadoopOssSecurityToken,
         "fs.oss.impl",
         "fs.oss.endpoint",
         "fs.oss.connection.secure.enabled",
@@ -587,6 +590,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       BackfillConfig.HadoopOssCredentialsProvider,
       BackfillConfig.HadoopOssAssumedRoleProvider
     )
+    hc.set(BackfillConfig.HadoopOssSecurityToken, "stale-target-token")
     try {
       MilvusBackfill.configureHadoopOssForPath(
         spark,
@@ -597,6 +601,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       hc.get("fs.oss.accessKeyId") shouldBe "static-ak"
       hc.get("fs.oss.accessKeySecret") shouldBe "static-sk"
       hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe null
+      hc.get(BackfillConfig.HadoopOssSecurityToken) shouldBe null
       hc.get("fs.oss.connection.secure.enabled") shouldBe null
       val uri = new java.net.URI("oss://static-bucket/files/data.parquet")
       val provider = org.apache.hadoop.fs.aliyun.oss.AliyunOSSUtils
@@ -607,6 +612,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     } finally {
       Seq(
         BackfillConfig.HadoopOssCredentialsProvider,
+        BackfillConfig.HadoopOssSecurityToken,
         "fs.oss.impl",
         "fs.oss.endpoint",
         "fs.oss.connection.secure.enabled",
@@ -631,6 +637,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     val hc = spark.sparkContext.hadoopConfiguration
     val provider = BackfillConfig.HadoopOssAssumedRoleProvider
     hc.set(BackfillConfig.HadoopOssCredentialsProvider, provider)
+    hc.set(BackfillConfig.HadoopOssSecurityToken, "managed-token")
     hc.set("fs.oss.endpoint", "managed-endpoint")
     try {
       MilvusBackfill.withScopedHadoopStorage(
@@ -642,8 +649,10 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
         hc.get("fs.oss.accessKeyId") shouldBe "source-ak"
         hc.get("fs.oss.accessKeySecret") shouldBe "source-sk"
         hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe null
+        hc.get(BackfillConfig.HadoopOssSecurityToken) shouldBe null
       }
       hc.get(BackfillConfig.HadoopOssCredentialsProvider) shouldBe provider
+      hc.get(BackfillConfig.HadoopOssSecurityToken) shouldBe "managed-token"
       hc.get("fs.oss.endpoint") shouldBe "managed-endpoint"
       hc.get("fs.oss.accessKeyId") shouldBe null
       hc.get("fs.oss.accessKeySecret") shouldBe null
@@ -652,6 +661,7 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     } finally {
       Seq(
         BackfillConfig.HadoopOssCredentialsProvider,
+        BackfillConfig.HadoopOssSecurityToken,
         "fs.oss.impl",
         "fs.oss.impl.disable.cache",
         "fs.oss.endpoint",

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -1,6 +1,7 @@
 package com.zilliz.spark.connector.operations.backfill
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.storage.StorageLevel
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -659,6 +660,27 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
         "fs.oss.accessKeySecret"
       ).foreach(hc.unset)
     }
+  }
+
+  test("OSS source checkpoint exposes and releases its persisted RDD") {
+    val session = spark
+    import session.implicits._
+
+    val source = MilvusBackfill.localCheckpointBackfillData(
+      spark,
+      Seq((1L, "one"), (2L, "two")).toDF("id", "value")
+    )
+    val checkpointRDD = source.checkpointRDD.get
+    try {
+      source.dataFrame.collect().map(_.getLong(0)).toSeq shouldBe Seq(1L, 2L)
+      checkpointRDD.getStorageLevel should not be StorageLevel.NONE
+      spark.sparkContext.getPersistentRDDs.keySet should contain(
+        checkpointRDD.id
+      )
+    } finally {
+      checkpointRDD.unpersist(blocking = true)
+    }
+    spark.sparkContext.getPersistentRDDs.keySet should not contain checkpointRDD.id
   }
 
   // ============ parseArgs whitelist ============

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -42,7 +42,7 @@ class V2SegmentLoaderTest
     with Matchers
     with BeforeAndAfterEach {
 
-  test("resolvePath uses OSS for Alibaba relative and legacy S3 paths") {
+  test("resolvePath uses OSS for Alibaba manifest and nested binlog paths") {
     V2SegmentLoader.resolvePath(
       "files/manifest.avro",
       "managed-bucket",
@@ -53,6 +53,16 @@ class V2SegmentLoaderTest
       "managed-bucket",
       "oss"
     ) shouldBe "oss://managed-bucket/files/manifest.avro"
+    V2SegmentLoader.resolvePath(
+      "s3a://managed-bucket/files/snapshots/manifest.avro",
+      "managed-bucket",
+      "oss"
+    ) shouldBe "oss://managed-bucket/files/snapshots/manifest.avro"
+    V2SegmentLoader.resolvePath(
+      "s3a://managed-bucket/files/insert_log/1/2/3/4.parquet",
+      "managed-bucket",
+      "oss"
+    ) shouldBe "oss://managed-bucket/files/insert_log/1/2/3/4.parquet"
   }
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -1,10 +1,16 @@
 package com.zilliz.spark.connector.read
 
+import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path => NPath}
+import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters._
 
+import org.apache.avro.generic.{GenericData, GenericDatumWriter, GenericRecord}
+import org.apache.avro.io.EncoderFactory
+import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{
   FSDataInputStream,
@@ -70,6 +76,93 @@ class V2SegmentLoaderTest
     CloseTrackingV2FileSystem.reset()
   }
 
+  private lazy val manifestSchema: Schema = {
+    val in = getClass.getResourceAsStream("/milvus-segment-manifest-v1.avsc")
+    val full =
+      try new Schema.Parser().parse(in)
+      finally in.close()
+    val lastFieldIndex = full.getFields.asScala.indexWhere(
+      _.name == "deltalog_files"
+    )
+    val schema = Schema.createRecord(
+      full.getName,
+      full.getDoc,
+      full.getNamespace,
+      full.isError
+    )
+    schema.setFields(
+      full.getFields.asScala
+        .take(lastFieldIndex + 1)
+        .map { f =>
+          new Schema.Field(f.name, f.schema, f.doc, f.defaultVal)
+        }
+        .asJava
+    )
+    schema
+  }
+
+  private def encodeManifest(
+      binlogPath: String,
+      deltaLogPath: String
+  ): Array[Byte] = {
+    val record = new GenericData.Record(manifestSchema)
+    record.put("segment_id", 1001L)
+    record.put("partition_id", 10L)
+    record.put("segment_level", 2L)
+    record.put("channel_name", "test-channel")
+    record.put("num_of_rows", 1L)
+
+    val positionSchema = manifestSchema.getField("start_position").schema
+    def position(): GenericRecord = {
+      val value = new GenericData.Record(positionSchema)
+      value.put("channel_name", "test-channel")
+      value.put("msg_id", ByteBuffer.wrap(Array.emptyByteArray))
+      value.put("msg_group", "test-group")
+      value.put("timestamp", 1L)
+      value
+    }
+    record.put("start_position", position())
+    record.put("dml_position", position())
+    record.put("storage_version", 2L)
+    record.put("is_sorted", false)
+
+    val fieldBinlogSchema =
+      manifestSchema.getField("binlog_files").schema.getElementType
+    val binlogSchema =
+      fieldBinlogSchema.getField("binlogs").schema.getElementType
+
+    def binlog(path: String, logId: Long): GenericRecord = {
+      val value = new GenericData.Record(binlogSchema)
+      value.put("entries_num", 1L)
+      value.put("timestamp_from", 1L)
+      value.put("timestamp_to", 1L)
+      value.put("log_path", path)
+      value.put("log_size", 1L)
+      value.put("log_id", logId)
+      value.put("memory_size", 1L)
+      value
+    }
+
+    def fieldBinlog(path: String, logId: Long): GenericRecord = {
+      val value = new GenericData.Record(fieldBinlogSchema)
+      value.put("field_id", 100L)
+      value.put("binlogs", Seq(binlog(path, logId)).asJava)
+      value
+    }
+
+    record.put("binlog_files", Seq(fieldBinlog(binlogPath, 1L)).asJava)
+    record.put("deltalog_files", Seq(fieldBinlog(deltaLogPath, 2L)).asJava)
+
+    val out = new ByteArrayOutputStream()
+    val encoder = EncoderFactory.get().directBinaryEncoder(out, null)
+    new GenericDatumWriter[GenericRecord](manifestSchema).write(record, encoder)
+    encoder.flush()
+    out.toByteArray
+  }
+
+  private def fileUriAsS3a(path: NPath): String =
+    "s3a://" + path.toUri.toString.stripPrefix("file://")
+
   /** Write a single-column parquet at `path` carrying the given field id, so
     * `readFieldIdsFromSchema` will return `Seq(fieldId)`.
     */
@@ -131,6 +224,34 @@ class V2SegmentLoaderTest
     val p = Files.createTempFile(prefix, ".parquet")
     Files.delete(p) // ExampleParquetWriter refuses to overwrite existing files
     p
+  }
+
+  test("loadV2Segments normalizes returned S3A binlog and delta paths") {
+    val parquet = mkTempParquet("v2loader-resolved-path-")
+    val manifest = Files.createTempFile("v2loader-manifest-", ".avro")
+    val deltaLog = manifest.resolveSibling("delete-log.bin")
+    try {
+      writeSingleFieldParquet(parquet, "pk", fieldId = 100)
+      Files.write(
+        manifest,
+        encodeManifest(fileUriAsS3a(parquet), fileUriAsS3a(deltaLog))
+      )
+
+      val result = V2SegmentLoader.loadV2Segments(
+        Seq(fileUriAsS3a(manifest)),
+        bucket = "",
+        hadoopConf = new Configuration(),
+        storageScheme = "file"
+      )
+
+      result shouldBe a[Right[_, _]]
+      val segment = result.toOption.get.head
+      segment.columnGroups.head.filePaths shouldBe Seq(parquet.toUri.toString)
+      segment.deltaLogs.map(_.logPath) shouldBe Seq(deltaLog.toUri.toString)
+    } finally {
+      Files.deleteIfExists(manifest)
+      Files.deleteIfExists(parquet)
+    }
   }
 
   private def entry(

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -42,6 +42,19 @@ class V2SegmentLoaderTest
     with Matchers
     with BeforeAndAfterEach {
 
+  test("resolvePath uses OSS for Alibaba relative and legacy S3 paths") {
+    V2SegmentLoader.resolvePath(
+      "files/manifest.avro",
+      "managed-bucket",
+      "oss"
+    ) shouldBe "oss://managed-bucket/files/manifest.avro"
+    V2SegmentLoader.resolvePath(
+      "s3://managed-bucket/files/manifest.avro",
+      "managed-bucket",
+      "oss"
+    ) shouldBe "oss://managed-bucket/files/manifest.avro"
+  }
+
   override def beforeEach(): Unit = {
     super.beforeEach()
     CloseTrackingV2FileSystem.reset()


### PR DESCRIPTION
## Summary
- route parquet, snapshot, StorageV2 manifest, and result JSON paths through OSS when `s3CloudProvider=aliyun`
- configure Hadoop OSS without overwriting the platform-injected OSS credentials provider
- preserve managed IAM role propagation and add OSS path/configuration coverage

## Validation
- scalafmt completed
- targeted Cloud-side contract tests pass
- Spark compile/test is environment-blocked locally until the required milvus-storage JNI jar is built; the failure is missing generated `io.milvus.storage` classes, not this change

## Dependency
The matching zilliz-cloud PR passes `--s3-cloud-provider aliyun` and must be deployed with this connector change.
