### PR TITLE
fix: support partial backfill column mappings

### DIFF
--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -495,14 +495,10 @@ object MilvusBackfill {
     }
   }
 
-  /** Project the raw backfill DataFrame through a parquet-column → Milvus-field
-    * mapping so downstream code sees column names that match the Milvus schema
-    * exactly (including the PK, which must be named `pkName`).
-    *
-    * When `userMapping` is None, a legacy implicit mapping is synthesized: the
-    * literal `"pk"` column is renamed to `pkName`, every other column is kept
-    * as-is. This preserves the pre-existing contract (parquet must have a `pk`
-    * column plus one or more field columns).
+  /** Project the raw backfill DataFrame through optional parquet-column →
+    * Milvus-field overrides. Columns omitted from `userMapping` keep their
+    * original names. The legacy literal `"pk"` column is still renamed to
+    * `pkName` when no same-name primary-key column exists.
     */
   private[backfill] def applyColumnMapping(
       df: DataFrame,
@@ -512,35 +508,10 @@ object MilvusBackfill {
     val cols = df.columns.toSeq
     val colSet = cols.toSet
 
-    val mapping: Map[String, String] = userMapping match {
-      case Some(m) => m
-      case None    =>
-        // Legacy: require a literal "pk" column; transparently rename it to pkName.
-        if (!colSet.contains("pk")) {
-          return Left(
-            SchemaValidationError(
-              "Backfill parquet must contain a 'pk' column (or supply --column-mapping to rename the PK column)"
-            )
-          )
-        }
-        // If the parquet already has a column named pkName, the implicit
-        // {pk→pkName} rename would collide with it. Surface a dedicated error
-        // rather than letting the generic duplicate-target check fire and
-        // reference "column mapping" — users in the legacy path never passed
-        // --column-mapping.
-        if (pkName != "pk" && colSet.contains(pkName)) {
-          return Left(
-            SchemaValidationError(
-              s"Backfill parquet contains both a 'pk' column and a column named '$pkName' " +
-                s"(the collection's primary-key field). Remove one, or supply --column-mapping to disambiguate."
-            )
-          )
-        }
-        cols.map(c => if (c == "pk") c -> pkName else c -> c).toMap
-    }
+    val overrides = userMapping.getOrElse(Map.empty)
 
-    // Mapping keys must all exist in the parquet.
-    val missingSrc = mapping.keySet.diff(colSet)
+    // Explicit override keys must all exist in the parquet.
+    val missingSrc = overrides.keySet.diff(colSet)
     if (missingSrc.nonEmpty) {
       return Left(
         SchemaValidationError(
@@ -550,8 +521,28 @@ object MilvusBackfill {
       )
     }
 
-    // Mapping values must be unique; two parquet columns cannot both point at
-    // the same Milvus field.
+    if (
+      pkName != "pk" && colSet.contains("pk") && colSet.contains(pkName) &&
+      !overrides.contains("pk") && !overrides.contains(pkName)
+    ) {
+      return Left(
+        SchemaValidationError(
+          s"Backfill parquet contains both a 'pk' column and a column named '$pkName' " +
+            s"(the collection's primary-key field). Remove one, or supply --column-mapping to disambiguate."
+        )
+      )
+    }
+
+    val identityMapping = cols.map(column => column -> column).toMap
+    val legacyPkMapping =
+      if (
+        !colSet.contains(pkName) && colSet.contains("pk") &&
+        !overrides.contains("pk")
+      ) Map("pk" -> pkName)
+      else Map.empty[String, String]
+    val mapping = identityMapping ++ legacyPkMapping ++ overrides
+
+    // Validate the effective mapping, including implicit same-name columns.
     val dupTargets = mapping.values.groupBy(identity).collect {
       case (k, v) if v.size > 1 => k
     }
@@ -567,7 +558,7 @@ object MilvusBackfill {
     if (!mapping.values.toSet.contains(pkName)) {
       return Left(
         SchemaValidationError(
-          s"column mapping must include the primary key field '$pkName' as a target"
+          s"Backfill parquet must contain the primary key field '$pkName', or columnMapping must map a source column to it"
         )
       )
     }
@@ -577,7 +568,7 @@ object MilvusBackfill {
     if (newFieldTargets.isEmpty) {
       return Left(
         SchemaValidationError(
-          "column mapping must include at least one non-PK field to backfill"
+          "Backfill parquet must contain at least one non-PK field to backfill"
         )
       )
     }
@@ -585,9 +576,8 @@ object MilvusBackfill {
     // Single-pass aliased select. A foldLeft of withColumnRenamed would rename
     // sequentially and corrupt chains like {a→b, b→c} (the second rename would
     // hit the already-renamed column) and swaps like {a→b, b→a}.
-    val orderedKeys = cols.filter(mapping.contains)
     val renamed = df.select(
-      orderedKeys.map(src => df.col(src).as(mapping(src))): _*
+      cols.map(src => df.col(src).as(mapping(src))): _*
     )
     Right(renamed)
   }

--- a/src/test/scala/operations/backfill/ColumnMappingTest.scala
+++ b/src/test/scala/operations/backfill/ColumnMappingTest.scala
@@ -109,7 +109,7 @@ class ColumnMappingTest
     }
   }
 
-  test("applyColumnMapping: explicit mapping renames, drops unlisted columns") {
+  test("applyColumnMapping: explicit mapping preserves unlisted columns") {
     val df = buildDf(
       Seq("pk", "vec", "extra"),
       Seq(Seq(1, "v1", "drop-me"), Seq(2, "v2", "drop-me-2"))
@@ -118,7 +118,11 @@ class ColumnMappingTest
     val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
     result.isRight shouldBe true
     val out = result.toOption.get
-    out.columns.toSeq should contain theSameElementsAs Seq("id", "embedding")
+    out.columns.toSeq should contain theSameElementsAs Seq(
+      "id",
+      "embedding",
+      "extra"
+    )
     val collected =
       out.orderBy("id").collect().map(r => (r.getInt(0), r.getString(1))).toSeq
     collected shouldBe Seq((1, "v1"), (2, "v2"))
@@ -164,12 +168,29 @@ class ColumnMappingTest
     out.columns.toSeq should contain theSameElementsAs Seq("id", "vec")
   }
 
-  test("applyColumnMapping: legacy path errors when 'pk' column missing") {
+  test("applyColumnMapping: same-name columns need no mapping") {
     val df = buildDf(Seq("id", "vec"), Seq(Seq(1, "v1")))
     val result = MilvusBackfill.applyColumnMapping(df, "id", None)
-    result.isLeft shouldBe true
-    result.left.toOption.get shouldBe a[SchemaValidationError]
-    result.left.toOption.get.message should include("'pk' column")
+    result.isRight shouldBe true
+    result.toOption.get.columns.toSeq should contain theSameElementsAs Seq(
+      "id",
+      "vec"
+    )
+  }
+
+  test("applyColumnMapping: partial mapping preserves same-name columns") {
+    val df = buildDf(
+      Seq("id", "source_label", "score"),
+      Seq(Seq(1, "label-1", "0.9"))
+    )
+    val mapping = Some(Map("source_label" -> "label"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isRight shouldBe true
+    result.toOption.get.columns.toSeq should contain theSameElementsAs Seq(
+      "id",
+      "label",
+      "score"
+    )
   }
 
   test(
@@ -205,6 +226,17 @@ class ColumnMappingTest
     val err = result.left.toOption.get
     err shouldBe a[SchemaValidationError]
     err.message should include("duplicate targets")
+  }
+
+  test("applyColumnMapping: override cannot collide with a same-name column") {
+    val df = buildDf(
+      Seq("id", "source_label", "label"),
+      Seq(Seq(1, "source", "existing"))
+    )
+    val mapping = Some(Map("source_label" -> "label"))
+    val result = MilvusBackfill.applyColumnMapping(df, "id", mapping)
+    result.isLeft shouldBe true
+    result.left.toOption.get.message should include("duplicate targets")
   }
 
   test("applyColumnMapping: explicit mapping missing pkName as target errors") {
@@ -258,9 +290,7 @@ class ColumnMappingTest
       .toSeq shouldBe Seq((1, "v1"), (2, "v2"))
   }
 
-  test(
-    "prepareBackfillData separates explicitly mapped PK from target fields"
-  ) {
+  test("prepareBackfillData applies overrides and keeps same-name fields") {
     val df = buildDf(
       Seq("source_id", "vec", "drop_me"),
       Seq(Seq("1", "v1", "x"))
@@ -274,9 +304,10 @@ class ColumnMappingTest
 
     prepared.dataFrame.columns.toSeq shouldBe Seq(
       ResolvedJoinKey.internalColumn(0),
-      "embedding"
+      "embedding",
+      "drop_me"
     )
-    prepared.targetFieldNames shouldBe Seq("embedding")
+    prepared.targetFieldNames shouldBe Seq("embedding", "drop_me")
   }
 
   test("prepareBackfillData preserves a target named like the default alias") {


### PR DESCRIPTION
## Summary

- treat `columnMapping` as source-to-target overrides instead of a complete projection
- keep unlisted Parquet columns under same-name mapping
- preserve legacy implicit `pk` to collection primary-key mapping
- reject missing sources and effective target collisions

## Validation

- `sbt -batch scalafmtAll 'testOnly com.zilliz.spark.connector.operations.backfill.ColumnMappingTest'`
- 26 tests passed
