### PR TITLE
fix: [reader] canonicalize Milvus-format S3 URIs

### DIFF
--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -475,8 +475,17 @@ case class MilvusS3Option(
 
   def getFilePath(path: String): Path = {
     if (notEmpty(s3FileSystemType)) {
-      if (path.startsWith("s3a://")) {
-        new Path(path)
+      if (path.startsWith("s3a://") || path.startsWith("s3://")) {
+        // Canonicalize Milvus-format s3://<address>/<bucket>/<key> so the
+        // endpoint is not treated as the bucket. Thread the configured
+        // endpoint so port-less endpoints are recognized too.
+        new Path(
+          MilvusStoragePath.toStandardS3Path(
+            path,
+            endpoint = s3Endpoint,
+            configuredBucket = s3BucketName
+          )
+        )
       } else {
         val finalPath = s"s3a://${s3BucketName}/${s3RootPath}/${path}"
         new Path(new URI(finalPath))

--- a/src/main/scala/MilvusStoragePath.scala
+++ b/src/main/scala/MilvusStoragePath.scala
@@ -1,0 +1,410 @@
+package com.zilliz.spark.connector
+
+import java.net.URI
+
+/** Neutral storage-path utilities shared by the config layer (MilvusOption)
+  * and the read layer (MilvusSnapshotReader).
+  *
+  * Milvus storage can surface the same object in three shapes depending on how
+  * the server was configured:
+  *
+  *   - bucket-relative key: `file/snapshots/...` (no scheme)
+  *   - standard S3: `s3://<bucket>/<key>`
+  *   - Milvus-format: `s3://<address>/<bucket>/<key>` (address = storage
+  *     endpoint, embedded whenever `fs.address` is non-empty, e.g. MinIO
+  *     deployments)
+  *
+  * [[toStandardS3Path]] collapses all three to the Hadoop `s3a://<bucket>/<key>`
+  * form; [[toBucketRelativeKey]] reduces a path to the bare object key that
+  * milvus-storage's native FFI resolves against the `fs.*` properties.
+  */
+object MilvusStoragePath {
+
+  /** Probe the scheme of a storage path without throwing on input
+    * `java.net.URI` rejects (a space, an unescaped `%`, brackets).
+    *
+    * `s3://` / `s3a://` prefixes are matched textually so the unparseable
+    * fallbacks in [[toStandardS3Path]] / [[toBucketRelativeKey]] / [[bucketOf]]
+    * stay reachable from callers that first branch on the scheme.
+    */
+  private[connector] def schemeOf(path: String): Option[String] = {
+    if (path == null) None
+    else {
+      val trimmed = path.trim
+      if (trimmed.isEmpty) None
+      else if (trimmed.startsWith("s3://")) Some("s3")
+      else if (trimmed.startsWith("s3a://")) Some("s3a")
+      else {
+        try Option(new URI(trimmed).getScheme).map(_.toLowerCase)
+        catch { case _: Exception => None }
+      }
+    }
+  }
+
+  /** Textually split a URI authority into its (host, port).
+    *
+    * `java.net.URI.getHost` / `getPort` return null / -1 for hosts that
+    * violate RFC 2396 `domainlabel` — e.g. a docker-compose service name with
+    * an underscore like `milvus_minio` — so fall back to parsing the raw
+    * authority: drop through the last `@` (userinfo) and split on the last
+    * `:` (a `[...]:port` IPv6 form keeps its brackets).
+    */
+  private def authorityHostPort(
+      authority: String
+  ): (String, Option[Int]) = {
+    if (authority == null || authority.isEmpty) ("", None)
+    else {
+      val noUser = authority.split("@").last
+      val colon = noUser.lastIndexOf(':')
+      if (colon > 0) {
+        val host = noUser.substring(0, colon)
+        val port = noUser.substring(colon + 1).toIntOption
+        (host, port)
+      } else (noUser, None)
+    }
+  }
+
+  /** Normalize a configured storage endpoint to a bare lowercase host, so it
+    * can be compared against a URI authority host.
+    *
+    * Handles `http://host:port`, `host:port`, and bare-host forms. Unknown
+    * shapes fall back to the trimmed, lowercased input.
+    */
+  private[connector] def storageEndpointHost(endpoint: String): String = {
+    if (endpoint == null) return ""
+    val trimmed = endpoint.trim
+    if (trimmed.isEmpty) return ""
+    val uri =
+      try new URI(if (trimmed.contains("://")) trimmed else "//" + trimmed)
+      catch { case _: Exception => return trimmed.toLowerCase }
+    // URI.getHost preserves case and is null for hosts that violate RFC 2396
+    // (e.g. an underscore), so normalize via the textual authority too.
+    Option(uri.getHost)
+      .map(_.toLowerCase)
+      .orElse(
+        Option(uri.getRawAuthority)
+          .map(a => authorityHostPort(a)._1.toLowerCase)
+          .filter(_.nonEmpty)
+      )
+      .getOrElse(trimmed.toLowerCase)
+  }
+
+  /** True when `uri` is a Milvus-format storage URI whose authority is the
+    * storage endpoint rather than the bucket.
+    *
+    * Signals, in order:
+    *
+    *   - the authority carries a port (`host:port`): an S3 bucket name may only
+    *     contain lowercase letters, digits, `-` and `.`, so it can never carry
+    *     a port. The port is read from `getPort` when the host parses as a
+    *     server-based authority, else derived textually from the raw authority
+    *     (hosts with an underscore fail RFC 2396 and yield getPort == -1).
+    *   - the authority host equals the configured storage endpoint host. This
+    *     covers port-less endpoints (e.g. `s3.amazonaws.com`).
+    *   - an endpoint-spelling-independent signal using the configured bucket:
+    *     when the port and endpoint-host checks cannot decide, an authority
+    *     that equals the configured bucket is standard S3 (the bucket is in
+    *     the authority), while a first path segment equal to the configured
+    *     bucket is Milvus-format (the bucket is embedded after the endpoint).
+    *     This survives spelling differences between what Milvus embedded in
+    *     the URI and what the connector was configured with (regional vs
+    *     global host, IP vs DNS name, an alias behind a proxy).
+    */
+  private def isEndpointPrefixed(
+      uri: URI,
+      endpoint: String,
+      configuredBucket: String
+  ): Boolean = {
+    val rawAuthority = Option(uri.getRawAuthority).getOrElse("")
+    val (textHost, textPort) = authorityHostPort(rawAuthority)
+    val port = if (uri.getPort > 0) uri.getPort else textPort.getOrElse(-1)
+    if (port > 0) {
+      true
+    } else {
+      val host = Option(uri.getHost)
+        .map(_.toLowerCase)
+        .orElse(Some(textHost.toLowerCase).filter(_.nonEmpty))
+        .getOrElse("")
+      if (host.nonEmpty && storageEndpointHost(endpoint) == host) {
+        true
+      } else {
+        val configured = configuredBucket.trim.toLowerCase
+        if (configured.nonEmpty && host.nonEmpty) {
+          val rawPath = Option(uri.getRawPath).getOrElse("").stripPrefix("/")
+          val slash = rawPath.indexOf('/')
+          val firstSegment =
+            (if (slash < 0) rawPath else rawPath.substring(0, slash)).toLowerCase
+          if (host == configured) false // authority IS the bucket → standard
+          else if (host.contains("."))
+            // endpoint-like authority (a DNS name or IP): a first path segment
+            // equal to the configured bucket implies Milvus-format. A
+            // single-label authority such as "archive" or "data-lake" is a
+            // standard bucket, not an endpoint — reading it as Milvus-format
+            // would silently rewrite the path to the configured bucket.
+            firstSegment == configured
+          else false
+        } else false
+      }
+    }
+  }
+
+  /** Textually split an unparseable `s3://` / `s3a://` URI (one that
+    * `java.net.URI` rejects — a space, a brace, a stray `%`) into its
+    * authority, path, host and port.
+    *
+    * `java.net.URI` cannot parse these inputs, but the authority/path split on
+    * `/` still works textually, so Milvus-format detection (a `host:port`
+    * authority, or a first path segment equal to the configured bucket) keeps
+    * working instead of leaving the endpoint as the bucket.
+    */
+  private def unparseableAuthorityParts(
+      trimmed: String
+  ): (String, String, String, Option[Int]) = {
+    val schemeEnd = trimmed.indexOf("://")
+    val rest = if (schemeEnd >= 0) trimmed.substring(schemeEnd + 3) else trimmed
+    val slash = rest.indexOf('/')
+    val authority = if (slash < 0) rest else rest.substring(0, slash)
+    val path = if (slash < 0) "" else rest.substring(slash + 1)
+    val (host, port) = authorityHostPort(authority)
+    (authority, path, host, port)
+  }
+
+  /** Reduce a bare object key from an unparseable `s3://` / `s3a://` URI. */
+  private def unparseableBucketRelativeKey(trimmed: String): String = {
+    val (_, path, _, port) = unparseableAuthorityParts(trimmed)
+    if (port.nonEmpty) {
+      // Milvus-format: scheme://address/bucket/key — strip the bucket segment.
+      // With no path segment after the bucket there is no object key.
+      val slash = path.indexOf('/')
+      if (slash < 0) "" else path.substring(slash + 1)
+    } else {
+      // Standard S3: scheme://bucket/key — everything after the authority.
+      path
+    }
+  }
+
+  /** Extract the bucket from an unparseable `s3://` / `s3a://` URI, so a bare
+    * key stripped from the same input is never left to resolve silently
+    * against the connector's configured bucket.
+    */
+  private def unparseableBucket(trimmed: String): String = {
+    val (authority, path, host, port) = unparseableAuthorityParts(trimmed)
+    if (port.nonEmpty) {
+      // Milvus-format: the first path segment is the bucket.
+      val slash = path.indexOf('/')
+      if (slash < 0) path else path.substring(0, slash)
+    } else if (host.nonEmpty) {
+      // Standard S3: the authority host is the bucket.
+      host
+    } else {
+      authority
+    }
+  }
+
+  /** Canonicalize an unparseable `s3://` / `s3a://` URI to
+    * `s3a://bucket/key`, applying the same Milvus-format detection as the
+    * parseable path.
+    */
+  private def unparseableStandardS3Path(trimmed: String): String = {
+    val (authority, path, _, port) = unparseableAuthorityParts(trimmed)
+    if (port.nonEmpty) {
+      val slash = path.indexOf('/')
+      if (slash < 0) "s3a://" + path
+      else {
+        val bucket = path.substring(0, slash)
+        val key = path.substring(slash + 1)
+        s"s3a://$bucket/$key"
+      }
+    } else s"s3a://$authority/$path"
+  }
+
+  /** Extract the bare bucket-relative object key from a storage path.
+    *
+    * This is the form milvus-storage's native FFI expects: it resolves
+    * scheme-less keys against the `fs.*` properties and rejects any
+    * scheme-bearing path for lack of an `extfs.*` config block. Hadoop APIs
+    * should keep the [[toStandardS3Path]] form instead.
+    *
+    *   - `files/snapshots/...` → `files/snapshots/...`
+    *   - `s3://bucket/files/...` → `files/...`
+    *   - `s3://minio:9000/bucket/files/...` (Milvus-format) → `files/...`
+    *
+    * @param path
+    *   storage path or URI to reduce
+    * @param endpoint
+    *   configured storage endpoint (e.g. `fs.address` / `s3Endpoint`), used to
+    *   recognize endpoint-prefixed Milvus-format URIs
+    */
+  private[connector] def toBucketRelativeKey(
+      path: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): String = {
+    if (path == null) return null
+    val trimmed = path.trim
+    if (trimmed.isEmpty) return trimmed
+    val uri =
+      try new URI(trimmed)
+      catch {
+        case _: Exception =>
+          // Unparseable s3 URI: textually split the authority so Milvus-format
+          // detection still applies and a bare key is returned for the native
+          // reader, instead of a scheme-bearing path it would reject.
+          if (trimmed.startsWith("s3://") || trimmed.startsWith("s3a://"))
+            return unparseableBucketRelativeKey(trimmed)
+          else return trimmed
+      }
+    Option(uri.getScheme).map(_.toLowerCase) match {
+      case Some("s3") | Some("s3a") =>
+        // getRawPath preserves percent-encoding; getPath would decode %20 to a
+        // space / %23 to a # and produce a broken object key or URI fragment.
+        // Re-append a literal '?'/'#' so the key is not truncated.
+        val rawPath = Option(uri.getRawPath).getOrElse("").stripPrefix("/")
+        val suffix =
+          Option(uri.getRawQuery).map("?" + _).getOrElse("") +
+            Option(uri.getRawFragment).map("#" + _).getOrElse("")
+        if (isEndpointPrefixed(uri, endpoint, configuredBucket)) {
+          // Milvus-format: scheme://address/bucket/key — the bucket segment
+          // precedes the object key. With no path segment after the bucket
+          // there is no object key.
+          val slash = rawPath.indexOf('/')
+          val key = if (slash < 0) "" else rawPath.substring(slash + 1)
+          key + suffix
+        } else {
+          // Standard S3: scheme://bucket/key — everything after the authority
+          // is the object key.
+          rawPath + suffix
+        }
+      case _ => trimmed
+    }
+  }
+
+  /** Extract the bucket a qualified storage URI names, or `None` when `path`
+    * carries no scheme (bucket-relative key).
+    *
+    * Unlike `MilvusScan.snapshotBucket` this never throws on a non-s3 scheme —
+    * it is used to pin the correct bucket on native partition options before
+    * a path is reduced to a bare key.
+    */
+  private[connector] def bucketOf(
+      path: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): Option[String] = {
+    if (path == null) return None
+    val trimmed = path.trim
+    if (trimmed.isEmpty) return None
+    val uri =
+      try new URI(trimmed)
+      catch {
+        case _: Exception =>
+          // Unparseable s3 URI: textually split the authority so the bucket is
+          // still extracted — toBucketRelativeKey strips the bucket from the
+          // same input, so giving up here would leave the bare key to resolve
+          // silently against the connector's configured bucket.
+          if (trimmed.startsWith("s3://") || trimmed.startsWith("s3a://"))
+            return Some(unparseableBucket(trimmed))
+          else return None
+      }
+    Option(uri.getScheme).map(_.toLowerCase) match {
+      case Some("s3") | Some("s3a") =>
+        if (isEndpointPrefixed(uri, endpoint, configuredBucket)) {
+          // Milvus-format: scheme://address/bucket/key — the first path
+          // segment is the bucket.
+          val rawPath = Option(uri.getRawPath).getOrElse("").stripPrefix("/")
+          val slash = rawPath.indexOf('/')
+          val bucket = if (slash < 0) rawPath else rawPath.substring(0, slash)
+          Option(bucket).filter(_.nonEmpty)
+        } else {
+          // Standard S3: scheme://bucket/key — the authority host is the bucket.
+          // getHost is null for hosts with e.g. an underscore, so fall back to
+          // the authority and strip userinfo (everything after the last '@')
+          // and any port.
+          Option(uri.getHost).orElse(
+            Option(uri.getRawAuthority)
+              .map(_.split("@").last)
+              .map(_.split(":").head)
+              .filter(_.nonEmpty)
+          )
+        }
+      case _ => None
+    }
+  }
+
+  /** Canonicalize a Milvus storage path to Hadoop S3A path-style
+    * `s3a://<bucket>/<key>`.
+    *
+    * This collapses the three shapes (bucket-relative, standard S3,
+    * Milvus-format) to `s3a://<bucket>/<key>` so downstream Hadoop parsers
+    * (bucket extraction, per-bucket S3A conf, S3A reads) see one shape.
+    * Native milvus-storage consumers should use [[toBucketRelativeKey]]
+    * instead.
+    *
+    * Detection of the Milvus-format uses both the authority carrying a port
+    * and a match against the configured `endpoint` host — see
+    * [[isEndpointPrefixed]].
+    *
+    * @param path
+    *   storage path or URI to canonicalize
+    * @param fallbackBucket
+    *   bucket to prefix when `path` is bucket-relative (no scheme)
+    * @param endpoint
+    *   configured storage endpoint (e.g. `fs.address` / `s3Endpoint`); used to
+    *   recognize endpoint-prefixed Milvus-format URIs
+    */
+  private[connector] def toStandardS3Path(
+      path: String,
+      fallbackBucket: String = "",
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): String = {
+    if (path == null) return null
+    val trimmed = path.trim
+    if (trimmed.isEmpty) return trimmed
+    val uri =
+      try new URI(trimmed)
+      catch {
+        case _: Exception =>
+          // Unparseable s3 URI (a space, an unescaped %, [ ]): textually split
+          // the authority so an endpoint-prefixed path still collapses to
+          // s3a://bucket/key instead of leaving the endpoint as the bucket.
+          if (trimmed.startsWith("s3://") || trimmed.startsWith("s3a://"))
+            return unparseableStandardS3Path(trimmed)
+          else return trimmed
+      }
+    Option(uri.getScheme).map(_.toLowerCase) match {
+      case Some("s3") | Some("s3a") =>
+        // getRawAuthority / getRawPath preserve percent-encoding so the
+        // reconstructed URI stays parseable (getPath would turn %20 into a
+        // literal space and %23 into a # fragment). getRawPath stops at a
+        // literal '?' / '#', so re-append the raw query / fragment — a global
+        // prefix rewrite would otherwise leave the endpoint as the bucket for
+        // Milvus-format URIs.
+        val authority = Option(uri.getRawAuthority).map(_.trim).filter(_.nonEmpty)
+        val rawPath = Option(uri.getRawPath).getOrElse("").stripPrefix("/")
+        val suffix =
+          Option(uri.getRawQuery).map("?" + _).getOrElse("") +
+            Option(uri.getRawFragment).map("#" + _).getOrElse("")
+        if (isEndpointPrefixed(uri, endpoint, configuredBucket)) {
+          // Milvus-format: scheme://address/bucket/key — the first path
+          // segment is the bucket, the authority is the storage endpoint.
+          val slash = rawPath.indexOf('/')
+          val reconstructed =
+            if (slash < 0) {
+              s"s3a://$rawPath"
+            } else {
+              val bucket = rawPath.substring(0, slash)
+              val key = rawPath.substring(slash + 1)
+              s"s3a://$bucket/$key"
+            }
+          reconstructed + suffix
+        } else {
+          // Standard S3: scheme://bucket/key (also normalize s3 -> s3a).
+          s"s3a://${authority.getOrElse("")}/$rawPath" + suffix
+        }
+      case None if fallbackBucket.trim.nonEmpty =>
+        s"s3a://${fallbackBucket.trim}/${trimmed.stripPrefix("/")}"
+      case _ => trimmed
+    }
+  }
+}

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -15,7 +15,8 @@ import org.slf4j.LoggerFactory
 import com.zilliz.spark.connector.{
   MilvusClient,
   MilvusConnectionParams,
-  MilvusOption
+  MilvusOption,
+  MilvusStoragePath
 }
 import com.zilliz.spark.connector.read.{
   MilvusSnapshotReader,
@@ -393,7 +394,12 @@ object MilvusBackfill {
       val (collectionID, segmentToPartitionMap, segmentBasePathMap) =
         snapshotMetadataOpt match {
           case Some(metadata) =>
-            extractMetadataFromSnapshot(metadata, v2Segments)
+            extractMetadataFromSnapshot(
+              metadata,
+              v2Segments,
+              config.s3Endpoint,
+              config.s3BucketName
+            )
           case None =>
             val (colId, segPartMap) =
               retrieveMilvusMetadata(config, client) match {
@@ -484,9 +490,22 @@ object MilvusBackfill {
   ): Either[BackfillError, BackfillSource] = {
     // Hadoop 3.4.1 has separate s3:// and s3a:// FileSystem implementations
     // and per-bucket fs.s3a.bucket.<b>.* config is only honored by
-    // S3AFileSystem. Force the s3a scheme so the credentials we just wrote
-    // actually take effect.
-    val path = normalizeObjectStorageScheme(rawPath, config)
+    // S3AFileSystem. Force the s3a scheme (and canonicalize any Milvus-format
+    // endpoint-prefixed path, using the source bucket's endpoint override when
+    // present) so the credentials we just wrote actually take effect; Aliyun
+    // OSS paths keep their own scheme.
+    val path =
+      if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun"))
+        normalizeObjectStorageScheme(rawPath, config)
+      else
+        // The source bucket is not configurable, so pass "" as the detection
+        // hint: using the Milvus target bucket here would misclassify a source
+        // key whose first segment happens to equal the target bucket name.
+        normalizeS3Scheme(
+          rawPath,
+          config.sourceS3Endpoint.getOrElse(config.s3Endpoint),
+          ""
+        )
     try {
       // Configure the source bucket before reading the parquet. OSS must be
       // fully materialized while this temporary credential scope is active;
@@ -1658,7 +1677,8 @@ object MilvusBackfill {
           hadoopConf,
           manifestSchemaVersion = metadata.manifestSchemaVersion,
           applyDeletes = false,
-          storageScheme = storageScheme(config)
+          storageScheme = storageScheme(config),
+          endpoint = config.s3Endpoint
         ) match {
         case Right(segs) =>
           // Workaround for Milvus snapshot not yet exposing FieldBinlog.child_fields:
@@ -1905,7 +1925,9 @@ object MilvusBackfill {
     */
   private def extractMetadataFromSnapshot(
       metadata: SnapshotMetadata,
-      v2Segments: Seq[com.zilliz.spark.connector.read.V2SegmentInfo] = Seq.empty
+      v2Segments: Seq[com.zilliz.spark.connector.read.V2SegmentInfo] = Seq.empty,
+      endpoint: String = "",
+      writeBucket: String = ""
   ): (Long, Map[Long, Long], Map[Long, String]) = {
     val collectionID = metadata.snapshotInfo.collectionId
 
@@ -1918,23 +1940,48 @@ object MilvusBackfill {
       val segId = item.segmentID
       MilvusSnapshotReader.parseManifestContent(item.manifest) match {
         case Right(mc) =>
+          // A qualified manifest basePath names the bucket its data lives in.
+          // The stripped key below becomes milvus.writer.customPath and is
+          // resolved against fs.bucket_name (config.s3BucketName), so writing
+          // to a different bucket would report success while Milvus (reading
+          // its own bucket) sees nothing. Reject the mismatch up front, like
+          // the read path's validateSnapshotBucketForRelativeDataPaths.
+          MilvusStoragePath
+            .bucketOf(mc.basePath, endpoint, writeBucket)
+            .filter(bucket => writeBucket.nonEmpty && bucket != writeBucket)
+            .foreach { manifestBucket =>
+              throw new IllegalArgumentException(
+                s"Snapshot manifest basePath '${mc.basePath}' names bucket " +
+                  s"'$manifestBucket' but backfill --s3-bucket is '$writeBucket'; " +
+                  "refusing to write addfield data into the wrong bucket"
+              )
+            }
+          // Reduce Milvus-format s3://<address>/<bucket>/<key> basePaths to the
+          // scheme-less bucket-relative key that the native writer consumes;
+          // it cannot read a scheme-bearing customPath for lack of an extfs.*
+          // config. This also keeps the insert_log slice below stable.
+          val basePath = MilvusStoragePath.toBucketRelativeKey(
+            mc.basePath,
+            endpoint,
+            writeBucket
+          )
           // Extract partition ID from basePath: .../insert_log/{col_id}/{part_id}/{seg_id}
-          val parts = mc.basePath.split("/")
+          val parts = basePath.split("/")
           val insertLogIdx = parts.indexOf("insert_log")
           if (insertLogIdx >= 0 && insertLogIdx + 2 < parts.length) {
             try {
               val partitionId = parts(insertLogIdx + 2).toLong
-              segmentBasePathMap += (segId -> mc.basePath)
+              segmentBasePathMap += (segId -> basePath)
               segmentToPartitionMap += (segId -> partitionId)
             } catch {
               case _: NumberFormatException =>
                 logger.warn(
-                  s"Skipping segment $segId: failed to parse partition ID from basePath: ${mc.basePath}"
+                  s"Skipping segment $segId: failed to parse partition ID from basePath: $basePath"
                 )
             }
           } else {
             logger.warn(
-              s"Skipping segment $segId: basePath does not contain expected insert_log structure: ${mc.basePath}"
+              s"Skipping segment $segId: basePath does not contain expected insert_log structure: $basePath"
             )
           }
         case Left(e) =>
@@ -1983,7 +2030,14 @@ object MilvusBackfill {
     // Same s3:// → s3a:// normalization as readSnapshotJson /
     // readBackfillData. Without it, an s3:// URL would route to the legacy
     // S3FileSystem which ignores fs.s3a.bucket.<b>.* config.
-    val outputPath = normalizeObjectStorageScheme(rawOutputPath, config)
+    val outputPath =
+      if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun"))
+        normalizeObjectStorageScheme(rawOutputPath, config)
+      else
+        // --output is a user-supplied path; passing the Milvus target bucket
+        // as the detection hint would misclassify a key whose first segment
+        // happens to equal it (see the source-path site above).
+        normalizeS3Scheme(rawOutputPath, config.s3Endpoint, "")
     try {
       withScopedHadoopStorage(spark, outputPath, config, isSource = false) {
         val hadoopPath = new Path(outputPath)
@@ -2023,9 +2077,18 @@ object MilvusBackfill {
     * write would be silently ignored. All read/write code paths in this object
     * route through this helper before touching Hadoop FS APIs.
     */
-  private[backfill] def normalizeS3Scheme(path: String): String = {
+  private[backfill] def normalizeS3Scheme(
+      path: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): String = {
     if (path == null) null
-    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else if (path.startsWith("s3://") || path.startsWith("s3a://"))
+      MilvusStoragePath.toStandardS3Path(
+        path,
+        endpoint = endpoint,
+        configuredBucket = configuredBucket
+      )
     else path
   }
 
@@ -2206,10 +2269,30 @@ object MilvusBackfill {
       isSource: Boolean
   ): Unit = {
     if (path == null) return
+    // Branch on the raw scheme so a malformed-but-s3 URI (spaces, unescaped
+    // %, [ ]) still gets per-bucket S3A config; only the extracted value is
+    // canonicalized.
     if (!(path.startsWith("s3://") || path.startsWith("s3a://"))) return
+    // The source bucket may have its own endpoint override; use the same
+    // effective endpoint for Milvus-format detection and credentials.
+    val endpoint =
+      if (isSource) config.sourceS3Endpoint.getOrElse(config.s3Endpoint)
+      else config.s3Endpoint
+    // Canonicalize Milvus-format s3://<address>/<bucket>/<key> to
+    // s3a://<bucket>/<key> so the bucket (and thus the per-bucket Hadoop
+    // S3A config) is extracted correctly.
+    val canonical = MilvusStoragePath.toStandardS3Path(
+      path,
+      endpoint = endpoint,
+      // Paths reaching here are user-supplied (source parquet, snapshot output)
+      // or already canonicalized by the caller; passing the Milvus target
+      // bucket as the detection hint would misclassify a key whose first
+      // segment happens to equal it.
+      configuredBucket = ""
+    )
 
-    // Extract bucket name from s3(a)://bucket/key
-    val withoutScheme = path.stripPrefix("s3a://").stripPrefix("s3://")
+    // Extract bucket name from s3a://bucket/key
+    val withoutScheme = canonical.stripPrefix("s3a://").stripPrefix("s3://")
     val bucket = {
       val slash = withoutScheme.indexOf('/')
       if (slash < 0) withoutScheme else withoutScheme.substring(0, slash)
@@ -2219,9 +2302,6 @@ object MilvusBackfill {
     // Resolve the effective credentials for this bucket. For the source bucket
     // any unset override falls back to the main credentials, preserving the
     // existing single-bucket behavior.
-    val endpoint =
-      if (isSource) config.sourceS3Endpoint.getOrElse(config.s3Endpoint)
-      else config.s3Endpoint
     val accessKey =
       if (isSource) config.sourceS3AccessKey.getOrElse(config.s3AccessKey)
       else config.s3AccessKey
@@ -2326,15 +2406,31 @@ object MilvusBackfill {
     }
 
     try {
-      // Check if it's an S3 path
-      if (
-        snapshotPath.startsWith("s3://") || snapshotPath.startsWith(
-          "s3a://"
-        ) || snapshotPath.startsWith("oss://")
-      ) {
-
-        // Construct full S3 path (ensure s3a:// scheme for Hadoop)
-        val s3Path = normalizeObjectStorageScheme(snapshotPath, config)
+      // Branch on the raw scheme: a malformed-but-s3 URI must still take the
+      // S3 branch (and configure per-bucket S3A) instead of falling through
+      // to scala.io.Source.fromFile. Only the read value is canonicalized.
+      val isS3 = snapshotPath.startsWith("s3://") ||
+        snapshotPath.startsWith("s3a://") ||
+        snapshotPath.startsWith("oss://")
+      // Canonicalize bucket-relative / standard / Milvus-format
+      // (s3://<address>/<bucket>/<key>) snapshot locations to s3a://bucket/key.
+      // Aliyun rewrites any s3:// / s3a:// location to oss:// (Milvus writes
+      // s3:// regardless of the backend), gated on the configured provider like
+      // readBackfillData / writeResultJson.
+      val s3Path = if (isS3) {
+        if (config.s3CloudProvider.trim.equalsIgnoreCase("aliyun"))
+          normalizeObjectStorageScheme(snapshotPath, config)
+        else
+          MilvusStoragePath.toStandardS3Path(
+            snapshotPath,
+            endpoint = config.s3Endpoint,
+            configuredBucket = config.s3BucketName
+          )
+      } else {
+        snapshotPath
+      }
+      // Check if it's an S3/OSS path
+      if (isS3) {
 
         // Configure S3 settings on Spark's Hadoop Configuration (per-bucket
         // so that snapshot bucket and backfill source bucket can use
@@ -2353,7 +2449,7 @@ object MilvusBackfill {
 
       } else {
         // Local file path, read directly
-        val source = scala.io.Source.fromFile(snapshotPath)
+        val source = scala.io.Source.fromFile(s3Path)
         try {
           val json = source.mkString
           Right(json)

--- a/src/main/scala/read/MilvusDeltaLogReader.scala
+++ b/src/main/scala/read/MilvusDeltaLogReader.scala
@@ -33,7 +33,8 @@ object MilvusDeltaLogReader extends Logging {
       segments: Seq[V2SegmentInfo],
       milvusSchema: CollectionSchema,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      endpoint: String = ""
   ): Either[Throwable, Map[Long, MilvusDeletePlan]] = {
     val pkField = primaryKeyField(milvusSchema)
     val deleteOnlySegments = segments.filter(_.columnGroups.isEmpty)
@@ -44,13 +45,13 @@ object MilvusDeltaLogReader extends Logging {
         deleteOnlySegments,
         pkField,
         bucket,
-        hadoopConf
+        hadoopConf,
+        endpoint
       )
       ownPlans <- sequence(
         dataSegments.map { seg =>
-          loadDeletePlan(seg.deltaLogs, pkField, bucket, hadoopConf).map {
-            ownPlan => seg.segmentId -> ownPlan
-          }
+          loadDeletePlan(seg.deltaLogs, pkField, bucket, hadoopConf, endpoint)
+            .map { ownPlan => seg.segmentId -> ownPlan }
         }
       )
     } yield mergeInheritedDeletePlans(
@@ -84,7 +85,8 @@ object MilvusDeltaLogReader extends Logging {
       deleteOnlySegments: Seq[V2SegmentInfo],
       pkField: FieldSchema,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      endpoint: String = ""
   ): Either[Throwable, Map[Long, MilvusDeletePlan]] = {
     sequence(
       deleteOnlySegments.groupBy(_.partitionId).toSeq.map {
@@ -93,7 +95,8 @@ object MilvusDeltaLogReader extends Logging {
             segments.flatMap(_.deltaLogs),
             pkField,
             bucket,
-            hadoopConf
+            hadoopConf,
+            endpoint
           ).map(partitionId -> _)
       }
     ).map(_.toMap)
@@ -128,13 +131,14 @@ object MilvusDeltaLogReader extends Logging {
       deltaLogs: Seq[V2DeltaLogFile],
       pkField: FieldSchema,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      endpoint: String = ""
   ): Either[Throwable, MilvusDeletePlan] = {
     try {
       validatePkType(pkField)
       val plans = deltaLogs.map { log =>
         val fullyQualifiedPath =
-          V2SegmentLoader.resolvePath(log.logPath, bucket)
+          V2SegmentLoader.resolvePath(log.logPath, bucket, endpoint = endpoint)
         val bytes = V2SegmentLoader.readAllBytes(hadoopConf, fullyQualifiedPath)
         decodeDeletePlan(bytes, pkField, fullyQualifiedPath)
       }

--- a/src/main/scala/read/MilvusStorageV3ManifestReader.scala
+++ b/src/main/scala/read/MilvusStorageV3ManifestReader.scala
@@ -5,6 +5,7 @@ import java.net.URI
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 
+import com.zilliz.spark.connector.MilvusStoragePath
 import org.apache.avro.file.DataFileStream
 import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.util.Utf8
@@ -19,15 +20,17 @@ object MilvusStorageV3ManifestReader {
       basePath: String,
       readVersion: Long,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      endpoint: String = ""
   ): Either[Throwable, Seq[V2DeltaLogFile]] = {
     try {
       val manifestPath = V2SegmentLoader.resolvePath(
         manifestFilePath(basePath, readVersion),
-        bucket
+        bucket,
+        endpoint = endpoint
       )
       val bytes = V2SegmentLoader.readAllBytes(hadoopConf, manifestPath)
-      parseDeltaLogs(bytes, basePath)
+      parseDeltaLogs(bytes, basePath, endpoint, bucket)
     } catch {
       case NonFatal(e) => Left(e)
     }
@@ -48,14 +51,16 @@ object MilvusStorageV3ManifestReader {
   private[connector] def latestManifestVersion(
       basePath: String,
       bucket: String,
-      hadoopConf: Configuration
+      hadoopConf: Configuration,
+      endpoint: String = ""
   ): Either[Throwable, Long] = {
     var uri: URI = null
     var fs: FileSystem = null
     try {
       val metadataPath = V2SegmentLoader.resolvePath(
         s"${basePath.stripSuffix("/")}/_metadata",
-        bucket
+        bucket,
+        endpoint = endpoint
       )
       uri = new URI(metadataPath)
       fs = FileSystem.get(uri, hadoopConf)
@@ -93,7 +98,9 @@ object MilvusStorageV3ManifestReader {
 
   private[read] def parseDeltaLogs(
       avroBytes: Array[Byte],
-      basePath: String
+      basePath: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
   ): Either[Throwable, Seq[V2DeltaLogFile]] = {
     try {
       val reader = new DataFileStream[GenericRecord](
@@ -105,7 +112,7 @@ object MilvusStorageV3ManifestReader {
           Right(Seq.empty)
         } else {
           val rec = reader.next()
-          Right(projectDeltaLogs(rec, basePath))
+          Right(projectDeltaLogs(rec, basePath, endpoint, configuredBucket))
         }
       } finally {
         reader.close()
@@ -117,7 +124,9 @@ object MilvusStorageV3ManifestReader {
 
   private def projectDeltaLogs(
       rec: GenericRecord,
-      basePath: String
+      basePath: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
   ): Seq[V2DeltaLogFile] = {
     val raw = rec.get("delta_logs")
     if (raw == null) {
@@ -133,8 +142,12 @@ object MilvusStorageV3ManifestReader {
         .map { case (log, idx) =>
           V2DeltaLogFile(
             logId = idx.toLong,
-            logPath =
-              resolveManifestDeltaPath(basePath, asString(log.get("path"))),
+            logPath = resolveManifestDeltaPath(
+              basePath,
+              asString(log.get("path")),
+              endpoint,
+              configuredBucket
+            ),
             entriesNum = asLong(log.get("num_entries"))
           )
         }
@@ -143,11 +156,17 @@ object MilvusStorageV3ManifestReader {
 
   private[read] def resolveManifestDeltaPath(
       basePath: String,
-      path: String
+      path: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
   ): String = {
     if (path == null || path.isEmpty) path
-    else if (path.startsWith("s3a://")) path
-    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else if (path.startsWith("s3a://") || path.startsWith("s3://"))
+      MilvusStoragePath.toStandardS3Path(
+        path,
+        endpoint = endpoint,
+        configuredBucket = configuredBucket
+      )
     else if (path.startsWith("_delta/"))
       s"${basePath.stripSuffix("/")}/$path"
     else if (path.startsWith("/"))

--- a/src/main/scala/read/V2SegmentLoader.scala
+++ b/src/main/scala/read/V2SegmentLoader.scala
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.net.URI
 import scala.util.control.NonFatal
 
+import com.zilliz.spark.connector.MilvusStoragePath
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
@@ -55,12 +56,14 @@ object V2SegmentLoader extends Logging {
       hadoopConf: Configuration,
       manifestSchemaVersion: Int = 1,
       applyDeletes: Boolean = true,
-      storageScheme: String = "s3a"
+      storageScheme: String = "s3a",
+      endpoint: String = ""
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
     try {
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
       manifestPaths.foreach { rawPath =>
-        val avroPath = resolvePath(rawPath, bucket, storageScheme)
+        val avroPath =
+          resolvePath(rawPath, bucket, storageScheme, endpoint)
         val avroBytes = readAllBytes(hadoopConf, avroPath)
         val entry =
           MilvusSegmentManifestReader
@@ -77,7 +80,8 @@ object V2SegmentLoader extends Logging {
           bucket,
           hadoopConf,
           applyDeletes,
-          storageScheme
+          storageScheme,
+          endpoint
         ) match {
           case Right(Some(seg)) => out += seg
           case Right(None)      => // skipped (storage version != 2)
@@ -106,9 +110,10 @@ object V2SegmentLoader extends Logging {
       bucket: String,
       hadoopConf: Configuration,
       applyDeletes: Boolean = true,
-      storageScheme: String = "s3a"
+      storageScheme: String = "s3a",
+      endpoint: String = ""
   ): Either[Throwable, Option[V2SegmentInfo]] = {
-    val resolvedEntry = resolveEntryPaths(entry, bucket, storageScheme)
+    val resolvedEntry = resolveEntryPaths(entry, bucket, storageScheme, endpoint)
     val isL0 = resolvedEntry.segmentLevel == 1L
 
     if (resolvedEntry.storageVersion != 2L) {
@@ -211,7 +216,8 @@ object V2SegmentLoader extends Logging {
   private def resolveEntryPaths(
       entry: AvroManifestEntry,
       bucket: String,
-      storageScheme: String
+      storageScheme: String,
+      endpoint: String = ""
   ): AvroManifestEntry = {
     def resolveFieldBinlogs(
         fieldBinlogs: Seq[AvroFieldBinlogEntry]
@@ -219,7 +225,9 @@ object V2SegmentLoader extends Logging {
       fieldBinlogs.map(fieldBinlog =>
         fieldBinlog.copy(binlogs =
           fieldBinlog.binlogs.map(log =>
-            log.copy(logPath = resolvePath(log.logPath, bucket, storageScheme))
+            log.copy(
+              logPath = resolvePath(log.logPath, bucket, storageScheme, endpoint)
+            )
           )
         )
       )
@@ -230,23 +238,34 @@ object V2SegmentLoader extends Logging {
     )
   }
 
-  /** Prefix `bucket` when `path` has no scheme; rewrite S3 aliases to the
-    * requested scheme and preserve other explicit schemes. `storageScheme` is
+  /** Prefix `bucket` when `path` has no scheme; pass through s3a:// / s3://.
+    *
+    * `endpoint` is the configured storage endpoint (e.g. `fs.address` /
+    * `s3Endpoint`); it lets [[MilvusStoragePath.toStandardS3Path]] recognize
+    * port-less endpoint-prefixed Milvus-format URIs. `storageScheme` is
     * intentionally explicit for non-S3 providers because the generic connector
     * read path does not yet derive a provider from its public options.
     */
   def resolvePath(
       path: String,
       bucket: String,
-      storageScheme: String = "s3a"
+      storageScheme: String = "s3a",
+      endpoint: String = ""
   ): String = {
     val scheme = storageScheme.stripSuffix("://")
     if (path == null) path
-    else if (path.startsWith("s3a://"))
-      s"$scheme://" + path.stripPrefix("s3a://")
-    else if (path.startsWith("s3://"))
-      s"$scheme://" + path.stripPrefix("s3://")
-    else if (path.contains("://")) path
+    else if (path.startsWith("s3a://") || path.startsWith("s3://")) {
+      // Canonicalize Milvus-format s3://<address>/<bucket>/<key> to
+      // s3a://bucket/key, then re-apply the target storage scheme (e.g. oss
+      // for Aliyun).
+      val canonical = MilvusStoragePath.toStandardS3Path(
+        path,
+        endpoint = endpoint,
+        configuredBucket = bucket
+      )
+      if (scheme == "s3a") canonical
+      else scheme + "://" + canonical.stripPrefix("s3a://")
+    } else if (path.contains("://")) path
     else if (bucket != null && bucket.nonEmpty)
       s"$scheme://$bucket/${path.stripPrefix("/")}"
     else path

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -55,6 +55,7 @@ import com.zilliz.spark.connector.{
   MilvusCollectionInfo,
   MilvusOption,
   MilvusSchemaUtil,
+  MilvusStoragePath,
   VectorSearchConfig
 }
 import com.zilliz.spark.connector.loon.Properties
@@ -68,6 +69,7 @@ import com.zilliz.spark.connector.read.{
   MilvusStorageV3ManifestReader,
   SnapshotMetadata,
   StorageV2ManifestItem,
+  V2ColumnGroup,
   V2DeltaLogFile,
   V2SegmentInfo,
   V2SegmentLoader
@@ -862,24 +864,32 @@ object MilvusScan extends Logging {
 
   private[sources] def resolveClientSnapshotLocation(
       location: String,
-      bucket: String
+      bucket: String,
+      endpoint: String = ""
   ): String = {
     val trimmed = Option(location).map(_.trim).getOrElse("")
     if (trimmed.isEmpty) {
       throw new IllegalArgumentException("snapshot s3_location is empty")
     }
 
-    val scheme = Option(new URI(trimmed).getScheme).map(_.toLowerCase)
+    val scheme = MilvusStoragePath.schemeOf(trimmed)
     scheme match {
-      case Some("s3a") => trimmed
-      case Some("s3") =>
-        s"s3a://${trimmed.substring(trimmed.indexOf("://") + 3)}"
+      case Some("s3") | Some("s3a") =>
+        // Canonicalize both standard s3://bucket/key and Milvus-format
+        // s3://<address>/<bucket>/<key> to s3a://bucket/key. schemeOf probes
+        // the scheme textually, so an unparseable s3:// path reaches the
+        // fallback instead of throwing a raw URISyntaxException.
+        MilvusStoragePath.toStandardS3Path(
+          trimmed,
+          endpoint = endpoint,
+          configuredBucket = bucket
+        )
       case Some(other) =>
         throw new IllegalArgumentException(
           s"Unsupported snapshot s3_location scheme '$other': $trimmed"
         )
       case None if bucket.trim.nonEmpty =>
-        s"s3a://${bucket.trim}/${trimmed.stripPrefix("/")}"
+        MilvusStoragePath.toStandardS3Path(trimmed, bucket)
       case None =>
         throw new IllegalArgumentException(
           "bucket-relative snapshot s3_location requires connector S3 bucket"
@@ -887,35 +897,38 @@ object MilvusScan extends Logging {
     }
   }
 
-  private[sources] def snapshotBucket(location: String): Option[String] = {
+  private[sources] def snapshotBucket(
+      location: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): Option[String] = {
     val trimmed = Option(location).map(_.trim).getOrElse("")
     if (trimmed.isEmpty) {
       None
     } else {
-      val uri = new URI(trimmed)
-      Option(uri.getScheme).map(_.toLowerCase) match {
-        case Some("s3a") | Some("s3") =>
-          Option(uri.getHost).orElse {
-            Option(uri.getAuthority)
-              .map(_.takeWhile(_ != '@'))
-              .map(_.split(":").head)
-              .filter(_.nonEmpty)
-          }
-        case Some(other) =>
+      MilvusStoragePath.schemeOf(trimmed) match {
+        case Some(other) if other != "s3" && other != "s3a" =>
           throw new IllegalArgumentException(
             s"Unsupported snapshot s3_location scheme '$other': $trimmed"
           )
-        case None => None
+        case _ =>
+          // bucketOf reduces the canonical / Milvus-format / bucket-relative /
+          // unparseable shapes to the bucket, never throwing on input
+          // java.net.URI rejects.
+          MilvusStoragePath.bucketOf(trimmed, endpoint, configuredBucket)
       }
     }
   }
 
   private[sources] def snapshotBucketsToConfigure(
       snapshotPath: String,
-      connectorBucket: String
+      connectorBucket: String,
+      endpoint: String = ""
   ): Seq[String] = {
     (Seq(connectorBucket).filter(_.nonEmpty) ++ snapshotBucket(
-      snapshotPath
+      snapshotPath,
+      endpoint,
+      connectorBucket
     )).distinct
   }
 
@@ -950,19 +963,74 @@ object MilvusScan extends Logging {
     }
   }
 
+  private[sources] def connectorS3EndpointOption(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    Seq(
+      Properties.FsConfig.FsAddress,
+      MilvusOption.S3Endpoint
+    ).view
+      .flatMap(key => optionValue(options, key).map(_.trim).filter(_.nonEmpty))
+      .headOption
+  }
+
+  private[sources] def connectorS3AccessKeyOption(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    Seq(
+      Properties.FsConfig.FsAccessKeyId,
+      MilvusOption.S3AccessKey
+    ).view
+      .flatMap(key => optionValue(options, key).map(_.trim).filter(_.nonEmpty))
+      .headOption
+  }
+
+  private[sources] def connectorS3SecretKeyOption(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    Seq(
+      Properties.FsConfig.FsAccessKeyValue,
+      MilvusOption.S3SecretKey
+    ).view
+      .flatMap(key => optionValue(options, key).map(_.trim).filter(_.nonEmpty))
+      .headOption
+  }
+
+  private[sources] def connectorS3UseSslOption(
+      options: scala.collection.Map[String, String]
+  ): Option[String] = {
+    Seq(
+      Properties.FsConfig.FsUseSSL,
+      MilvusOption.S3UseSSL
+    ).view
+      .flatMap(key => optionValue(options, key).map(_.trim).filter(_.nonEmpty))
+      .headOption
+  }
+
   private[sources] def snapshotS3BucketForRelativePaths(
       snapshotPath: String,
       options: scala.collection.Map[String, String]
   ): Option[String] = {
-    snapshotBucket(snapshotPath).orElse(connectorS3BucketOption(options))
+    snapshotBucket(
+      snapshotPath,
+      connectorS3EndpointOption(options).getOrElse(""),
+      connectorS3BucketOption(options).getOrElse("")
+    ).orElse(connectorS3BucketOption(options))
   }
 
   private[sources] def storageV2ManifestBasePath(
-      item: StorageV2ManifestItem
+      item: StorageV2ManifestItem,
+      endpoint: String = "",
+      configuredBucket: String = ""
   ): String = {
     MilvusSnapshotReader.parseManifestContent(item.manifest) match {
-      case Right(content) => content.basePath
-      case Left(_)        => item.manifest
+      case Right(content) =>
+        MilvusStoragePath.toStandardS3Path(
+          content.basePath,
+          endpoint = endpoint,
+          configuredBucket = configuredBucket
+        )
+      case Left(_) => item.manifest
     }
   }
 
@@ -970,11 +1038,13 @@ object MilvusScan extends Logging {
       snapshotPath: String,
       connectorBucket: Option[String],
       storageV2ManifestList: Seq[StorageV2ManifestItem],
-      v2Segments: Seq[V2SegmentInfo]
+      v2Segments: Seq[V2SegmentInfo],
+      endpoint: String = ""
   ): Unit = {
-    snapshotBucket(snapshotPath).foreach { snapshot =>
+    val configuredBucket = connectorBucket.getOrElse("")
+    snapshotBucket(snapshotPath, endpoint, configuredBucket).foreach { snapshot =>
       val relativeStorageV3Paths = storageV2ManifestList
-        .map(storageV2ManifestBasePath)
+        .map(item => storageV2ManifestBasePath(item, endpoint, configuredBucket))
         .filter(isBucketRelativeSnapshotLocation)
       val relativeStorageV2Paths = v2Segments
         .flatMap(_.columnGroups.flatMap(_.filePaths))
@@ -1010,7 +1080,7 @@ object MilvusScan extends Logging {
       location: String
   ): Boolean = {
     val trimmed = Option(location).map(_.trim).getOrElse("")
-    trimmed.nonEmpty && Option(new URI(trimmed).getScheme).isEmpty
+    trimmed.nonEmpty && MilvusStoragePath.schemeOf(trimmed).isEmpty
   }
 
   private[sources] def canUseClientSnapshotFastPath(
@@ -1513,7 +1583,9 @@ class MilvusScan(
           }
           val snapshotPath = MilvusScan.resolveClientSnapshotLocation(
             snapshot.s3Location,
-            connectorBucket.getOrElse("")
+            connectorBucket.getOrElse(""),
+            MilvusScan.connectorS3EndpointOption(milvusOption.options)
+              .getOrElse("")
           )
           Some(
             planInputPartitionsFromClientSnapshotPath(
@@ -1581,7 +1653,10 @@ class MilvusScan(
           snapshotBucket.getOrElse(""),
           hadoopConf,
           manifestSchemaVersion = metadata.manifestSchemaVersion,
-          applyDeletes = applyDeletes
+          applyDeletes = applyDeletes,
+          endpoint = MilvusScan
+            .connectorS3EndpointOption(milvusOption.options)
+            .getOrElse("")
         ) match {
           case Right(segs) => segs
           case Left(err) =>
@@ -1602,7 +1677,8 @@ class MilvusScan(
       snapshotPath,
       MilvusScan.connectorS3BucketOption(milvusOption.options),
       storageV2ManifestList,
-      v2Segments
+      v2Segments,
+      MilvusScan.connectorS3EndpointOption(milvusOption.options).getOrElse("")
     )
 
     val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
@@ -1650,7 +1726,8 @@ class MilvusScan(
           inheritedDeleteSegments,
           pkField,
           snapshotBucket.getOrElse(""),
-          hadoopConf
+          hadoopConf,
+          MilvusScan.connectorS3EndpointOption(milvusOption.options).getOrElse("")
         ) match {
           case Right(plans) => plans
           case Left(err) =>
@@ -1783,14 +1860,18 @@ class MilvusScan(
       .map(_.sessionState.newHadoopConf())
       .getOrElse(new Configuration())
     val rawOptions = milvusOption.options
+    // Resolve the S3A endpoint and credentials through the same multi-key
+    // aliases used for Milvus-format detection (fs.* and s3.*), so a user who
+    // configures only s3.endpoint / s3.accessKey gets both the detection and
+    // the Hadoop S3A endpoint/credentials pointing at the same storage.
     val endpoint =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAddress)
+      MilvusScan.connectorS3EndpointOption(rawOptions)
     val accessKey =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyId)
+      MilvusScan.connectorS3AccessKeyOption(rawOptions)
     val secretKey =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyValue)
+      MilvusScan.connectorS3SecretKeyOption(rawOptions)
     val useSsl =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsUseSSL)
+      MilvusScan.connectorS3UseSslOption(rawOptions)
     val region =
       MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsRegion)
     val useIam = MilvusScan
@@ -1799,8 +1880,12 @@ class MilvusScan(
     val useVirtualHost = MilvusScan
       .optionValue(rawOptions, Properties.FsConfig.FsUseVirtualHost)
       .filter(_.trim.nonEmpty)
+    // Resolve path-style access through the same multi-key aliases as the
+    // other S3 options; without it a MinIO user configuring only the s3.*
+    // family gets S3A's virtual-host default and resolves bucket.minio:9000.
     val pathStyle = MilvusScan
       .optionValue(rawOptions, "fs.s3a.path.style.access")
+      .orElse(MilvusScan.optionValue(rawOptions, MilvusOption.S3PathStyleAccess))
       .orElse(
         useVirtualHost.map(v => (!v.trim.equalsIgnoreCase("true")).toString)
       )
@@ -1853,7 +1938,8 @@ class MilvusScan(
     MilvusScan
       .snapshotBucketsToConfigure(
         snapshotPath,
-        MilvusScan.connectorS3BucketOption(rawOptions).getOrElse("")
+        MilvusScan.connectorS3BucketOption(rawOptions).getOrElse(""),
+        MilvusScan.connectorS3EndpointOption(rawOptions).getOrElse("")
       )
       .foreach(bucket => configureS3A(s"fs.s3a.bucket.$bucket"))
     conf
@@ -1911,7 +1997,8 @@ class MilvusScan(
           seg.deltaLogs,
           pkField,
           snapshotBucket.getOrElse(""),
-          hadoopConf
+          hadoopConf,
+          MilvusScan.connectorS3EndpointOption(milvusOption.options).getOrElse("")
         ) match {
           case Right(plan) => seg.segmentId -> plan
           case Left(err) =>
@@ -1946,8 +2033,18 @@ class MilvusScan(
       val entries = manifestList.flatMap { item =>
         val (basePath, requestedReadVersion) =
           MilvusSnapshotReader.parseManifestContent(item.manifest) match {
-            case Right(content) => (content.basePath, content.ver.toLong)
-            case Left(_)        => (item.manifest, -1L)
+            case Right(content) =>
+              (
+                MilvusStoragePath.toStandardS3Path(
+                  content.basePath,
+                  endpoint = MilvusScan
+                    .connectorS3EndpointOption(milvusOption.options)
+                    .getOrElse(""),
+                  configuredBucket = snapshotBucket.getOrElse("")
+                ),
+                content.ver.toLong
+              )
+            case Left(_) => (item.manifest, -1L)
           }
         val segmentId = MilvusScan.segmentIdForManifestItem(item, basePath)
         if (segmentId == 0L) {
@@ -1960,7 +2057,9 @@ class MilvusScan(
               MilvusStorageV3ManifestReader.latestManifestVersion(
                 basePath,
                 snapshotBucket.getOrElse(""),
-                hadoopConf
+                hadoopConf,
+                MilvusScan.connectorS3EndpointOption(milvusOption.options)
+                  .getOrElse("")
               ) match {
                 case Right(version) => version
                 case Left(err) =>
@@ -1978,7 +2077,9 @@ class MilvusScan(
                 basePath,
                 readVersion,
                 snapshotBucket.getOrElse(""),
-                hadoopConf
+                hadoopConf,
+                MilvusScan.connectorS3EndpointOption(milvusOption.options)
+                  .getOrElse("")
               ) match {
                 case Right(logs) => logs
                 case Left(err) =>
@@ -1996,7 +2097,9 @@ class MilvusScan(
                   deltaLogs,
                   pkField.get,
                   snapshotBucket.getOrElse(""),
-                  hadoopConf
+                  hadoopConf,
+                  MilvusScan.connectorS3EndpointOption(milvusOption.options)
+                    .getOrElse("")
                 ) match {
                   case Right(plan) => Some(plan)
                   case Left(err) =>
@@ -2021,6 +2124,98 @@ class MilvusScan(
     }
   }
 
+  private[sources] def withPinnedBucket(
+      milvusOption: MilvusOption,
+      bucket: String
+  ): MilvusOption = {
+    val trimmed = bucket.trim
+    val opts = milvusOption.options
+    var updated =
+      if (trimmed.isEmpty) opts else opts + (Properties.FsConfig.FsBucketName -> trimmed)
+    // The native FFI (Properties.fromMilvusOption) reads only fs.* keys, so a
+    // user who configured the s3.* aliases gets them translated here — without
+    // this the executors would fall back to localhost:9000 / minioadmin.
+    // Under fs.use_iam the driver deliberately drops static credentials (the
+    // FFI must consult the default credentials chain), so skip the AK/SK
+    // translation there to avoid signing with stale keys.
+    val useIam = MilvusScan
+      .optionValue(opts, Properties.FsConfig.FsUseIam)
+      .exists(_.trim.equalsIgnoreCase("true"))
+    Seq(
+      (Properties.FsConfig.FsAddress, MilvusScan.connectorS3EndpointOption(opts)),
+      (
+        Properties.FsConfig.FsAccessKeyId,
+        if (useIam) None else MilvusScan.connectorS3AccessKeyOption(opts)
+      ),
+      (
+        Properties.FsConfig.FsAccessKeyValue,
+        if (useIam) None else MilvusScan.connectorS3SecretKeyOption(opts)
+      ),
+      (Properties.FsConfig.FsUseSSL, MilvusScan.connectorS3UseSslOption(opts))
+    ).foreach { case (fsKey, value) =>
+      value.foreach(v => updated = updated + (fsKey -> v))
+    }
+    milvusOption.copy(options = updated)
+  }
+
+  /** Reduce a V3 manifest basePath to the scheme-less key the native reader
+    * consumes, pinning the bucket the path names on the partition option so
+    * the FFI resolves the key against the right `fs.bucket_name`.
+    */
+  private[sources] def nativeV3ManifestPath(
+      basePath: String,
+      milvusOption: MilvusOption,
+      endpoint: String,
+      configuredBucket: String = ""
+  ): (String, MilvusOption) = {
+    val bucket =
+      MilvusStoragePath.bucketOf(basePath, endpoint, configuredBucket)
+    val key = MilvusStoragePath.toBucketRelativeKey(
+      basePath,
+      endpoint,
+      configuredBucket
+    )
+    (key, withPinnedBucket(milvusOption, bucket.getOrElse("")))
+  }
+
+  /** Reduce a V2 segment's column-group file paths to scheme-less keys the
+    * native reader consumes, returning the bucket the (qualified) paths name
+    * (None when all paths are already bucket-relative) together with the
+    * stripped column groups.
+    *
+    * The bucket is captured BEFORE any path is reduced to a bare key, so a
+    * qualified cross-bucket path cannot silently resolve against the
+    * connector's configured bucket. A segment whose qualified paths name more
+    * than one distinct bucket is refused — there is no single bucket to pin,
+    * and stripping against the first one would silently read the wrong data.
+    */
+  private[sources] def nativeV2ColumnGroups(
+      columnGroups: Seq[V2ColumnGroup],
+      endpoint: String,
+      configuredBucket: String = ""
+  ): (Option[String], Seq[V2ColumnGroup]) = {
+    val buckets = columnGroups.iterator
+      .flatMap(_.filePaths)
+      .flatMap(p => MilvusStoragePath.bucketOf(p, endpoint, configuredBucket))
+      .toSet
+    if (buckets.size > 1) {
+      throw new IllegalArgumentException(
+        s"StorageV2 segment column-group paths reference more than one bucket " +
+          s"(${buckets.toSeq.sorted.mkString(", ")}); refusing to guess which " +
+          "bucket native executors should resolve them against"
+      )
+    }
+    val bucket = buckets.headOption
+    val native = columnGroups.map { cg =>
+      cg.copy(
+        filePaths = cg.filePaths.map(
+          MilvusStoragePath.toBucketRelativeKey(_, endpoint, configuredBucket)
+        )
+      )
+    }
+    (bucket, native)
+  }
+
   private[sources] def buildSnapshotPartitions(
       manifestList: Seq[StorageV2ManifestItem],
       defaultPartitionId: String,
@@ -2042,15 +2237,12 @@ class MilvusScan(
       inlineInheritedDeletePlans: Boolean = false,
       forceCanonicalBucket: Option[String] = None
   ): Array[InputPartition] = {
+    val endpoint =
+      MilvusScan.connectorS3EndpointOption(milvusOption.options).getOrElse("")
     val canonicalMilvusOption = forceCanonicalBucket
       .map(_.trim)
       .filter(_.nonEmpty)
-      .map(bucket =>
-        milvusOption.copy(
-          options = milvusOption.options +
-            (Properties.FsConfig.FsBucketName -> bucket)
-        )
-      )
+      .map(bucket => withPinnedBucket(milvusOption, bucket))
       .getOrElse(milvusOption)
 
     val v3Partitions = manifestList.map { item =>
@@ -2059,9 +2251,24 @@ class MilvusScan(
           case Right(content) => (content.basePath, content.ver.toLong)
           case Left(_)        => (item.manifest, -1L)
         }
+      // milvus-storage's native FFI resolves scheme-less keys against the
+      // fs.* properties and rejects scheme-bearing paths for lack of an
+      // extfs.* block, so hand it the bare bucket-relative key — and pin the
+      // bucket the path names on the canonical partition option (which already
+      // carries forceCanonicalBucket), so a cross-bucket snapshot is not
+      // silently resolved against the connector's configured bucket and a
+      // bucket-relative base path is not resolved against an unset default.
+      val (manifestPath, partitionMilvusOption) =
+        nativeV3ManifestPath(
+          basePath,
+          canonicalMilvusOption,
+          endpoint,
+          MilvusScan.connectorS3BucketOption(canonicalMilvusOption.options)
+            .getOrElse("")
+        )
 
-      val pathParts = basePath.split("/").filter(_.nonEmpty)
-      val segmentID = MilvusScan.segmentIdForManifestItem(item, basePath)
+      val pathParts = manifestPath.split("/").filter(_.nonEmpty)
+      val segmentID = MilvusScan.segmentIdForManifestItem(item, manifestPath)
       val readVersion = v3ReadVersions.getOrElse(segmentID, parsedReadVersion)
       val insertLogIdx = pathParts.lastIndexOf("insert_log")
       val partitionId =
@@ -2069,12 +2276,12 @@ class MilvusScan(
           pathParts(insertLogIdx + 2)
         } else {
           logWarning(
-            s"Manifest path '$basePath' does not match expected insert_log/{collectionID}/{partitionID}/{segmentID} layout; using fallback partitionID=$defaultPartitionId"
+            s"Manifest path '$manifestPath' does not match expected insert_log/{collectionID}/{partitionID}/{segmentID} layout; using fallback partitionID=$defaultPartitionId"
           )
           defaultPartitionId
         }
       logInfo(
-        s"Creating partition with manifestPath=$basePath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
+        s"Creating partition with manifestPath=$manifestPath, partitionID=$partitionId, segmentID=$segmentID, readVersion=$readVersion"
       )
       val partitionIdLong =
         try partitionId.toLong
@@ -2093,10 +2300,10 @@ class MilvusScan(
         com.zilliz.spark.connector.read.MilvusDeletePlan.empty
       )
       MilvusStorageV3InputPartition(
-        basePath,
+        manifestPath,
         schemaBytes,
         partitionId,
-        milvusOption,
+        partitionMilvusOption,
         vectorSearchConfig.map(_.topK),
         vectorSearchConfig.map(_.queryVector),
         vectorSearchConfig.map(_.metricType),
@@ -2138,12 +2345,24 @@ class MilvusScan(
             inheritedDeletePlan,
             ownDeletePlan
           )
+        // Reduce column-group file paths to scheme-less keys the native reader
+        // consumes, pinning the bucket the qualified paths name so the FFI
+        // resolves them against the right fs.bucket_name.
+        val (nativeBucket, nativeColumnGroups) =
+          nativeV2ColumnGroups(
+            seg.columnGroups,
+            endpoint,
+            MilvusScan.connectorS3BucketOption(canonicalMilvusOption.options)
+              .getOrElse("")
+          )
+        val partitionOption =
+          withPinnedBucket(canonicalMilvusOption, nativeBucket.getOrElse(""))
         MilvusPackedV2InputPartition(
           segmentID = seg.segmentId,
           partitionID = seg.partitionId,
-          columnGroups = seg.columnGroups,
+          columnGroups = nativeColumnGroups,
           milvusSchemaBytes = schemaBytes,
-          milvusOption = canonicalMilvusOption,
+          milvusOption = partitionOption,
           neededColumnFieldIds = Seq.empty,
           applyDeletes = MilvusOption.readApplyDeletes(options),
           deletePlan = deletePlan,
@@ -2291,7 +2510,8 @@ class MilvusScan(
           inheritedDeleteSegments,
           pkField,
           snapshotBucketForRelativePaths.getOrElse(""),
-          snapshotHadoopConf
+          snapshotHadoopConf,
+          MilvusScan.connectorS3EndpointOption(milvusOption.options).getOrElse("")
         ) match {
           case Right(plans) => plans
           case Left(err) =>
@@ -2357,7 +2577,8 @@ class MilvusScan(
             inheritedDeleteSegments,
             pkField,
             MilvusScan.connectorS3BucketOption(optionsMap).getOrElse(""),
-            buildSnapshotHadoopConf("")
+            buildSnapshotHadoopConf(""),
+            MilvusScan.connectorS3EndpointOption(optionsMap).getOrElse("")
           ) match {
             case Right(plans) => plans
             case Left(err) =>

--- a/src/main/scala/tools/ListV2SegmentsApp.scala
+++ b/src/main/scala/tools/ListV2SegmentsApp.scala
@@ -7,6 +7,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 
+import com.zilliz.spark.connector.MilvusStoragePath
 import com.zilliz.spark.connector.read.{
   MilvusParquetFooterReader,
   MilvusSegmentManifestReader,
@@ -80,7 +81,7 @@ object ListV2SegmentsApp {
       println(s"  Milvus snapshot: $snapshotPath")
       println("==============================================")
 
-      val resolvedSnapshotPath = resolvePath(snapshotPath, s3Bucket)
+      val resolvedSnapshotPath = resolvePath(snapshotPath, s3Bucket, s3Endpoint)
       val metadata = loadMetadata(hadoopConf, resolvedSnapshotPath)
       printHeader(metadata)
 
@@ -103,9 +104,10 @@ object ListV2SegmentsApp {
         metadata.manifestList.foreach { manifestPath =>
           processOneSegment(
             hadoopConf,
-            resolvePath(manifestPath, s3Bucket),
+            resolvePath(manifestPath, s3Bucket, s3Endpoint),
             s3Bucket,
-            metadata.manifestSchemaVersion
+            metadata.manifestSchemaVersion,
+            s3Endpoint
           )
         }
       }
@@ -122,7 +124,8 @@ object ListV2SegmentsApp {
       hadoopConf: Configuration,
       manifestPath: String,
       bucket: String,
-      manifestSchemaVersion: Int
+      manifestSchemaVersion: Int,
+      endpoint: String = ""
   ): Unit = {
     println(s"\n  AVRO: $manifestPath")
     val avroBytes = readAllBytes(hadoopConf, manifestPath)
@@ -157,7 +160,7 @@ object ListV2SegmentsApp {
           // the real field IDs per column group. All files in the segment
           // carry the same group_field_id_list.
           val samplePath = entry.binlogFiles.head.binlogs.head.logPath
-          val normalized = resolvePath(samplePath, bucket)
+          val normalized = resolvePath(samplePath, bucket, endpoint)
           MilvusParquetFooterReader.read(normalized, hadoopConf) match {
             case Left(err) =>
               println(
@@ -270,10 +273,18 @@ object ListV2SegmentsApp {
     * Hadoop would default to the local filesystem — which is usually not what
     * we want, but is intentional for unit-test paths like `src/test/data/...`.
     */
-  private def resolvePath(path: String, bucket: String): String = {
+  private def resolvePath(
+      path: String,
+      bucket: String,
+      endpoint: String = ""
+  ): String = {
     if (path == null) path
-    else if (path.startsWith("s3a://")) path
-    else if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://")
+    else if (path.startsWith("s3a://") || path.startsWith("s3://"))
+      MilvusStoragePath.toStandardS3Path(
+        path,
+        endpoint = endpoint,
+        configuredBucket = bucket
+      )
     else if (bucket != null && bucket.nonEmpty)
       s"s3a://$bucket/${path.stripPrefix("/")}"
     else path

--- a/src/main/scala/tools/ReadSourceOnlyApp.scala
+++ b/src/main/scala/tools/ReadSourceOnlyApp.scala
@@ -10,6 +10,8 @@ import com.zilliz.spark.connector.read.{
   V2SegmentLoader
 }
 import com.zilliz.spark.connector.MilvusOption
+import com.zilliz.spark.connector.MilvusStoragePath
+import com.zilliz.spark.connector.loon.Properties
 
 /** Standalone reader-only verification app.
   *
@@ -64,7 +66,7 @@ object ReadSourceOnlyApp {
       )
 
       val snapshotJson = new String(
-        readAllBytes(hadoopConf, normalizeS3(snapshotPath)),
+        readAllBytes(hadoopConf, normalizeS3(snapshotPath, s3Endpoint, s3Bucket)),
         "UTF-8"
       )
       val metadata =
@@ -84,7 +86,8 @@ object ReadSourceOnlyApp {
           metadata.manifestList,
           s3Bucket,
           hadoopConf,
-          manifestSchemaVersion = metadata.manifestSchemaVersion
+          manifestSchemaVersion = metadata.manifestSchemaVersion,
+          endpoint = s3Endpoint
         ) match {
           case Right(segs) => segs
           case Left(err) =>
@@ -124,7 +127,17 @@ object ReadSourceOnlyApp {
         "milvus.s3.accessKey" -> s3AccessKey,
         "milvus.s3.secretKey" -> s3SecretKey,
         "milvus.s3.region" -> s3Region,
-        "milvus.s3.rootPath" -> s3RootPath
+        "milvus.s3.rootPath" -> s3RootPath,
+        // The executor-side native FFI reads only fs.* keys
+        // (Properties.fromMilvusOption); the milvus.s3.* aliases above are
+        // ignored by it, so populate fs.* here too or the FFI falls back to
+        // localhost:9000 / a-bucket / minioadmin.
+        Properties.FsConfig.FsAddress -> s3Endpoint,
+        Properties.FsConfig.FsBucketName -> s3Bucket,
+        Properties.FsConfig.FsAccessKeyId -> s3AccessKey,
+        Properties.FsConfig.FsAccessKeyValue -> s3SecretKey,
+        Properties.FsConfig.FsRegion -> s3Region,
+        Properties.FsConfig.FsRootPath -> s3RootPath
       )
 
       val schemaBytes = MilvusSnapshotReader.toProtobufSchemaBytes(
@@ -268,8 +281,18 @@ object ReadSourceOnlyApp {
     }
   }
 
-  private def normalizeS3(path: String): String =
-    if (path.startsWith("s3://")) "s3a://" + path.stripPrefix("s3://") else path
+  private def normalizeS3(
+      path: String,
+      endpoint: String = "",
+      configuredBucket: String = ""
+  ): String =
+    if (path.startsWith("s3://") || path.startsWith("s3a://"))
+      MilvusStoragePath.toStandardS3Path(
+        path,
+        endpoint = endpoint,
+        configuredBucket = configuredBucket
+      )
+    else path
 
   private def readAllBytes(
       conf: Configuration,

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -432,6 +432,44 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     path2.toString shouldBe "s3a://other-bucket/other-path"
   }
 
+  test("getFilePath canonicalizes Milvus-format endpoint-prefixed paths") {
+    import scala.collection.JavaConverters._
+    import org.apache.spark.sql.util.CaseInsensitiveStringMap
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert",
+        MilvusOption.S3FileSystemTypeName -> "s3a://",
+        MilvusOption.S3BucketName -> "test-bucket",
+        MilvusOption.S3RootPath -> "files"
+      ).asJava
+    )
+    val s3Option = MilvusS3Option(options)
+
+    val path = s3Option.getFilePath(
+      "s3a://minio:9000/milvus-bucket/files/insert_log/123/456"
+    )
+    path.toString shouldBe "s3a://milvus-bucket/files/insert_log/123/456"
+  }
+
+  test("getFilePath detects port-less endpoints via the configured endpoint") {
+    import scala.collection.JavaConverters._
+    import org.apache.spark.sql.util.CaseInsensitiveStringMap
+    val options = new CaseInsensitiveStringMap(
+      Map(
+        MilvusOption.ReaderType -> "insert",
+        MilvusOption.S3FileSystemTypeName -> "s3a://",
+        MilvusOption.S3BucketName -> "test-bucket",
+        MilvusOption.S3Endpoint -> "oss-cn-hangzhou.aliyuncs.com"
+      ).asJava
+    )
+    val s3Option = MilvusS3Option(options)
+
+    val path = s3Option.getFilePath(
+      "s3://oss-cn-hangzhou.aliyuncs.com/bucket/files/insert_log/123/456"
+    )
+    path.toString shouldBe "s3a://bucket/files/insert_log/123/456"
+  }
+
   test("getConf generates correct S3 configuration") {
     import scala.collection.JavaConverters._
     import org.apache.spark.sql.util.CaseInsensitiveStringMap

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -231,6 +231,56 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     ) shouldBe "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
   }
 
+  test(
+    "configureHadoopS3ForPath canonicalizes Milvus-format endpoint-prefixed paths"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "minio:9000",
+      s3BucketName = "main-bucket",
+      s3AccessKey = "ak1",
+      s3SecretKey = "sk1",
+      s3UseSSL = false
+    )
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "s3://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json",
+      cfg,
+      isSource = false
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    // The endpoint-prefixed authority must not be treated as a bucket.
+    hc.get("fs.s3a.bucket.eric-spark-minio.endpoint") shouldBe null
+    hc.get("fs.s3a.bucket.eric-spark-minio:9000.endpoint") shouldBe null
+    // The real data bucket gets the per-bucket S3A config.
+    hc.get("fs.s3a.bucket.milvus-bucket.endpoint") shouldBe "minio:9000"
+    hc.get("fs.s3a.bucket.milvus-bucket.path.style.access") shouldBe "true"
+    hc.get("fs.s3a.bucket.milvus-bucket.access.key") shouldBe "ak1"
+  }
+
+  test(
+    "configureHadoopS3ForPath does not misclassify a user output path whose first segment equals the target bucket"
+  ) {
+    val cfg = BackfillConfig(
+      s3Endpoint = "minio:9000",
+      s3BucketName = "main-bucket",
+      s3AccessKey = "ak1",
+      s3SecretKey = "sk1",
+      s3UseSSL = false
+    )
+    MilvusBackfill.configureHadoopS3ForPath(
+      spark,
+      "s3://results/main-bucket/backfill.json",
+      cfg,
+      isSource = false
+    )
+    val hc = spark.sparkContext.hadoopConfiguration
+    hc.unset("fs.s3a.bucket.main-bucket.endpoint")
+    // The user-supplied path is standard; its bucket is "results", not the
+    // target bucket "main-bucket".
+    hc.get("fs.s3a.bucket.results.endpoint") shouldBe "minio:9000"
+    hc.get("fs.s3a.bucket.main-bucket.endpoint") shouldBe null
+  }
+
   test("configureHadoopS3ForPath uses IAM provider when useIam=true") {
     val cfg = BackfillConfig(
       s3Endpoint = "s3.amazonaws.com",
@@ -493,6 +543,12 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     ) shouldBe "file:///tmp/x"
     MilvusBackfill.normalizeS3Scheme("/local/path") shouldBe "/local/path"
     MilvusBackfill.normalizeS3Scheme(null) shouldBe null
+  }
+
+  test("normalizeS3Scheme canonicalizes Milvus-format endpoint-prefixed paths") {
+    MilvusBackfill.normalizeS3Scheme(
+      "s3://eric-spark-minio:9000/milvus-bucket/data.parquet"
+    ) shouldBe "s3a://milvus-bucket/data.parquet"
   }
 
   test("normalizeObjectStorageScheme selects OSS aliases for Alibaba") {

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -1,5 +1,6 @@
 package com.zilliz.spark.connector.read
 
+import com.zilliz.spark.connector.MilvusStoragePath
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -36,6 +37,307 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
       MilvusSnapshotReader.readUtf8WithLimit(in, "memory", -1)
     }
     err.getMessage should include("must be positive")
+  }
+
+  test("toStandardS3Path canonicalizes Milvus-format endpoint-prefixed URIs") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path normalizes standard s3 scheme to s3a") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3://a-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://a-bucket/file/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toStandardS3Path(
+      "s3a://a-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://a-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path prefixes bucket for bucket-relative paths") {
+    MilvusStoragePath.toStandardS3Path(
+      "files/snapshots/1/metadata/2.json",
+      "a-bucket"
+    ) shouldBe "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path leaves bucket-relative paths alone without a bucket") {
+    MilvusStoragePath.toStandardS3Path(
+      "files/snapshots/1/metadata/2.json"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path leaves local and unsupported schemes alone") {
+    MilvusStoragePath.toStandardS3Path("/tmp/snapshot.json") shouldBe
+      "/tmp/snapshot.json"
+    MilvusStoragePath.toStandardS3Path("minio:/a/b") shouldBe "minio:/a/b"
+    MilvusStoragePath.toStandardS3Path(null) shouldBe null
+    MilvusStoragePath.toStandardS3Path("") shouldBe ""
+  }
+
+  test("toStandardS3Path handles s3a Milvus-format and endpoint host matches") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3a://minio:9000/milvus-bucket/files/data.parquet"
+    ) shouldBe "s3a://milvus-bucket/files/data.parquet"
+  }
+
+  test(
+    "toStandardS3Path detects port-less endpoints via the configured endpoint"
+  ) {
+    // No port in the URI; without the configured endpoint the shape is
+    // indistinguishable from a standard URI.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://s3.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://s3.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json"
+    // With the endpoint configured, "s3.amazonaws.com" is recognized as the
+    // storage endpoint rather than the bucket.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://s3.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json",
+      "",
+      "s3.amazonaws.com"
+    ) shouldBe "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path keeps userinfo out of endpoint detection") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3a://user:pass@bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://user:pass@bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("toBucketRelativeKey reduces standard and Milvus-format URIs to keys") {
+    MilvusStoragePath.toBucketRelativeKey(
+      "files/snapshots/1/metadata/2.json"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://a-bucket/files/snapshots/1/metadata/2.json"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://minio:9000/a-bucket/files/snapshots/1/metadata/2.json"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://s3.amazonaws.com/a-bucket/files/snapshots/1/metadata/2.json",
+      "s3.amazonaws.com"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+  }
+
+  test("toBucketRelativeKey ignores userinfo and leaves non-s3 paths alone") {
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3a://user:pass@bucket/files/snapshots/1/metadata/2.json"
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toBucketRelativeKey("minio:/a/b") shouldBe "minio:/a/b"
+    MilvusStoragePath.toBucketRelativeKey(null) shouldBe null
+    MilvusStoragePath.toBucketRelativeKey("") shouldBe ""
+  }
+
+  test("storageEndpointHost normalizes configured endpoints to bare hosts") {
+    MilvusStoragePath.storageEndpointHost("minio:9000") shouldBe "minio"
+    MilvusStoragePath.storageEndpointHost("http://localhost:9000") shouldBe
+      "localhost"
+    MilvusStoragePath.storageEndpointHost("s3.amazonaws.com") shouldBe
+      "s3.amazonaws.com"
+    MilvusStoragePath.storageEndpointHost("") shouldBe ""
+    MilvusStoragePath.storageEndpointHost(null) shouldBe ""
+  }
+
+  test("storageEndpointHost lowercases the URI host") {
+    MilvusStoragePath.storageEndpointHost("S3.INTERNAL.EXAMPLE") shouldBe
+      "s3.internal.example"
+  }
+
+  test("toStandardS3Path preserves percent-encoding in the reconstructed URI") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3://a-bucket/file/a%20b.json"
+    ) shouldBe "s3a://a-bucket/file/a%20b.json"
+    MilvusStoragePath.toStandardS3Path(
+      "s3://a-bucket/file/%23hash.json"
+    ) shouldBe "s3a://a-bucket/file/%23hash.json"
+  }
+
+  test(
+    "toStandardS3Path detects underscore hosts via the textual authority"
+  ) {
+    // milvus_minio violates RFC 2396 domainlabel, so java.net.URI.getHost is
+    // null and getPort is -1; the port signal must still fire.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://milvus_minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+    MilvusStoragePath.bucketOf(
+      "s3://milvus_minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe Some("milvus-bucket")
+  }
+
+  test(
+    "toStandardS3Path keeps the s3->s3a rewrite for unparseable s3 URIs"
+  ) {
+    // A space makes this an invalid java.net.URI; the prefix rewrite must
+    // survive so the legacy s3:// FileSystem never swallows S3A config.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://bucket/my snapshot/2.json"
+    ) shouldBe "s3a://bucket/my snapshot/2.json"
+  }
+
+  test("toStandardS3Path does not truncate keys with '#' or '?'") {
+    // getRawPath stops at '#'/'?'; the raw query/fragment is re-appended.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://a-bucket/file#frag"
+    ) shouldBe "s3a://a-bucket/file#frag"
+    MilvusStoragePath.toStandardS3Path(
+      "s3://a-bucket/file?query=1"
+    ) shouldBe "s3a://a-bucket/file?query=1"
+  }
+
+  test(
+    "toStandardS3Path keeps the Milvus-format bucket when a key has '#' or '?'"
+  ) {
+    // The global prefix rewrite would have left the endpoint as the bucket.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://minio:9000/milvus-bucket/file#frag"
+    ) shouldBe "s3a://milvus-bucket/file#frag"
+    MilvusStoragePath.toStandardS3Path(
+      "s3://minio:9000/milvus-bucket/file?query=1"
+    ) shouldBe "s3a://milvus-bucket/file?query=1"
+  }
+
+  test("toBucketRelativeKey preserves '#' / '?' in the object key") {
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://a-bucket/file#frag"
+    ) shouldBe "file#frag"
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://minio:9000/milvus-bucket/file?query=1"
+    ) shouldBe "file?query=1"
+  }
+
+  test("toBucketRelativeKey reduces unparseable s3 URIs to a bare key") {
+    // The native reader expects a bare key, not a scheme-bearing value.
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://bucket/my snapshot/2.json"
+    ) shouldBe "my snapshot/2.json"
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://minio:9000/milvus-bucket/my snapshot/2.json"
+    ) shouldBe "my snapshot/2.json"
+  }
+
+  test("toBucketRelativeKey returns empty for a bucket-only Milvus-format URI") {
+    // rawPath's first segment is the bucket itself; there is no object key.
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://minio:9000/milvus-bucket"
+    ) shouldBe ""
+  }
+
+  test(
+    "toStandardS3Path splits unparseable Milvus-format URIs textually"
+  ) {
+    // java.net.URI rejects the space; the textual authority split must still
+    // strip the endpoint so it is not left as the bucket.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://minio:9000/milvus-bucket/my snapshot/2.json"
+    ) shouldBe "s3a://milvus-bucket/my snapshot/2.json"
+  }
+
+  test("toBucketRelativeKey preserves percent-encoding in the object key") {
+    MilvusStoragePath.toBucketRelativeKey(
+      "s3://a-bucket/file/a%20b.json"
+    ) shouldBe "file/a%20b.json"
+  }
+
+  test("bucketOf extracts the bucket from qualified URIs") {
+    MilvusStoragePath.bucketOf(
+      "s3://a-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe Some("a-bucket")
+    MilvusStoragePath.bucketOf(
+      "s3://minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe Some("milvus-bucket")
+    MilvusStoragePath.bucketOf(
+      "s3://s3.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json",
+      "s3.amazonaws.com"
+    ) shouldBe Some("milvus-bucket")
+    MilvusStoragePath.bucketOf(
+      "s3a://user:pass@bucket/file/snapshots/1/metadata/2.json"
+    ) shouldBe Some("bucket")
+  }
+
+  test("bucketOf strips userinfo even when the host is not a valid URI host") {
+    // 'a_bucket' makes java.net.URI.getHost return null; the fallback must
+    // take the part after the userinfo, not before it.
+    MilvusStoragePath.bucketOf(
+      "s3a://user:pass@a_bucket/files/snapshots/1/metadata/2.json"
+    ) shouldBe Some("a_bucket")
+  }
+
+  test("toStandardS3Path trims whitespace around the fallback bucket") {
+    MilvusStoragePath.toStandardS3Path(
+      "files/snapshots/1/metadata/2.json",
+      "  a-bucket "
+    ) shouldBe "s3a://a-bucket/files/snapshots/1/metadata/2.json"
+    MilvusStoragePath.toStandardS3Path(
+      "files/snapshots/1/metadata/2.json",
+      "   "
+    ) shouldBe "files/snapshots/1/metadata/2.json"
+  }
+
+  test(
+    "toStandardS3Path detects Milvus-format via the first path segment bucket"
+  ) {
+    // Port-less endpoint whose embedded host differs from the configured
+    // endpoint (regional vs global host); the first path segment matching the
+    // configured bucket still reveals the Milvus-format shape.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://s3.us-east-1.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json",
+      "",
+      "s3.amazonaws.com",
+      "milvus-bucket"
+    ) shouldBe "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test(
+    "toStandardS3Path does not misclassify a single-label bucket whose key's first segment equals the configured bucket"
+  ) {
+    // A single-label authority like "archive" is a standard bucket, not an
+    // endpoint; the key's first segment matching the configured bucket must
+    // not rewrite the path to the configured bucket.
+    MilvusStoragePath.toStandardS3Path(
+      "s3://archive/milvus-bucket/file/snapshots/1/metadata/2.json",
+      "",
+      "",
+      "milvus-bucket"
+    ) shouldBe "s3a://archive/milvus-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("toStandardS3Path keeps authority-as-bucket standard when it matches") {
+    MilvusStoragePath.toStandardS3Path(
+      "s3://milvus-bucket/file/snapshots/1/metadata/2.json",
+      "",
+      "",
+      "milvus-bucket"
+    ) shouldBe "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+  }
+
+  test("bucketOf uses the configured-bucket signal for port-less endpoints") {
+    MilvusStoragePath.bucketOf(
+      "s3://s3.us-east-1.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json",
+      "s3.amazonaws.com",
+      "milvus-bucket"
+    ) shouldBe Some("milvus-bucket")
+  }
+
+  test("bucketOf extracts the bucket from unparseable URIs textually") {
+    // java.net.URI rejects the space; bucketOf must still pin a bucket so the
+    // bare key toBucketRelativeKey strips from the same input never resolves
+    // silently against the connector's configured bucket.
+    MilvusStoragePath.bucketOf(
+      "s3://minio:9000/milvus-bucket/my snapshot/2.json"
+    ) shouldBe Some("milvus-bucket")
+    MilvusStoragePath.bucketOf(
+      "s3://bucket/my snapshot/2.json"
+    ) shouldBe Some("bucket")
+  }
+
+  test("bucketOf returns None for bucket-relative and non-s3 paths") {
+    MilvusStoragePath.bucketOf("files/snapshots/1/metadata/2.json") shouldBe
+      None
+    MilvusStoragePath.bucketOf("") shouldBe None
+    MilvusStoragePath.bucketOf(null) shouldBe None
+    MilvusStoragePath.bucketOf("/tmp/snapshot.json") shouldBe None
   }
 
   test("Parse complete snapshot metadata successfully") {

--- a/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusStorageV3ManifestReaderTest.scala
@@ -74,6 +74,19 @@ class MilvusStorageV3ManifestReaderTest extends AnyFunSuite with Matchers {
     ) shouldBe "s3a://bucket/files/insert_log/10/20/30/_delta/9001"
   }
 
+  test(
+    "resolveManifestDeltaPath canonicalizes Milvus-format endpoint-prefixed deltalog paths"
+  ) {
+    MilvusStorageV3ManifestReader.resolveManifestDeltaPath(
+      "s3://minio:9000/bucket/files/insert_log/10/20/30",
+      "s3://minio:9000/bucket/files/insert_log/10/20/30/_delta/9001"
+    ) shouldBe "s3a://bucket/files/insert_log/10/20/30/_delta/9001"
+    MilvusStorageV3ManifestReader.resolveManifestDeltaPath(
+      "s3://minio:9000/bucket/files/insert_log/10/20/30",
+      "s3a://minio:9000/bucket/files/insert_log/10/20/30/_delta/9001"
+    ) shouldBe "s3a://bucket/files/insert_log/10/20/30/_delta/9001"
+  }
+
   test("latestManifestVersion returns greatest StorageV3 manifest version") {
     val basePath = Files.createTempDirectory("milvus-v3-manifest-test")
     val metadataPath = Files.createDirectory(basePath.resolve("_metadata"))

--- a/src/test/scala/read/V2SegmentLoaderTest.scala
+++ b/src/test/scala/read/V2SegmentLoaderTest.scala
@@ -448,6 +448,8 @@ class V2SegmentLoaderTest
       val Some(seg) = result.toOption.get
       seg.segmentId shouldBe 5005L
       seg.columnGroups.map(_.fieldIds) shouldBe Seq(Seq(100L))
+      // V2SegmentInfo keeps the original AVRO paths; the native reader boundary
+      // strips + pins the bucket at partition-build time.
       seg.deltaLogs shouldBe Seq(
         V2DeltaLogFile(9L, "s3a://bucket/delete-1", 1L)
       )
@@ -507,6 +509,8 @@ class V2SegmentLoaderTest
       val Some(seg) = result.toOption.get
       seg.segmentId shouldBe 5007L
       seg.columnGroups.map(_.fieldIds) shouldBe Seq(Seq(100L))
+      // V2SegmentInfo keeps the original AVRO paths; the native reader boundary
+      // strips + pins the bucket at partition-build time.
       seg.deltaLogs shouldBe Seq(
         V2DeltaLogFile(9L, "s3a://bucket/delete-1", 1L)
       )
@@ -541,6 +545,32 @@ class V2SegmentLoaderTest
 
     err.getMessage should include("failed to read bytes")
     err.getMessage should include("s3a://bucket/path with spaces/[bad].avro")
+  }
+
+  test("resolvePath canonicalizes Milvus-format endpoint-prefixed paths") {
+    V2SegmentLoader.resolvePath(
+      "s3://eric-spark-minio:9000/milvus-bucket/file/insert_log/10/20/30/100/1",
+      "ignored"
+    ) shouldBe "s3a://milvus-bucket/file/insert_log/10/20/30/100/1"
+  }
+
+  test("resolvePath prefixes bucket for bucket-relative paths") {
+    V2SegmentLoader.resolvePath("file/insert_log/10/20/30/100/1", "a-bucket")
+      .shouldBe("s3a://a-bucket/file/insert_log/10/20/30/100/1")
+  }
+
+  test("resolvePath passes standard s3a paths through unchanged") {
+    V2SegmentLoader.resolvePath(
+      "s3a://a-bucket/file/insert_log/10/20/30/100/1",
+      "ignored"
+    ) shouldBe "s3a://a-bucket/file/insert_log/10/20/30/100/1"
+  }
+
+  test("resolvePath canonicalizes s3a Milvus-format endpoint-prefixed paths") {
+    V2SegmentLoader.resolvePath(
+      "s3a://eric-spark-minio:9000/milvus-bucket/file/insert_log/10/20/30/100/1",
+      "ignored"
+    ) shouldBe "s3a://milvus-bucket/file/insert_log/10/20/30/100/1"
   }
 
   test("readAllBytes does not swallow fatal errors") {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -190,6 +190,17 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       }
   }
 
+  test(
+    "resolveClientSnapshotLocation canonicalizes Milvus-format endpoint-prefixed locations"
+  ) {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "s3://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json",
+        "ignored"
+      ) == "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+    )
+  }
+
   test("snapshotBucket extracts authority when URI host is null") {
     assert(
       MilvusScan.snapshotBucket(
@@ -198,10 +209,217 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test(
+    "snapshotBucket returns data bucket for Milvus-format endpoint-prefixed locations"
+  ) {
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+      ) == Some("milvus-bucket")
+    )
+  }
+
   test("snapshotBucket returns None for bucket-relative snapshot locations") {
     assert(
       MilvusScan.snapshotBucket("files/snapshots/1/metadata/2.json") == None
     )
+  }
+
+  test("snapshotBucket ignores userinfo when extracting the bucket") {
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3a://user:pass@bucket/files/snapshots/1/metadata/2.json"
+      ) == Some("bucket")
+    )
+  }
+
+  test(
+    "snapshotBucket strips userinfo even when the host is not a valid URI host"
+  ) {
+    // 'a_bucket' makes java.net.URI.getHost return null; the authority
+    // fallback must take the part after the userinfo, not before it.
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3a://user:pass@a_bucket/files/snapshots/1/metadata/2.json"
+      ) == Some("a_bucket")
+    )
+  }
+
+  test(
+    "snapshotBucket detects port-less endpoints via the configured endpoint"
+  ) {
+    // Without the endpoint, s3.amazonaws.com is indistinguishable from a bucket.
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3://s3.amazonaws.com/milvus-bucket/files/snapshots/1/metadata/2.json"
+      ) == Some("s3.amazonaws.com")
+    )
+    // With the endpoint configured, the data bucket is extracted.
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3://s3.amazonaws.com/milvus-bucket/files/snapshots/1/metadata/2.json",
+        "s3.amazonaws.com"
+      ) == Some("milvus-bucket")
+    )
+  }
+
+  test(
+    "resolveClientSnapshotLocation detects port-less endpoints via the configured endpoint"
+  ) {
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "s3://s3.amazonaws.com/milvus-bucket/file/snapshots/1/metadata/2.json",
+        "ignored",
+        "s3.amazonaws.com"
+      ) == "s3a://milvus-bucket/file/snapshots/1/metadata/2.json"
+    )
+  }
+
+  test("nativeV3ManifestPath reduces the key and pins the manifest bucket") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val (key, option) = scan.nativeV3ManifestPath(
+      "s3://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/20/30",
+      MilvusOption(Map.empty[String, String]),
+      "minio:9000"
+    )
+    assert(key == "file/snapshots/1/20/30")
+    assert(
+      option.options.get(Properties.FsConfig.FsBucketName) == Some(
+        "milvus-bucket"
+      )
+    )
+  }
+
+  test("withPinnedBucket translates s3.* aliases into fs.* for the FFI") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val option = scan.withPinnedBucket(
+      MilvusOption(
+        Map(
+          MilvusOption.S3Endpoint -> "minio:9000",
+          MilvusOption.S3AccessKey -> "ak",
+          MilvusOption.S3SecretKey -> "sk",
+          MilvusOption.S3UseSSL -> "false"
+        )
+      ),
+      "milvus-bucket"
+    )
+    assert(
+      option.options.get(Properties.FsConfig.FsBucketName) == Some(
+        "milvus-bucket"
+      )
+    )
+    assert(option.options.get(Properties.FsConfig.FsAddress) == Some("minio:9000"))
+    assert(
+      option.options.get(Properties.FsConfig.FsAccessKeyId) == Some("ak")
+    )
+    assert(
+      option.options.get(Properties.FsConfig.FsAccessKeyValue) == Some("sk")
+    )
+    assert(option.options.get(Properties.FsConfig.FsUseSSL) == Some("false"))
+  }
+
+  test("withPinnedBucket skips AK/SK translation under IAM") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val option = scan.withPinnedBucket(
+      MilvusOption(
+        Map(
+          Properties.FsConfig.FsUseIam -> "true",
+          MilvusOption.S3Endpoint -> "minio:9000",
+          MilvusOption.S3AccessKey -> "stale-ak",
+          MilvusOption.S3SecretKey -> "stale-sk"
+        )
+      ),
+      "milvus-bucket"
+    )
+    assert(
+      option.options.get(Properties.FsConfig.FsAddress) == Some("minio:9000")
+    )
+    // Under IAM the driver drops static credentials; the translation must not
+    // reintroduce them for the executor FFI.
+    assert(option.options.get(Properties.FsConfig.FsAccessKeyId) == None)
+    assert(option.options.get(Properties.FsConfig.FsAccessKeyValue) == None)
+  }
+
+  test(
+    "resolveClientSnapshotLocation tolerates unparseable snapshot locations"
+  ) {
+    // A space makes this an invalid java.net.URI; the scheme probe must not
+    // throw a raw URISyntaxException before the textual fallback runs.
+    assert(
+      MilvusScan.resolveClientSnapshotLocation(
+        "s3://minio:9000/milvus-bucket/my snapshot/2.json",
+        "connector-bucket"
+      ) == "s3a://milvus-bucket/my snapshot/2.json"
+    )
+  }
+
+  test("snapshotBucket tolerates unparseable snapshot locations") {
+    assert(
+      MilvusScan.snapshotBucket(
+        "s3://minio:9000/milvus-bucket/my snapshot/2.json"
+      ) == Some("milvus-bucket")
+    )
+  }
+
+  test("nativeV3ManifestPath leaves bucket-relative base paths unpinned") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val (key, option) = scan.nativeV3ManifestPath(
+      "files/snapshots/1/20/30",
+      MilvusOption(
+        Map(Properties.FsConfig.FsBucketName -> "connector-bucket")
+      ),
+      "minio:9000"
+    )
+    assert(key == "files/snapshots/1/20/30")
+    assert(
+      option.options.get(Properties.FsConfig.FsBucketName) == Some(
+        "connector-bucket"
+      )
+    )
+  }
+
+  test("nativeV2ColumnGroups strips qualified paths and pins their bucket") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val (bucket, groups) = scan.nativeV2ColumnGroups(
+      Seq(
+        V2ColumnGroup(
+          fieldIds = Seq(100L),
+          filePaths = Seq(
+            "s3://eric-spark-minio:9000/milvus-bucket/files/insert_log/10/20/30/100/1",
+            "files/insert_log/10/20/30/100/2"
+          )
+        )
+      ),
+      "minio:9000"
+    )
+    assert(bucket == Some("milvus-bucket"))
+    assert(
+      groups.head.filePaths == Seq(
+        "files/insert_log/10/20/30/100/1",
+        "files/insert_log/10/20/30/100/2"
+      )
+    )
+  }
+
+  test("nativeV2ColumnGroups refuses segments spanning more than one bucket") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val err = intercept[IllegalArgumentException] {
+      scan.nativeV2ColumnGroups(
+        Seq(
+          V2ColumnGroup(
+            fieldIds = Seq(100L),
+            filePaths = Seq(
+              "s3://minio:9000/milvus-bucket/files/insert_log/10/20/30/100/1",
+              "s3://minio:9000/data-bucket/files/insert_log/10/20/30/100/2"
+            )
+          )
+        ),
+        "minio:9000"
+      )
+    }
+    assert(err.getMessage.contains("more than one bucket"))
+    assert(err.getMessage.contains("milvus-bucket"))
+    assert(err.getMessage.contains("data-bucket"))
   }
 
   test("snapshotBucket rejects unsupported schemes") {
@@ -360,6 +578,17 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test(
+    "snapshotBucketsToConfigure canonicalizes Milvus-format endpoint-prefixed locations"
+  ) {
+    assert(
+      MilvusScan.snapshotBucketsToConfigure(
+        "s3a://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json",
+        "connector-bucket"
+      ) == Seq("connector-bucket", "milvus-bucket")
+    )
+  }
+
   test("resolveConnectorS3Bucket trims configured bucket") {
     assert(
       MilvusScan.resolveConnectorS3Bucket(
@@ -426,13 +655,62 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test(
+    "buildSnapshotHadoopConf maps s3.* aliases to S3A endpoint and credentials"
+  ) {
+    // Detection accepts s3.endpoint etc.; the S3A Hadoop conf must too, so a
+    // user who configures only the s3.* family gets one consistent storage.
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(MilvusOption.S3BucketName, "connector-bucket")
+    rawOptions.put(MilvusOption.S3Endpoint, "minio:9000")
+    rawOptions.put(MilvusOption.S3AccessKey, "ak")
+    rawOptions.put(MilvusOption.S3SecretKey, "sk")
+    rawOptions.put(MilvusOption.S3UseSSL, "false")
+    rawOptions.put(MilvusOption.S3PathStyleAccess, "true")
+
+    val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
+      "s3://minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    )
+
+    assert(conf.get("fs.s3a.endpoint") == "minio:9000")
+    assert(conf.get("fs.s3a.connection.ssl.enabled") == "false")
+    assert(conf.get("fs.s3a.path.style.access") == "true")
+    assert(conf.get("fs.s3a.access.key") == "ak")
+    assert(conf.get("fs.s3a.secret.key") == "sk")
+    assert(conf.get("fs.s3a.bucket.milvus-bucket.endpoint") == "minio:9000")
+    assert(conf.get("fs.s3a.bucket.milvus-bucket.path.style.access") == "true")
+  }
+
+  test(
+    "buildSnapshotHadoopConf configures data bucket for Milvus-format snapshot location"
+  ) {
+    val rawOptions = new ju.HashMap[String, String]()
+    rawOptions.put(Properties.FsConfig.FsBucketName, "connector-bucket")
+    rawOptions.put(Properties.FsConfig.FsAddress, "minio:9000")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyId, "ak")
+    rawOptions.put(Properties.FsConfig.FsAccessKeyValue, "sk")
+
+    val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
+      "s3a://eric-spark-minio:9000/milvus-bucket/file/snapshots/1/metadata/2.json"
+    )
+
+    // The endpoint-prefixed authority must not be treated as a bucket.
+    assert(conf.get("fs.s3a.bucket.eric-spark-minio.endpoint") == null)
+    assert(conf.get("fs.s3a.bucket.eric-spark-minio:9000.endpoint") == null)
+    // The real data bucket gets the per-bucket S3A config.
+    assert(conf.get("fs.s3a.bucket.milvus-bucket.endpoint") == "minio:9000")
+    assert(
+      conf.get("fs.s3a.bucket.milvus-bucket.aws.credentials.provider") ==
+        "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+    )
+  }
+
   test("buildSnapshotHadoopConf maps IAM mode without static credentials") {
     val rawOptions = new ju.HashMap[String, String]()
     rawOptions.put(Properties.FsConfig.FsBucketName, "connector-bucket")
     rawOptions.put(Properties.FsConfig.FsUseIam, "true")
     rawOptions.put(Properties.FsConfig.FsAccessKeyId, "ak")
     rawOptions.put(Properties.FsConfig.FsAccessKeyValue, "sk")
-
     val conf = scanWithOptions(rawOptions).buildSnapshotHadoopConf(
       "s3a://connector-bucket/files/snapshots/1/metadata/2.json"
     )
@@ -1230,6 +1508,57 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
 
     val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
     assert(partition.readVersion == 11L)
+  }
+
+  test(
+    "snapshot planner pins the canonical bucket on bucket-relative StorageV3 partitions"
+  ) {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq(
+        StorageV2ManifestItem(30L, "files/insert_log/10/20/30")
+      ),
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v2Segments = Seq.empty,
+      v2DeletePlans = Map.empty,
+      forceCanonicalBucket = Some("data-bucket")
+    )
+
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.manifestPath == "files/insert_log/10/20/30")
+    assert(
+      partition.milvusOption.options.get(Properties.FsConfig.FsBucketName) ==
+        Some("data-bucket")
+    )
+  }
+
+  test(
+    "snapshot planner pins the manifest bucket on qualified StorageV3 partitions"
+  ) {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq(
+        StorageV2ManifestItem(
+          30L,
+          "s3://minio:9000/milvus-bucket/files/insert_log/10/20/30"
+        )
+      ),
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v2Segments = Seq.empty,
+      v2DeletePlans = Map.empty,
+      forceCanonicalBucket = Some("other-bucket")
+    )
+
+    val partition = partitions.head.asInstanceOf[MilvusStorageV3InputPartition]
+    assert(partition.manifestPath == "files/insert_log/10/20/30")
+    // The manifest-named bucket wins over forceCanonicalBucket for a qualified
+    // base path.
+    assert(
+      partition.milvusOption.options.get(Properties.FsConfig.FsBucketName) ==
+        Some("milvus-bucket")
+    )
   }
 
   test("snapshot planner applies inherited L0 delete plans to StorageV3") {


### PR DESCRIPTION
Milvus servers configured with a custom storage endpoint (non-empty fs.address, e.g. MinIO) write snapshot locations and the data paths embedded in snapshot metadata in the "Milvus format" s3://<address>/<bucket>/<key>. Consumers here assumed bucket-relative (file/...) or standard s3://bucket/key shapes, so the endpoint host was mistaken for the bucket, breaking S3A reads with "object URI bucket ..." mismatches and FileNotFoundException on the snapshot JSON.

Add MilvusSnapshotReader.toStandardS3Path to collapse all three shapes to s3a://bucket/key, and route every snapshot path parse point through it (resolveClientSnapshotLocation, snapshotBucket, buildSnapshotHadoopConf, configureHadoopS3ForPath, readSnapshotJson, V2SegmentLoader.resolvePath, manifest base paths). Detection uses the authority containing a port, since S3 bucket names never contain ':'.

Milvus on real S3 (empty fs.address) is unaffected: URIs there already use the standard shape.