### PR TITLE
Add backup datasource mode for Milvus reads

### DIFF
--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -9,8 +9,9 @@
 Milvus 2.6 deployments that cannot use the server snapshot feature (or that want
 a fully offline, client-free read path) currently have no way to read data
 through the connector without a live Proxy connection. `milvus-backup create`
-already produces a byte-identical, point-in-time copy of the flushed binlogs,
-but the connector had no way to consume it.
+already produces a copy of the flushed binlogs (byte-identical objects at a
+per-collection flush boundary; see the consistency caveat in §7), but the
+connector had no way to consume it.
 
 This change adds a **backup datasource mode**: point the connector at a
 binlog-format milvus-backup export and read it as a Spark DataFrame with the
@@ -28,7 +29,12 @@ required.
   snapshot reads (`milvus.read.apply.deletes`).
 - Reuse the existing StorageV2 packed read path (`MilvusPackedV2PartitionReader`
   + the milvus-storage JNI reader) unchanged.
-- **No changes to milvus-backup**: existing exports work as-is.
+- **No changes to milvus-backup**: existing binlog-format exports work as-is.
+  One caveat: a dynamic collection (`enable_dynamic_field=true`) requires the
+  backup meta to record the `$meta` field, which milvus-backup only captures
+  with etcd access (`--backup_index_extra`) and **v0.5.13+** (on v0.5.10–v0.5.12
+  the flag does not capture `$meta`); such backups are rejected with that
+  guidance.
 
 **Out of scope**
 
@@ -44,7 +50,7 @@ milvus-backup's meta records only `log_size` per binlog, not `entries_num`
 derive the `(start_index, end_index)` ranges for each file; missing or wrong
 counts are rejected or silently mis-read. **Approach A**: recover each file's
 row count by reading its parquet footer at planning time. This requires no
-backup-side changes and works on any existing export.
+backup-side changes and works on any existing binlog-format export.
 
 ## 2. Verified Key Facts
 
@@ -236,15 +242,24 @@ Behavior:
 
 ## 7. Edge Cases & Limitations
 
-- Backups default to a flush, so only disk-resident (flushed) data is read — a
-  consistent point-in-time copy, same constraint as snapshot reads.
+- **Consistency caveat (differs from a server snapshot).** A backup's binlog
+  flow is flush → segment enumeration → per-object copy. The flush is
+  best-effort per the chosen strategy: `serialFlushPlan` seals each collection
+  at its own timestamp, `skipFlushPlan` omits the flush, and the GC pause that
+  protects against a sweep/compaction between enumeration and copy is an
+  advisory that may fail silently (zilliztech/milvus-backup#1119). So only
+  disk-resident (flushed) data is read, but a backup is **not** a
+  server-enforced, transactionally consistent point-in-time view across the
+  whole backup — a GC/compaction race can tear it. Do not treat it as a
+  cutover/snapshot source of truth; that guarantee is the server snapshot's.
 - Empty segments (`num_of_rows == 0`, no binlogs) emit `columnGroups =
   Seq.empty` and are skipped during partition planning. A StorageV2 data
   segment with rows but no binlogs fails hard rather than silently dropping
   rows.
 - Dynamic collections: a default backup (no etcd access) does not record the
   `$meta` field, so reading it would return null `$meta` rows; such backups are
-  rejected with a pointer to `--backup_index_extra`.
+  rejected with a pointer to `--backup_index_extra` (requires milvus-backup
+  v0.5.13+ to capture `$meta`).
 - `milvus.partition.name` / `milvus.partition.id` / `milvus.segment.id`
   selectors are rejected (not yet supported); read the whole backup and filter
   in Spark.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -82,12 +82,13 @@ Branch precedence: snapshot mode > backup mode > client mode.
 
 Two gaps versus a Milvus snapshot are closed in `BackupMetaReader`:
 
-1. **Per-file row counts** (`fileRowCounts`) — recovered from each parquet
-   footer via the new `MilvusParquetFooterReader.readRowCount` (head file read
-   once via `readFieldIdsAndRowCount`, remaining files read in parallel).
+1. **Per-file row counts** (`fileRowCounts`) — always recovered from the parquet
+   footers (the meta never carries `entries_num`); the head file is read once
+   via `readFieldIdsAndRowCount`, the remaining files in parallel.
 2. **Slot → real field ID mapping** — the AVRO segment-info is not copied by
-   the backup, so real field IDs are recovered from each parquet file's own
-   schema via the existing `readFieldIdsFromSchema`.
+   the backup, so real field IDs are recovered from the **head file** of each
+   column group via `readFieldIdsAndRowCount` (all files in a group share the
+   schema, matching `V2SegmentLoader`).
 
 Path resolution: the `log_path` values in `full_meta.json` are the **original
 Milvus source keys** — milvus-backup copies each binlog into a separately

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -81,15 +81,31 @@ Branch precedence: snapshot mode > backup mode > client mode.
 Two gaps versus a Milvus snapshot are closed in `BackupMetaReader`:
 
 1. **Per-file row counts** (`fileRowCounts`) — recovered from each parquet
-   footer via the new `MilvusParquetFooterReader.readRowCount`.
+   footer via the new `MilvusParquetFooterReader.readRowCount` (head file read
+   once via `readFieldIdsAndRowCount`, remaining files read in parallel).
 2. **Slot → real field ID mapping** — the AVRO segment-info is not copied by
    the backup, so real field IDs are recovered from each parquet file's own
    schema via the existing `readFieldIdsFromSchema`.
 
-Path resolution: backup `log_path` values are bucket-relative; they are
-resolved with `V2SegmentLoader.resolvePath(logPath, bucket)` to
-`s3a://bucket/...` (or kept local when the bucket is empty). No `groupID`
-reverse-engineering is needed — paths are taken verbatim from the meta.
+Path resolution: the `log_path` values in `full_meta.json` are the **original
+Milvus source keys** — milvus-backup copies each binlog into a separately
+computed `DestKey` under the backup dir and records only the source key in the
+meta (`coll_dml_task.go` asserts the two differ). Backup object paths are
+therefore **reconstructed** from `milvus.backup.dir` plus the segment's
+collection/partition/group/segment/field/log IDs, mirroring
+`insertLogsAttrs`/`deltaLogAttrs`:
+
+```
+insert: {backupDir}/binlogs/insert_log/{coll}/{part}/{group}/{seg}/{field}/{log}
+delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}          (part == -1)
+        {backupDir}/binlogs/delta_log/{coll}/{part}/{group}/{seg}/{log}  (part != -1)
+```
+
+The `groupID` level is always present for `insert_log` (it is the virtual
+partition id; `0` for `partition_id == -1`) and present for L1 `delta_log`
+only when `partition_id != -1`. The bucket always comes from the
+`milvus.backup.dir` URI (S3 only); `fs.bucket_name` plays no part in path
+resolution.
 
 ## 4. Changes
 
@@ -111,7 +127,7 @@ object BackupMetaReader {
   def readMeta(hadoopConf: Configuration, backupDir: String): Either[Throwable, BackupInfo]
   def parse(json: String): Either[Throwable, BackupInfo]
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte]
-  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, bucket: String,
+  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, backupDir: String,
                    applyDeletes: Boolean = true): Either[Throwable, Seq[V2SegmentInfo]]
 }
 ```
@@ -124,9 +140,12 @@ Embedded JSON model mirrors `backuppb.BackupInfo` → `CollectionBackupInfo` →
 
 Behavior:
 
-- Rejects snapshot-format backups and StorageV3 (`storage_version > 2`) segments.
-- Skips StorageV1 (`storage_version < 2`) segments.
-- Skips L0 segments when `applyDeletes = false`.
+- Rejects snapshot-format backups and non-L0 segments whose `storage_version`
+  is not `2` (StorageV1/V3) — both fail loudly rather than producing a partial
+  dataset.
+- Skips L0 segments when `applyDeletes = false` (otherwise L0 segments, which
+  Milvus creates without a storage version, bypass the V2 filter and feed the
+  inherited delete-plan path).
 - L0 segments produce a `V2SegmentInfo` with empty `columnGroups` plus
   `deltaLogs`, feeding the inherited delete-plan path.
 
@@ -135,6 +154,8 @@ Behavior:
 - New `readRowCount(path, hadoopConf): Either[Throwable, Long]` — sums the
   row groups' row counts from the parquet footer (a `HEAD` + a single tail
   `GET`, same cost profile as the existing footer reads).
+- New `readFieldIdsAndRowCount(path, hadoopConf)` — field IDs + row count from
+  a single footer open (avoids opening the head file twice).
 
 ### 4.4 `src/main/scala/sources/MilvusDataSource.scala`
 
@@ -144,15 +165,17 @@ Behavior:
 - `MilvusTable`: `isBackupMode`, `initFromBackup()` (materializes the collection
   schema from the backup meta so metadata rehydration for vector columns works
   like snapshot mode), and `schema()` handling for offline modes.
-- `MilvusScan.planInputPartitionsFromBackup()`: reads the meta, builds
-  `V2SegmentInfo`, loads delete plans, and hands everything to the shared
+- `MilvusScan.planInputPartitionsFromBackup()`: reads the meta, validates that
+  it carries a collection schema with a primary key, builds `V2SegmentInfo`,
+  loads delete plans, and hands everything to the shared
   `buildSnapshotPartitions` with `inlineInheritedDeletePlans = true`.
 - `MilvusScan.pushFilters`: backup mode returns all filters as unsupported
   (the packed-V2 reader has no filter pushdown), matching the packed-V2 snapshot
   path.
 - `MilvusScan.buildSnapshotHadoopConf` refactored into the companion
   `buildHadoopConfForOptions(rawOptions, path)` so both the planner and table
-  schema rehydration share it.
+  schema rehydration share it. `snapshotBucket` now treats non-S3 schemes as
+  "no bucket" (so `file://` backup dirs don't raise a snapshot-flavoured error).
 
 ## 5. Data Mapping (`full_meta.json → V2SegmentInfo`)
 
@@ -161,14 +184,14 @@ Behavior:
 | `segmentId` | `SegmentBackupInfo.segment_id` | |
 | `partitionId` | `.partition_id` | `-1` preserved for L0 / all-partition |
 | `numOfRows` | `.num_of_rows` | |
-| `storageVersion` | `.storage_version` | only `== 2` supported; `< 2` skipped, `> 2` rejected |
+| `storageVersion` | `.storage_version` | L0 handled before this; non-L0 must be `== 2`, else the read fails hard |
 | `columnGroups` | `.binlogs[]` grouped by `fieldID` (slot) | slot = directory name |
-| `cg.fieldIds` | first file of each group via `readFieldIdsFromSchema` | |
-| `cg.filePaths` | group's `log_path` sorted by `log_id` | explicit paths incl. `binlogs/` + groupID levels |
-| `cg.fileRowCounts` | per-file `readRowCount` | gap-closer; `size == paths.size` enforced |
+| `cg.fieldIds` | head file of each group via `readFieldIdsAndRowCount` | |
+| `cg.filePaths` | reconstructed from `backupDir` + IDs (never the meta `log_path`) | `insert_log` carries the groupID level; sorted by `log_id` |
+| `cg.fileRowCounts` | head via combined read, rest via parallel `readRowCount` | gap-closer; `size == paths.size` enforced |
 | `cg.slotFieldId` | group's `fieldID` | used for slot-based dedup |
-| `deltaLogs` | `.deltalogs[].binlogs[]` → `(log_id, log_path)` | `entriesNum = 0` (unused by the decoder) |
-| L0 segment | `is_l0 = true` → empty `columnGroups` + `deltaLogs` | inherited delete-plan path |
+| `deltaLogs` | reconstructed `delta_log` paths from `backupDir` + IDs | `entriesNum = 0` (unused by the decoder) |
+| L0 segment | `is_l0 = true` → empty `columnGroups` + `deltaLogs` | inherited delete-plan path; Milvus creates L0 without a storage version, so it bypasses the V2 filter |
 
 ## 6. Delete Semantics (reuses existing logic)
 
@@ -189,9 +212,14 @@ Behavior:
   and are skipped during partition planning (`skippedDeleteOnlySegments`).
 - Dynamic field `$meta` is preserved via `enableDynamicField`; the packed
   reader tolerates unmapped `$meta` columns.
-- StorageV3 segments are rejected loudly rather than silently mis-read.
-- Local paths (`/data/backup/...`) work for the meta/footer mapping layer
-  (and unit tests); the JNI packed reader itself requires S3 storage.
+- Non-L0 segments that are not StorageV2 (`storage_version != 2`) fail hard on
+  the driver rather than returning a partial dataset. L0 delete-only segments
+  bypass the storage-version check (Milvus creates them without one).
+- The driver validates that the backup meta carries a collection schema with a
+  primary key before planning.
+- Local paths (`/data/backup/...` or `file:///...`) work for the meta/footer
+  mapping layer (and unit tests); the JNI packed reader itself requires S3
+  storage.
 - A backup must contain exactly one collection per datasource read.
 
 ## 8. Usage

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -154,6 +154,12 @@ Behavior:
   inherited delete-plan path).
 - L0 segments produce a `V2SegmentInfo` with empty `columnGroups` plus
   `deltaLogs`, feeding the inherited delete-plan path.
+- Fails hard for a StorageV2 data segment with rows but no binlogs (would
+  otherwise silently drop rows), and for dynamic collections whose meta lacks
+  the `$meta` field (default backups; points at `--backup_index_extra`).
+- `readMeta` reads `full_meta.json` with a bounded reader
+  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and caches the parsed
+  `BackupInfo` per backup dir so table init and scan planning read it once.
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
 
@@ -169,11 +175,13 @@ Behavior:
   `milvus.uri`; enforce snapshot/backup mutual exclusion; return an empty
   schema from inference (callers supply `.schema()`).
 - `MilvusTable`: `isBackupMode`, `initFromBackup()` (materializes the collection
-  schema from the backup meta so metadata rehydration for vector columns works
+  schema and collection id from the backup meta — matched by
+  `milvus.collection.name` — so metadata rehydration for vector columns works
   like snapshot mode), and `schema()` handling for offline modes.
-- `MilvusScan.planInputPartitionsFromBackup()`: reads the meta, validates that
-  it carries a collection schema with a primary key, builds `V2SegmentInfo`,
-  loads delete plans, and hands everything to the shared
+- `MilvusScan.planInputPartitionsFromBackup()`: resolves the collection by name
+  (`resolveBackupCollection`), rejects partition/segment selectors, validates
+  that the meta carries a collection schema with a primary key, builds
+  `V2SegmentInfo`, loads delete plans, and hands everything to the shared
   `buildSnapshotPartitions` with `inlineInheritedDeletePlans = true`.
 - `MilvusScan.pushFilters`: backup mode returns all filters as unsupported
   (the packed-V2 reader has no filter pushdown), matching the packed-V2 snapshot
@@ -214,15 +222,27 @@ Behavior:
 
 - Backups default to a flush, so only disk-resident (flushed) data is read — a
   consistent point-in-time copy, same constraint as snapshot reads.
-- Empty segments / segments without binlogs emit `columnGroups = Seq.empty`
-  and are skipped during partition planning (`skippedDeleteOnlySegments`).
-- Dynamic field `$meta` is preserved via `enableDynamicField`; the packed
-  reader tolerates unmapped `$meta` columns.
+- Empty segments (`num_of_rows == 0`, no binlogs) emit `columnGroups =
+  Seq.empty` and are skipped during partition planning. A StorageV2 data
+  segment with rows but no binlogs fails hard rather than silently dropping
+  rows.
+- Dynamic collections: a default backup (no etcd access) does not record the
+  `$meta` field, so reading it would return null `$meta` rows; such backups are
+  rejected with a pointer to `--backup_index_extra`.
+- `milvus.partition.name` / `milvus.partition.id` / `milvus.segment.id`
+  selectors are rejected (not yet supported); read the whole backup and filter
+  in Spark.
+- The collection is selected by `milvus.collection.name` (never `.head`); when
+  the name is unset and the backup holds multiple collections the read is
+  rejected.
 - Non-L0 segments that are not StorageV2 (`storage_version != 2`) fail hard on
   the driver rather than returning a partial dataset. L0 delete-only segments
   bypass the storage-version check (Milvus creates them without one).
 - The driver validates that the backup meta carries a collection schema with a
-  primary key before planning.
+  primary key before planning. `full_meta.json` is read with a bounded reader
+  (default 64 MiB, overridable via `milvus.snapshot.max.json.bytes`) and cached
+  per backup dir.
+- `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`.
 - Local paths (`/data/backup/...` or `file:///...`) work for the meta/footer
   mapping layer (and unit tests); the JNI packed reader itself requires S3
   storage.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -252,21 +252,26 @@ Behavior:
   primary key before planning, and that the read has at least one packed
   (non-delete-only) segment — an L0-only backup otherwise reads zero rows.
   `full_meta.json` is read with a bounded reader
-  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and **not** cached.
+  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and **not** cached; the
+  parse done at table init is threaded to the scan planner via an internal
+  option, so the meta is read/parsed once per `spark.read`.
 - `toV2Segments` materializes segments only for the resolved `collectionId`, so
   a multi-collection backup never leaks another collection's segments into the
   read.
 - Schema conversion drops system fields by field ID (`0`/`1`), never by name:
   milvus-backup's schema carries only user fields, so a user field literally
   named `RowID`/`Timestamp` survives.
-- `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`; `file:///...`
-  and bare local paths resolve to the same native keys.
+- `milvus.backup.dir` must be an S3 URI (`s3a://`) for reads — local/`file://`
+  dirs are rejected at planning since the JNI packed reader requires S3.
+  `s3://` is normalized to `s3a://` at entry.
 - A dynamic collection whose `$meta` field is present is not duplicated by the
   computed schema.
-- Local paths (`/data/backup/...` or `file:///...`) work for the meta/footer
-  mapping layer (and unit tests); the JNI packed reader itself requires S3
-  storage.
-- A backup must contain exactly one collection per datasource read.
+- Local paths (`/data/backup/...` or `file:///...`) are exercised by the
+  meta/footer mapping layer and unit tests; actual reads require an S3
+  (`s3a://`) backup dir because the JNI packed reader needs S3.
+- The collection to read is resolved by `milvus.database.name` +
+  `milvus.collection.name` (never `.head`); a backup may hold several
+  collections.
 
 ## 8. Usage
 

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -203,7 +203,9 @@ Behavior:
   the shared L0 delete plan **independently from the parsed meta** (not as a
   planning side effect), so a delete-heavy backup is not materialized once per
   segment (O(S×D)) and delete handling does not depend on Spark evaluating
-  partitions first.
+  partitions first. If table init did not parse the meta (e.g. its read failed
+  while the planner's succeeded), the factory falls back to a fresh meta read
+  rather than silently resolving every marker to an empty plan.
 - Shared `buildSnapshotPartitions` dedups each segment's column groups by slot
   (`V2SegmentInfo.dedupColumnGroupsBySlot`) so a field carried by an old
   multi-field group and a newer single-field group (add-field + backfill) is
@@ -261,17 +263,18 @@ Behavior:
   Seq.empty` and are skipped during partition planning. A StorageV2 data
   segment with rows but no binlogs fails hard rather than silently dropping
   rows.
-- **Known external bug — multi-file column groups read short.** The connector
+- **Known external bug — multi-file column groups rejected.** The connector
   feeds per-file row counts to `MilvusStorageColumnGroups.createFromGroups`,
   but milvus-storage's `BuildLoonColumnGroups` (`v2_column_groups_builder.cpp`)
   writes them as group-cumulative `start_index`/`end_index` while
   `ColumnGroupReaderImpl::open` intersects them against per-file row-group
-  offsets, so a column group spanning more than one binlog file returns fewer
-  rows (file `i > 0` truncated, zero when earlier files are at least as large).
-  This also affects the snapshot/backfill read path (they share
-  `createFromGroups`). The fix belongs in milvus-storage (per-file, not
-  cumulative, indices) plus a submodule bump — tracked as a separate task, not
-  in this PR.
+  offsets, so a column group spanning more than one binlog file would return
+  fewer rows (file `i > 0` truncated, zero when earlier files are at least as
+  large). Rather than silently read short, the backup planner **rejects any
+  column group with more than one file** (`buildV2SegmentWithFs`); the fix
+  belongs in milvus-storage (per-file, not cumulative, indices) plus a
+  submodule bump, after which the guard can be removed. The snapshot/backfill
+  path shares `createFromGroups` and is affected by the same bug.
 - Dynamic collections: a default backup (no etcd access) does not record the
   `$meta` field, so reading it would return null `$meta` rows; such backups are
   rejected with a pointer to `--backup_index_extra` (requires milvus-backup

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -89,8 +89,9 @@ Branch precedence: snapshot mode > backup mode > client mode.
 Two gaps versus a Milvus snapshot are closed in `BackupMetaReader`:
 
 1. **Per-file row counts** (`fileRowCounts`) — always recovered from the parquet
-   footers (the meta never carries `entries_num`); the head file is read once
-   via `readFieldIdsAndRowCount`, the remaining files in parallel.
+   footers (the meta never carries `entries_num`); each column group is a single
+   file read once via `readFieldIdsAndRowCount` (multi-file column groups are
+   rejected, see §7).
 2. **Slot → real field ID mapping** — the AVRO segment-info is not copied by
    the backup, so real field IDs are recovered from the **head file** of each
    column group via `readFieldIdsAndRowCount` (all files in a group share the
@@ -176,11 +177,10 @@ Behavior:
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
 
-- New `readRowCount(path, hadoopConf): Either[Throwable, Long]` — sums the
-  row groups' row counts from the parquet footer (a `HEAD` + a single tail
-  `GET`, same cost profile as the existing footer reads).
-- New `readFieldIdsAndRowCount(path, hadoopConf)` — field IDs + row count from
-  a single footer open (avoids opening the head file twice).
+- New `readFieldIdsAndRowCount(path, hadoopConf)` — field IDs + summed row-group
+  row count from a single footer open (a `HEAD` + a single tail `GET`), the only
+  footer-read path the backup planner uses. (A `FileSystem` overload reuses one
+  instance across a read.)
 
 ### 4.4 `src/main/scala/sources/MilvusDataSource.scala`
 
@@ -197,13 +197,15 @@ Behavior:
   `milvus.database.name` + `milvus.collection.name` (`resolveBackupCollection`,
   ambiguous names rejected), rejects partition/segment selectors, validates
   that the meta carries a collection schema with a primary key, builds
-  `V2SegmentInfo`, loads delete plans, and hands everything to the shared
-  `buildSnapshotPartitions` with `inlineInheritedDeletePlans = false`: backup
-  partitions carry a partition-scoped marker and the reader factory computes
-  the shared L0 delete plan **independently from the parsed meta** (not as a
-  planning side effect), so a delete-heavy backup is not materialized once per
-  segment (O(S×D)) and delete handling does not depend on Spark evaluating
-  partitions first. If table init did not parse the meta (e.g. its read failed
+  `V2SegmentInfo`, and hands everything to the shared `buildSnapshotPartitions`
+  with `inlineInheritedDeletePlans = false`: backup partitions carry a
+  partition-scoped marker and the reader factory computes the shared L0 delete
+  plan **independently from the parsed meta** (not as a planning side effect),
+  so a delete-heavy backup is not materialized once per segment (O(S×D)), the
+  L0 delete set is not downloaded/decoded twice, and delete handling does not
+  depend on Spark evaluating partitions first. The planner only stamps the
+  marker's key set (partition IDs); the single full plan load happens in the
+  reader factory. If table init did not parse the meta (e.g. its read failed
   while the planner's succeeded), the factory falls back to a fresh meta read
   rather than silently resolving every marker to an empty plan.
 - Shared `buildSnapshotPartitions` dedups each segment's column groups by slot
@@ -231,7 +233,7 @@ Behavior:
 | `columnGroups` | `.binlogs[]` grouped by `fieldID` (slot) | slot = directory name |
 | `cg.fieldIds` | head file of each group via `readFieldIdsAndRowCount` | |
 | `cg.filePaths` | reconstructed from `backupDir` + IDs (never the meta `log_path`), **bucket-relative** for the native reader | `insert_log` carries the groupID level; sorted by `log_id` |
-| `cg.fileRowCounts` | head via combined read, rest via parallel `readRowCount` | gap-closer; `size == paths.size` enforced |
+| `cg.fileRowCounts` | the single file via `readFieldIdsAndRowCount` | gap-closer; validated to equal `num_of_rows` |
 | `cg.slotFieldId` | group's `fieldID` | used for slot-based dedup |
 | `deltaLogs` | reconstructed `delta_log` paths from `backupDir` + IDs (**qualified**, Hadoop-side) | `entriesNum = 0` (unused by the decoder) |
 | L0 segment | `is_l0 = true` → empty `columnGroups` + `deltaLogs` | inherited delete-plan path; Milvus creates L0 without a storage version, so it bypasses the V2 filter |
@@ -315,9 +317,9 @@ Behavior:
   `s3://` is normalized to `s3a://` at entry. Bucket-root backups and trailing
   double-slashes are handled: the native key never gains a leading slash and
   all trailing slashes are stripped (both would be different S3 keys).
-- Column-group footer reads run on two independent bounded pools (segments vs
-  per-file tail reads) so a segment worker waiting on its tail reads can never
-  deadlock the single pool.
+- Column-group footer reads run on a single bounded pool (`SegmentReadPool`,
+  segment-level parallelism). Multi-file column groups are rejected (see §7),
+  so there are no nested per-file tail reads and therefore no worker-blocks-on-its-own-pool deadlock risk.
 - A dynamic collection whose `$meta` field is present is not duplicated by the
   computed schema.
 - Local paths (`/data/backup/...` or `file:///...`) are exercised by the
@@ -349,7 +351,8 @@ spark.read
   schema round-trip, column-group / row-count recovery against local parquet
   files written with parquet-mr (carrying `PARQUET:field_id`), L0 skipping with
   `applyDeletes = false`, StorageV1/V3 branches, and snapshot-format rejection.
-- `MilvusParquetFooterReaderTest` — `readRowCount` sums row groups.
+- `MilvusParquetFooterReaderTest` — `readFieldIdsAndRowCount` recovers field IDs
+  and sums multiple row groups in one footer open.
 - `MilvusOptionTest` — `isBackupMode` and snapshot/backup mutual exclusion.
 - End-to-end: Milvus 2.6 → `milvus-backup create` → `spark.read` with
   `milvus.backup.dir`, cross-checked against `count(*)` / distinct PKs.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -130,11 +130,12 @@ Parses a binlog-format backup's `meta/full_meta.json` (wire keys match the Go
 ```scala
 object BackupMetaReader {
   def metaPath(backupDir: String): String          // <dir>/meta/full_meta.json
-  def readMeta(hadoopConf: Configuration, backupDir: String): Either[Throwable, BackupInfo]
+  def readMeta(hadoopConf: Configuration, backupDir: String,
+               maxBytes: Long = MaxSnapshotJsonBytes): Either[Throwable, BackupInfo]
   def parse(json: String): Either[Throwable, BackupInfo]
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte]
   def toV2Segments(info: BackupInfo, hadoopConf: Configuration, backupDir: String,
-                   applyDeletes: Boolean = true): Either[Throwable, Seq[V2SegmentInfo]]
+                   applyDeletes: Boolean, collectionId: Long): Either[Throwable, Seq[V2SegmentInfo]]
 }
 ```
 
@@ -242,12 +243,17 @@ Behavior:
   ambiguous across databases, or no name with multiple collections, is
   rejected.
 - Non-L0 segments that are not StorageV2 (`storage_version != 2`) fail hard on
-  the driver rather than returning a partial dataset. L0 delete-only segments
-  bypass the storage-version check (Milvus creates them without one).
+  the driver rather than returning a partial dataset; `0`/absent is reported as
+  StorageV1. L0 delete-only segments bypass the storage-version check (Milvus
+  creates them without one).
 - The driver validates that the backup meta carries a collection schema with a
-  primary key before planning. `full_meta.json` is read with a bounded reader
-  (`milvus.snapshot.max.json.bytes`, default 64 MiB, honored at both read
-  sites) and cached per (backup dir, limit).
+  primary key before planning, and that the read has at least one packed
+  (non-delete-only) segment — an L0-only backup otherwise reads zero rows.
+  `full_meta.json` is read with a bounded reader
+  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and **not** cached.
+- `toV2Segments` materializes segments only for the resolved `collectionId`, so
+  a multi-collection backup never leaks another collection's segments into the
+  read.
 - `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`; `file:///...`
   and bare local paths resolve to the same native keys.
 - A dynamic collection whose `$meta` field is present is not duplicated by the

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -1,0 +1,229 @@
+# Design Doc — milvus-backup as a Milvus Read Data Source (spark-milvus)
+
+**Status:** Implemented
+**Audience:** Milvus / Spark connector / storage-v2 engineers
+**Last updated:** 2026-08-25
+
+## 1. Background & Goals
+
+Milvus 2.6 deployments that cannot use the server snapshot feature (or that want
+a fully offline, client-free read path) currently have no way to read data
+through the connector without a live Proxy connection. `milvus-backup create`
+already produces a byte-identical, point-in-time copy of the flushed binlogs,
+but the connector had no way to consume it.
+
+This change adds a **backup datasource mode**: point the connector at a
+binlog-format milvus-backup export and read it as a Spark DataFrame with the
+existing StorageV2 packed-parquet read stack — no Milvus client connection
+required.
+
+**Goals**
+
+- Input: a backup directory (`milvus.backup.dir`, e.g. `s3a://bucket/backup/<name>`
+  or a local path) produced by `milvus-backup create`.
+- Output: a Spark DataFrame supporting column pruning, `milvus.extra.columns`
+  (`partition`, `$segment_id`, `$row_offset`), and the same delete semantics as
+  snapshot reads (`milvus.read.apply.deletes`).
+- Reuse the existing StorageV2 packed read path (`MilvusPackedV2PartitionReader`
+  + the milvus-storage JNI reader) unchanged.
+- **No changes to milvus-backup**: existing exports work as-is.
+
+**Out of scope**
+
+- StorageV3 (loon manifest) segments.
+- Write / backfill flows and the client snapshot fast path.
+- Snapshot-format backups (`format == "snapshot"`), which bundle a different
+  directory layout and are rejected explicitly.
+
+**Core gap and the chosen approach**
+
+milvus-backup's meta records only `log_size` per binlog, not `entries_num`
+(per-file row count). The packed-V2 reader requires exact per-file row counts to
+derive the `(start_index, end_index)` ranges for each file; missing or wrong
+counts are rejected or silently mis-read. **Approach A**: recover each file's
+row count by reading its parquet footer at planning time. This requires no
+backup-side changes and works on any existing export.
+
+## 2. Verified Key Facts
+
+| Fact | Source |
+|---|---|
+| Backup binlog objects are byte-identical copies of Milvus storage objects | `milvus-backup/core/backup/coll_dml_task.go` (`CopyObjectsTask`) |
+| Backup layout `binlogs/insert_log/{coll}/{part}/{groupID}/{seg}/{field}/{log}`; `groupID` is a virtual partition for restore only | `milvus-backup/internal/storage/mpath/path.go` |
+| Full metadata lives in `meta/full_meta.json` (schema + partitions + segments incl. L0) | `milvus-backup/internal/meta/meta.go`, `meta_builder.go` |
+| `SegmentBackupInfo` carries id / `num_of_rows` / `storage_version` / `group_id` / `is_l0` / `binlogs` / `deltalogs` | `milvus-backup/core/proto/backup.proto` |
+| `Binlog` records only `log_path/log_size/log_id`; `entries_num` exists but is deprecated and unset | `backup.proto`; `coll_dml_task.go` |
+| Packed read requires exact `fileRowCounts` | `MilvusPackedV2PartitionReader.scala`; `v2_column_groups_builder.h` |
+| Real field IDs are recoverable from each parquet file's own schema (`PARQUET:field_id`) | `MilvusParquetFooterReader.readFieldIdsFromSchema` |
+| Delta-log decoding uses only `logPath`; `entriesNum` is unused | `MilvusDeltaLogReader.scala` |
+| L0 (delete-only) segments have no column groups; they feed partition-scoped inherited delete plans | `MilvusDataSource.scala` |
+
+## 3. Overall Design
+
+A new **backup offline mode** sits alongside snapshot mode:
+
+```
+MilvusDataSource / MilvusTable  isBackupMode? ─┐
+                                              ▼
+MilvusScan.computeInputPartitions ──> planInputPartitionsFromBackup()
+                                              │   via BackupMetaReader
+                                              ▼
+                           (schemaBytes, Seq[V2SegmentInfo])
+                                              │   reuse
+                                              ▼
+                    buildSnapshotPartitions() → MilvusPackedV2InputPartition[]
+                                              │
+              createReaderFactory() → MilvusPackedV2PartitionReader (unchanged)
+```
+
+Branch precedence: snapshot mode > backup mode > client mode.
+
+Two gaps versus a Milvus snapshot are closed in `BackupMetaReader`:
+
+1. **Per-file row counts** (`fileRowCounts`) — recovered from each parquet
+   footer via the new `MilvusParquetFooterReader.readRowCount`.
+2. **Slot → real field ID mapping** — the AVRO segment-info is not copied by
+   the backup, so real field IDs are recovered from each parquet file's own
+   schema via the existing `readFieldIdsFromSchema`.
+
+Path resolution: backup `log_path` values are bucket-relative; they are
+resolved with `V2SegmentLoader.resolvePath(logPath, bucket)` to
+`s3a://bucket/...` (or kept local when the bucket is empty). No `groupID`
+reverse-engineering is needed — paths are taken verbatim from the meta.
+
+## 4. Changes
+
+### 4.1 `src/main/scala/MilvusOption.scala`
+
+- New option `MilvusOption.BackupDir = "milvus.backup.dir"`.
+- New helpers `backupDir(options)`, `isBackupMode(options)`, and
+  `validateBackupModeOptions(options)` — backup mode and snapshot mode are
+  mutually exclusive.
+
+### 4.2 `src/main/scala/read/BackupMetaReader.scala` (new — core)
+
+Parses a binlog-format backup's `meta/full_meta.json` (wire keys match the Go
+`encoding/json` tags of `backuppb`) and exposes:
+
+```scala
+object BackupMetaReader {
+  def metaPath(backupDir: String): String          // <dir>/meta/full_meta.json
+  def readMeta(hadoopConf: Configuration, backupDir: String): Either[Throwable, BackupInfo]
+  def parse(json: String): Either[Throwable, BackupInfo]
+  def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte]
+  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, bucket: String,
+                   applyDeletes: Boolean = true): Either[Throwable, Seq[V2SegmentInfo]]
+}
+```
+
+Embedded JSON model mirrors `backuppb.BackupInfo` → `CollectionBackupInfo` →
+`PartitionBackupInfo` / `SegmentBackupInfo` → `FieldBinlog`/`Binlog`, plus
+`CollectionSchema`/`FieldSchema` (a mirror of Milvus `schemapb`, including
+`type_params`, `data_type`, `is_primary_key`, `element_type`, `is_dynamic`,
+`nullable`, and `default_value_base64`).
+
+Behavior:
+
+- Rejects snapshot-format backups and StorageV3 (`storage_version > 2`) segments.
+- Skips StorageV1 (`storage_version < 2`) segments.
+- Skips L0 segments when `applyDeletes = false`.
+- L0 segments produce a `V2SegmentInfo` with empty `columnGroups` plus
+  `deltaLogs`, feeding the inherited delete-plan path.
+
+### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
+
+- New `readRowCount(path, hadoopConf): Either[Throwable, Long]` — sums the
+  row groups' row counts from the parquet footer (a `HEAD` + a single tail
+  `GET`, same cost profile as the existing footer reads).
+
+### 4.4 `src/main/scala/sources/MilvusDataSource.scala`
+
+- `MilvusDataSource.getTable` / `inferSchema`: allow backup mode without
+  `milvus.uri`; enforce snapshot/backup mutual exclusion; return an empty
+  schema from inference (callers supply `.schema()`).
+- `MilvusTable`: `isBackupMode`, `initFromBackup()` (materializes the collection
+  schema from the backup meta so metadata rehydration for vector columns works
+  like snapshot mode), and `schema()` handling for offline modes.
+- `MilvusScan.planInputPartitionsFromBackup()`: reads the meta, builds
+  `V2SegmentInfo`, loads delete plans, and hands everything to the shared
+  `buildSnapshotPartitions` with `inlineInheritedDeletePlans = true`.
+- `MilvusScan.pushFilters`: backup mode returns all filters as unsupported
+  (the packed-V2 reader has no filter pushdown), matching the packed-V2 snapshot
+  path.
+- `MilvusScan.buildSnapshotHadoopConf` refactored into the companion
+  `buildHadoopConfForOptions(rawOptions, path)` so both the planner and table
+  schema rehydration share it.
+
+## 5. Data Mapping (`full_meta.json → V2SegmentInfo`)
+
+| `V2SegmentInfo` | Source | Notes |
+|---|---|---|
+| `segmentId` | `SegmentBackupInfo.segment_id` | |
+| `partitionId` | `.partition_id` | `-1` preserved for L0 / all-partition |
+| `numOfRows` | `.num_of_rows` | |
+| `storageVersion` | `.storage_version` | only `== 2` supported; `< 2` skipped, `> 2` rejected |
+| `columnGroups` | `.binlogs[]` grouped by `fieldID` (slot) | slot = directory name |
+| `cg.fieldIds` | first file of each group via `readFieldIdsFromSchema` | |
+| `cg.filePaths` | group's `log_path` sorted by `log_id` | explicit paths incl. `binlogs/` + groupID levels |
+| `cg.fileRowCounts` | per-file `readRowCount` | gap-closer; `size == paths.size` enforced |
+| `cg.slotFieldId` | group's `fieldID` | used for slot-based dedup |
+| `deltaLogs` | `.deltalogs[].binlogs[]` → `(log_id, log_path)` | `entriesNum = 0` (unused by the decoder) |
+| L0 segment | `is_l0 = true` → empty `columnGroups` + `deltaLogs` | inherited delete-plan path |
+
+## 6. Delete Semantics (reuses existing logic)
+
+- `milvus.read.apply.deletes` (default `true`).
+- L1 data segments with their own `deltalog` → per-segment own delete plan
+  (`loadV2DeletePlans`), attached to that segment's partition.
+- L0 delete-only segments → partition-scoped inherited plans
+  (`loadPartitionScopedDeletePlans`); `partition_id = -1` means
+  collection-wide.
+- At read time, rows are filtered by `(pk, timestamp)` inside the packed-V2
+  reader, matching snapshot-read behavior.
+
+## 7. Edge Cases & Limitations
+
+- Backups default to a flush, so only disk-resident (flushed) data is read — a
+  consistent point-in-time copy, same constraint as snapshot reads.
+- Empty segments / segments without binlogs emit `columnGroups = Seq.empty`
+  and are skipped during partition planning (`skippedDeleteOnlySegments`).
+- Dynamic field `$meta` is preserved via `enableDynamicField`; the packed
+  reader tolerates unmapped `$meta` columns.
+- StorageV3 segments are rejected loudly rather than silently mis-read.
+- Local paths (`/data/backup/...`) work for the meta/footer mapping layer
+  (and unit tests); the JNI packed reader itself requires S3 storage.
+- A backup must contain exactly one collection per datasource read.
+
+## 8. Usage
+
+```scala
+spark.read
+  .format("milvus")
+  .schema(userSchema)
+  .option("milvus.backup.dir", "s3a://bucket/backup/b1")
+  .option("milvus.collection.name", "demo")
+  // reuse the existing fs.* / s3.* options for S3 credentials:
+  .option("fs.address", "localhost:9000")
+  .option("fs.bucket_name", "a-bucket")
+  .option("fs.access_key_id", "minioadmin")
+  .option("fs.access_key_value", "minioadmin")
+  .load()
+```
+
+## 9. Testing
+
+- `BackupMetaReaderTest` — meta parsing from a fixture `full_meta.json`,
+  schema round-trip, column-group / row-count recovery against local parquet
+  files written with parquet-mr (carrying `PARQUET:field_id`), L0 skipping with
+  `applyDeletes = false`, StorageV1/V3 branches, and snapshot-format rejection.
+- `MilvusParquetFooterReaderTest` — `readRowCount` sums row groups.
+- `MilvusOptionTest` — `isBackupMode` and snapshot/backup mutual exclusion.
+- End-to-end: Milvus 2.6 → `milvus-backup create` → `spark.read` with
+  `milvus.backup.dir`, cross-checked against `count(*)` / distinct PKs.
+
+## 10. Out of Scope / Future Work
+
+- StorageV3 (loon) segments: requires milvus-backup to copy `.milvus_manifest`
+  or footer-based layout recovery for V3.
+- Optional: milvus-backup persisting `entries_num` (the connector already
+  falls back to footer reads when the meta lacks it).

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -279,6 +279,13 @@ Behavior:
   `$meta` field, so reading it would return null `$meta` rows; such backups are
   rejected with a pointer to `--backup_index_extra` (requires milvus-backup
   v0.5.13+ to capture `$meta`).
+- Struct-array fields (`struct_array_fields`): the connector's read path does
+  not support Struct/ArrayOfStruct data types end-to-end, so a backup whose
+  schema carries non-empty `struct_array_fields` is **rejected** rather than
+  silently dropping those columns. Full support is tracked separately.
+- A segment whose recovered footer row total disagrees with `num_of_rows` (and
+  segments whose column groups disagree with each other) fail hard on the
+  driver rather than producing short `(start_index, end_index)` ranges.
 - `milvus.partition.name` / `milvus.partition.id` / `milvus.segment.id`
   selectors are rejected (not yet supported); read the whole backup and filter
   in Spark.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -163,7 +163,9 @@ Behavior:
 - `readMeta` reads `full_meta.json` with a bounded reader
   (`milvus.snapshot.max.json.bytes`, default 64 MiB) and keeps **no** cache; the
   parse done at table init is threaded to the scan planner via an internal
-  option, so the meta is read/parsed once per read.
+  option, so the meta is read/parsed once per read. That option never reaches
+  executors: it is stripped from both the per-partition `milvusOption` and the
+  reader-factory options map.
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
 
@@ -268,7 +270,12 @@ Behavior:
   named `RowID`/`Timestamp` survives.
 - `milvus.backup.dir` must be an S3 URI (`s3a://`) for reads — local/`file://`
   dirs are rejected at planning since the JNI packed reader requires S3.
-  `s3://` is normalized to `s3a://` at entry.
+  `s3://` is normalized to `s3a://` at entry. Bucket-root backups and trailing
+  double-slashes are handled: the native key never gains a leading slash and
+  all trailing slashes are stripped (both would be different S3 keys).
+- Column-group footer reads run on two independent bounded pools (segments vs
+  per-file tail reads) so a segment worker waiting on its tail reads can never
+  deadlock the single pool.
 - A dynamic collection whose `$meta` field is present is not duplicated by the
   computed schema.
 - Local paths (`/data/backup/...` or `file:///...`) are exercised by the

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -189,6 +189,8 @@ Behavior:
   (`V2SegmentInfo.dedupColumnGroupsBySlot`) so a field carried by an old
   multi-field group and a newer single-field group (add-field + backfill) is
   read from the newest owner — the same gap the snapshot read path had.
+  `MilvusBackfill.dedupColumnGroupsBySlot` delegates to the same method, so the
+  rule has a single implementation.
 - `MilvusScan.pushFilters`: backup mode returns all filters as unsupported
   (the packed-V2 reader has no filter pushdown), matching the packed-V2 snapshot
   path.
@@ -254,6 +256,9 @@ Behavior:
 - `toV2Segments` materializes segments only for the resolved `collectionId`, so
   a multi-collection backup never leaks another collection's segments into the
   read.
+- Schema conversion drops system fields by field ID (`0`/`1`), never by name:
+  milvus-backup's schema carries only user fields, so a user field literally
+  named `RowID`/`Timestamp` survives.
 - `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`; `file:///...`
   and bare local paths resolve to the same native keys.
 - A dynamic collection whose `$meta` field is present is not duplicated by the

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented
 **Audience:** Milvus / Spark connector / storage-v2 engineers
-**Last updated:** 2026-08-25
+**Last updated:** 2026-08-27
 
 ## 1. Background & Goals
 
@@ -19,8 +19,10 @@ required.
 
 **Goals**
 
-- Input: a backup directory (`milvus.backup.dir`, e.g. `s3a://bucket/backup/<name>`
-  or a local path) produced by `milvus-backup create`.
+- Input: an S3 backup directory (`milvus.backup.dir`, e.g.
+  `s3a://bucket/backup/<name>`) produced by `milvus-backup create`. Local /
+  `file://` dirs are exercised only by the mapping layer and unit tests; reads
+  require S3 because the JNI packed reader does.
 - Output: a Spark DataFrame supporting column pruning, `milvus.extra.columns`
   (`partition`, `$segment_id`, `$row_offset`), and the same delete semantics as
   snapshot reads (`milvus.read.apply.deletes`).
@@ -159,8 +161,9 @@ Behavior:
   otherwise silently drop rows), and for dynamic collections whose meta lacks
   the `$meta` field (default backups; points at `--backup_index_extra`).
 - `readMeta` reads `full_meta.json` with a bounded reader
-  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and caches the parsed
-  `BackupInfo` per backup dir so table init and scan planning read it once.
+  (`milvus.snapshot.max.json.bytes`, default 64 MiB) and keeps **no** cache; the
+  parse done at table init is threaded to the scan planner via an internal
+  option, so the meta is read/parsed once per read.
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
 
@@ -177,8 +180,10 @@ Behavior:
   schema from inference (callers supply `.schema()`).
 - `MilvusTable`: `isBackupMode`, `initFromBackup()` (materializes the collection
   schema and collection id from the backup meta — matched by
-  `milvus.collection.name` — so metadata rehydration for vector columns works
-  like snapshot mode), and `schema()` handling for offline modes.
+  `milvus.database.name` + `milvus.collection.name`; fails loudly when no
+  `.schema()` is supplied and the meta is unreadable — so metadata rehydration
+  for vector columns works like snapshot mode), and `schema()` handling for
+  offline modes.
 - `MilvusScan.planInputPartitionsFromBackup()`: resolves the collection by
   `milvus.database.name` + `milvus.collection.name` (`resolveBackupCollection`,
   ambiguous names rejected), rejects partition/segment selectors, validates
@@ -281,9 +286,9 @@ spark.read
   .schema(userSchema)
   .option("milvus.backup.dir", "s3a://bucket/backup/b1")
   .option("milvus.collection.name", "demo")
-  // reuse the existing fs.* / s3.* options for S3 credentials:
+  // reuse the existing fs.* options for S3 credentials. The bucket comes from
+  // the milvus.backup.dir URI (URI wins), so fs.bucket_name need not be set:
   .option("fs.address", "localhost:9000")
-  .option("fs.bucket_name", "a-bucket")
   .option("fs.access_key_id", "minioadmin")
   .option("fs.access_key_value", "minioadmin")
   .load()

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -169,10 +169,10 @@ Behavior:
   the `$meta` field (default backups; points at `--backup_index_extra`).
 - `readMeta` reads `full_meta.json` with a bounded reader
   (`milvus.snapshot.max.json.bytes`, default 64 MiB) and keeps **no** cache; the
-  parse done at table init is threaded to the scan planner via an internal
-  option, so the meta is read/parsed once per read. That option never reaches
-  executors: it is stripped from both the per-partition `milvusOption` and the
-  reader-factory options map.
+  meta is parsed once at table init and the parsed `BackupInfo` is threaded
+  directly to the scan planner (never via options, so it is neither
+  re-serialized nor shipped to executors); a direct scan falls back to a fresh
+  read.
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
 
@@ -198,7 +198,10 @@ Behavior:
   ambiguous names rejected), rejects partition/segment selectors, validates
   that the meta carries a collection schema with a primary key, builds
   `V2SegmentInfo`, loads delete plans, and hands everything to the shared
-  `buildSnapshotPartitions` with `inlineInheritedDeletePlans = true`.
+  `buildSnapshotPartitions` with `inlineInheritedDeletePlans = false`: backup
+  partitions carry a partition-scoped marker and the reader factory resolves
+  the L0 delete plan from a single shared map, so a delete-heavy backup is not
+  materialized once per segment (O(S×D)).
 - Shared `buildSnapshotPartitions` dedups each segment's column groups by slot
   (`V2SegmentInfo.dedupColumnGroupsBySlot`) so a field carried by an old
   multi-field group and a newer single-field group (add-field + backfill) is
@@ -276,8 +279,8 @@ Behavior:
   (non-delete-only) segment — an L0-only backup otherwise reads zero rows.
   `full_meta.json` is read with a bounded reader
   (`milvus.snapshot.max.json.bytes`, default 64 MiB) and **not** cached; the
-  parse done at table init is threaded to the scan planner via an internal
-  option, so the meta is read/parsed once per `spark.read`.
+  meta is parsed once at table init and the parsed `BackupInfo` is threaded
+  directly to the scan planner, so it is read/parsed once per `spark.read`.
 - `toV2Segments` materializes segments only for the resolved `collectionId`, so
   a multi-collection backup never leaks another collection's segments into the
   read.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -259,6 +259,17 @@ Behavior:
   Seq.empty` and are skipped during partition planning. A StorageV2 data
   segment with rows but no binlogs fails hard rather than silently dropping
   rows.
+- **Known external bug — multi-file column groups read short.** The connector
+  feeds per-file row counts to `MilvusStorageColumnGroups.createFromGroups`,
+  but milvus-storage's `BuildLoonColumnGroups` (`v2_column_groups_builder.cpp`)
+  writes them as group-cumulative `start_index`/`end_index` while
+  `ColumnGroupReaderImpl::open` intersects them against per-file row-group
+  offsets, so a column group spanning more than one binlog file returns fewer
+  rows (file `i > 0` truncated, zero when earlier files are at least as large).
+  This also affects the snapshot/backfill read path (they share
+  `createFromGroups`). The fix belongs in milvus-storage (per-file, not
+  cumulative, indices) plus a submodule bump — tracked as a separate task, not
+  in this PR.
 - Dynamic collections: a default backup (no etcd access) does not record the
   `$meta` field, so reading it would return null `$meta` rows; such backups are
   rejected with a pointer to `--backup_index_extra` (requires milvus-backup

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -199,9 +199,11 @@ Behavior:
   that the meta carries a collection schema with a primary key, builds
   `V2SegmentInfo`, loads delete plans, and hands everything to the shared
   `buildSnapshotPartitions` with `inlineInheritedDeletePlans = false`: backup
-  partitions carry a partition-scoped marker and the reader factory resolves
-  the L0 delete plan from a single shared map, so a delete-heavy backup is not
-  materialized once per segment (O(S×D)).
+  partitions carry a partition-scoped marker and the reader factory computes
+  the shared L0 delete plan **independently from the parsed meta** (not as a
+  planning side effect), so a delete-heavy backup is not materialized once per
+  segment (O(S×D)) and delete handling does not depend on Spark evaluating
+  partitions first.
 - Shared `buildSnapshotPartitions` dedups each segment's column groups by slot
   (`V2SegmentInfo.dedupColumnGroupsBySlot`) so a field carried by an old
   multi-field group and a newer single-field group (add-field + backfill) is

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -178,11 +178,16 @@ Behavior:
   schema and collection id from the backup meta — matched by
   `milvus.collection.name` — so metadata rehydration for vector columns works
   like snapshot mode), and `schema()` handling for offline modes.
-- `MilvusScan.planInputPartitionsFromBackup()`: resolves the collection by name
-  (`resolveBackupCollection`), rejects partition/segment selectors, validates
+- `MilvusScan.planInputPartitionsFromBackup()`: resolves the collection by
+  `milvus.database.name` + `milvus.collection.name` (`resolveBackupCollection`,
+  ambiguous names rejected), rejects partition/segment selectors, validates
   that the meta carries a collection schema with a primary key, builds
   `V2SegmentInfo`, loads delete plans, and hands everything to the shared
   `buildSnapshotPartitions` with `inlineInheritedDeletePlans = true`.
+- Shared `buildSnapshotPartitions` dedups each segment's column groups by slot
+  (`V2SegmentInfo.dedupColumnGroupsBySlot`) so a field carried by an old
+  multi-field group and a newer single-field group (add-field + backfill) is
+  read from the newest owner — the same gap the snapshot read path had.
 - `MilvusScan.pushFilters`: backup mode returns all filters as unsupported
   (the packed-V2 reader has no filter pushdown), matching the packed-V2 snapshot
   path.
@@ -232,17 +237,21 @@ Behavior:
 - `milvus.partition.name` / `milvus.partition.id` / `milvus.segment.id`
   selectors are rejected (not yet supported); read the whole backup and filter
   in Spark.
-- The collection is selected by `milvus.collection.name` (never `.head`); when
-  the name is unset and the backup holds multiple collections the read is
+- The collection is selected by `milvus.database.name` +
+  `milvus.collection.name` (never `.head`); an unqualified name that is
+  ambiguous across databases, or no name with multiple collections, is
   rejected.
 - Non-L0 segments that are not StorageV2 (`storage_version != 2`) fail hard on
   the driver rather than returning a partial dataset. L0 delete-only segments
   bypass the storage-version check (Milvus creates them without one).
 - The driver validates that the backup meta carries a collection schema with a
   primary key before planning. `full_meta.json` is read with a bounded reader
-  (default 64 MiB, overridable via `milvus.snapshot.max.json.bytes`) and cached
-  per backup dir.
-- `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`.
+  (`milvus.snapshot.max.json.bytes`, default 64 MiB, honored at both read
+  sites) and cached per (backup dir, limit).
+- `milvus.backup.dir` normalizes the `s3://` alias to `s3a://`; `file:///...`
+  and bare local paths resolve to the same native keys.
+- A dynamic collection whose `$meta` field is present is not duplicated by the
+  computed schema.
 - Local paths (`/data/backup/...` or `file:///...`) work for the meta/footer
   mapping layer (and unit tests); the JNI packed reader itself requires S3
   storage.

--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -103,9 +103,15 @@ delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}          (part =
 
 The `groupID` level is always present for `insert_log` (it is the virtual
 partition id; `0` for `partition_id == -1`) and present for L1 `delta_log`
-only when `partition_id != -1`. The bucket always comes from the
-`milvus.backup.dir` URI (S3 only); `fs.bucket_name` plays no part in path
-resolution.
+only when `partition_id != -1`. Two path forms are produced:
+
+- **Qualified** (`s3a://bucket/backup/b1/binlogs/...`) for the Hadoop-side
+  reads (parquet footers, delta logs, meta).
+- **Bucket-relative keys** (`backup/b1/binlogs/...`) for the milvus-storage
+  native packed reader: its `FilesystemCache::resolve_config` rejects
+  scheme-qualified URIs (demanding `extfs.*` config), and the filesystem proxy
+  prepends `fs.bucket_name`. The connector therefore canonicalizes
+  `fs.bucket_name` to the backup URI's bucket for the native reader.
 
 ## 4. Changes
 
@@ -187,10 +193,10 @@ Behavior:
 | `storageVersion` | `.storage_version` | L0 handled before this; non-L0 must be `== 2`, else the read fails hard |
 | `columnGroups` | `.binlogs[]` grouped by `fieldID` (slot) | slot = directory name |
 | `cg.fieldIds` | head file of each group via `readFieldIdsAndRowCount` | |
-| `cg.filePaths` | reconstructed from `backupDir` + IDs (never the meta `log_path`) | `insert_log` carries the groupID level; sorted by `log_id` |
+| `cg.filePaths` | reconstructed from `backupDir` + IDs (never the meta `log_path`), **bucket-relative** for the native reader | `insert_log` carries the groupID level; sorted by `log_id` |
 | `cg.fileRowCounts` | head via combined read, rest via parallel `readRowCount` | gap-closer; `size == paths.size` enforced |
 | `cg.slotFieldId` | group's `fieldID` | used for slot-based dedup |
-| `deltaLogs` | reconstructed `delta_log` paths from `backupDir` + IDs | `entriesNum = 0` (unused by the decoder) |
+| `deltaLogs` | reconstructed `delta_log` paths from `backupDir` + IDs (**qualified**, Hadoop-side) | `entriesNum = 0` (unused by the decoder) |
 | L0 segment | `is_l0 = true` → empty `columnGroups` + `deltaLogs` | inherited delete-plan path; Milvus creates L0 without a storage version, so it bypasses the V2 filter |
 
 ## 6. Delete Semantics (reuses existing logic)

--- a/docs/backup-datasource-plan.md
+++ b/docs/backup-datasource-plan.md
@@ -134,4 +134,4 @@ Hadoop 侧读（footer/meta/delta）用带 scheme 的 URI（`s3a://...`）；原
 ## 9. 不在本次范围 / 后续可选
 
 - StorageV3(loon) 段：需 milvus-backup 拷贝 `.milvus_manifest` 或 footer 反推 V3 布局。
-- 方案 B：milvus-backup 填充 `entries_num`（连接器留 fallback：meta 有则优先，无则读 footer）。
+- 方案 B：milvus-backup 填充 `entries_num`（**已实现：连接器总是读 footer 行数，不优先 meta 的 entries_num**；若未来 milvus-backup 填充该字段，可加"有则用"的 fallback）。

--- a/docs/backup-datasource-plan.md
+++ b/docs/backup-datasource-plan.md
@@ -1,0 +1,123 @@
+# 实现计划：milvus-backup 作为 Milvus 读数据源（spark-milvus）
+
+## 1. 背景与目标
+
+**场景**：Milvus 2.6，无 snapshot 可用。希望用 `milvus-backup create` 的产物（binlog 格式备份）作为 spark-milvus 的只读数据源，替代 client / snapshot 读，提供一致的离线读能力。
+
+**目标**：
+- 输入：一个 backup 目录（`milvus.backup.dir`，形如 `s3a://bucket/backup/<name>` 或本地路径）。
+- 输出：Spark DataFrame，支持列裁剪、`milvus.extra.columns`（partition / `$segment_id` / `$row_offset`）、删除语义（apply deletes）。
+- 完全复用现有 StorageV2 packed read 栈（`MilvusPackedV2PartitionReader` + milvus-storage JNI），**不改 milvus-backup**。
+- **排除**：StorageV3(loon manifest) 段、写入/回填、client snapshot 快路径。
+
+**核心缺口与方案**：backup meta 的 `Binlog` 只写 `log_path/log_size/log_id`，`entries_num`（每文件行数）未填充；而 packed 读要求精确的 `fileRowCounts`（累加出 `(start_index,end_index)`，缺失即拒/错读）。**方案 A：连接器读各 parquet footer 的总行数补齐**，对现有 backup 零改动。
+
+## 2. 关键事实（已核实）
+
+| 事实 | 出处 |
+|---|---|
+| backup 的 binlog 对象与 Milvus 存储逐字节一致 | `milvus-backup/core/backup/coll_dml_task.go:511-546`（CopyObjectsTask 原样复制） |
+| backup 布局 `binlogs/insert_log/{coll}/{part}/{groupID}/{seg}/{field}/{log}`；`groupID` 为虚拟 partition，仅 restore 用 | `milvus-backup/internal/storage/mpath/path.go:17-26, 288-297` |
+| 完整 meta 在 `meta/full_meta.json`（schema + partitions + segments + L0） | `milvus-backup/internal/meta/meta.go:129-139`；`meta_builder.go:327-337` |
+| `SegmentBackupInfo`：id / `num_of_rows` / `storage_version` / `group_id` / `is_l0` / `binlogs` / `deltalogs` | `milvus-backup/core/proto/backup.proto:102-120` |
+| `Binlog` 仅填 `log_path/log_size/log_id`，`entries_num` 字段存在但 deprecate 未填充 | `backup.proto:494-501`；`coll_dml_task.go:101,131` |
+| packed 读要求 `fileRowCounts` 精确 | `src/main/scala/read/MilvusPackedV2PartitionReader.scala:253-260`；`milvus-storage/cpp/include/milvus-storage/ffi_internal/v2_column_groups_builder.h:35-43` |
+| 真实 field ID 可从 parquet 自带 schema 的 `PARQUET:field_id` 恢复 | `src/main/scala/read/MilvusParquetFooterReader.readFieldIdsFromSchema` |
+| delta log 解码只用 `logPath`，`entriesNum` 不参与 | `src/main/scala/read/MilvusDeltaLogReader.scala:127-145` |
+| L0 段无 column groups、只有 delta log → inherited partition 级 delete plan | `src/main/scala/sources/MilvusDataSource.scala:1628-1662, 2269-2303` |
+
+## 3. 总体设计
+
+新增 **backup 离线模式**，与 snapshot 模式平级：
+
+```
+MilvusDataSource / MilvusTable  isBackupMode? ─┐
+                                              ▼
+MilvusScan.computeInputPartitions ──> planInputPartitionsFromBackup()
+                                              │  用 BackupMetaReader 产出
+                                              ▼
+                           (schemaBytes, Seq[V2SegmentInfo])
+                                              │  复用
+                                              ▼
+                    buildSnapshotPartitions() → MilvusPackedV2InputPartition[]
+                                              │
+              createReaderFactory() → MilvusPackedV2PartitionReader（不变）
+```
+
+分支优先级：`isSnapshotMode` > `isBackupMode` > client。
+
+## 4. 改动文件清单
+
+### 4.1 `src/main/scala/MilvusOption.scala`
+- 新增 `MilvusOption.BackupDir = "milvus.backup.dir"`。
+- 新增 `isBackupMode(options)`：`BackupDir` 非空即开启。
+- `MilvusDataSource.getTable/inferSchema`：backup 模式下允许无 `milvus.uri`；`validateSnapshotModeOptions` 处新增 snapshot/backup 互斥校验。
+- S3 配置复用现有 `fs.*` / `s3.*`。
+
+### 4.2 新增 `src/main/scala/read/BackupMetaReader.scala`（核心）
+Jackson 解析 backup `full_meta.json`（仿 `MilvusSnapshotReader`），对外：
+```scala
+object BackupMetaReader {
+  def readMeta(hadoopConf: Configuration, backupDir: String): Either[Throwable, BackupInfo]
+  def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte]
+  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, bucket: String, applyDeletes: Boolean): Either[Throwable, Seq[V2SegmentInfo]]
+}
+```
+内嵌 JSON 模型：`BackupInfo`、`CollectionBackupInfo`、`PartitionBackupInfo`、`SegmentBackupInfo`、`FieldBinlog`、`Binlog`、`CollectionSchema`/`FieldSchema`（镜像 schemapb，含 `type_params`、`data_type`、`is_primary_key`、`element_type`、`is_dynamic`、`nullable` 等）。
+
+### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
+- 新增 `readRowCount(path, hadoopConf): Either[Throwable, Long]`：`ParquetFileReader.getFooter.getBlocks` 求和（每文件总行数），复用现有 `readWithFileSystem`。
+
+### 4.4 `src/main/scala/sources/MilvusDataSource.scala`
+- `MilvusTable.isBackupMode` → `initFromBackup()`（跳过 client，schema 由 `BackupMetaReader` 或用户 `.schema()` 提供）。
+- `MilvusScan.planInputPartitionsFromBackup()`：
+  1. 构建 backup bucket hadoop conf（复用 `buildSnapshotHadoopConf`）。
+  2. `BackupMetaReader.readMeta` → schema bytes + `V2SegmentInfo`。
+  3. 复用 `loadV2DeletePlans`（L1 段）与 `loadPartitionScopedDeletePlans`（L0 段）。
+  4. 调用现有 `buildSnapshotPartitions(v2Segments=..., v2DeletePlans=...)`。
+
+## 5. 数据映射（`full_meta.json → V2SegmentInfo`）
+
+| `V2SegmentInfo` | 来源 | 备注 |
+|---|---|---|
+| `segmentId` | `SegmentBackupInfo.segment_id` | |
+| `partitionId` | `.partition_id` | part=-1 保留（L0/全分区） |
+| `numOfRows` | `.num_of_rows` | |
+| `storageVersion` | `.storage_version` | 仅支持 ==2；>2 报错，<2 跳过 |
+| `columnGroups` | `.binlogs[]` 按 `field_id`(slot) 分组 | slot 即目录名 |
+| `cg.fieldIds` | 每组首个文件 `readFieldIdsFromSchema` | |
+| `cg.filePaths` | 组内 `log_path` 按 `log_id` 升序 | 路径显式，含 `binlogs/` 与 groupID 层级，直接解析 |
+| `cg.fileRowCounts` | 每组每文件 `readRowCount` | **方案 A 补齐**；`size==paths.size` 校验 |
+| `cg.slotFieldId` | 组的 `field_id` | 供 slot 去重 |
+| `deltaLogs` | `.deltalogs[].binlogs[]` → `(log_id, log_path)` | `entriesNum=0`（解码不使用） |
+| L0 段 | `is_l0=true` → `columnGroups=Seq.empty` + deltaLogs | 走 inherited plan |
+
+路径解析：`V2SegmentLoader.resolvePath(logPath, bucket)` 加 `s3a://bucket/`；不做 groupID 反推。
+
+## 6. 删除语义（复用现有逻辑）
+
+- `milvus.read.apply.deletes`（默认 true）。
+- L1 段 `delta_log` → `loadV2DeletePlans`（段级 plan）。
+- L0 段 → `loadPartitionScopedDeletePlans`（`-1` = 全集合删除）。
+- 读时按 `(pk, timestamp)` 在 packed reader 内过滤（`isDeleted`）。
+
+## 7. 边界与限制
+
+- backup 默认 flush，仅含落盘数据；一致时间点快照，与 snapshot 读语义一致。
+- 空段/无 binlog：`columnGroups=Seq.empty`，planning 跳过（沿用 `skippedDeleteOnlySegments`）。
+- 动态字段 `$meta`：保留 `enableDynamicField` 与 `$meta`（packed 读 `ToleratedUnmappedColumns` 容忍）。
+- V3 段直接报"不支持"，避免静默读错。
+- 本地路径（`/data/backup/xxx`）走本地 FS，便于 dev/test。
+
+## 8. 测试计划
+
+1. **单元测试**
+   - `BackupMetaReaderSpec`：fixture `full_meta.json`（1 个 L1 段 + 1 个 L0 段 + 多列分组）→ 断言 schema bytes、`V2SegmentInfo` 的 fieldIds/filePaths/排序、L0 空 columnGroups。
+   - `readRowCountSpec`：本地 parquet 行数正确性。
+2. **集成脚本**（仿现有 demo）：MinIO + Milvus 2.6 → 灌数据/flush → `milvus-backup create -n b1` → `spark.read.format(...).options("milvus.backup.dir", ...)`，对比 `count(*)` 与 distinct PK。
+3. **回归**：snapshot 模式、client 读不受影响。
+
+## 9. 不在本次范围 / 后续可选
+
+- StorageV3(loon) 段：需 milvus-backup 拷贝 `.milvus_manifest` 或 footer 反推 V3 布局。
+- 方案 B：milvus-backup 填充 `entries_num`（连接器留 fallback：meta 有则优先，无则读 footer）。

--- a/docs/backup-datasource-plan.md
+++ b/docs/backup-datasource-plan.md
@@ -1,6 +1,6 @@
 # 实现计划：milvus-backup 作为 Milvus 读数据源（spark-milvus）
 
-> **⚠️ 已废弃 / SUPERSEDED**：本文件是**首个提交**时的实现计划，此后 8 轮 review 修正了大量设计（路径重建、L0/storage_version 处理、非 S3 拒绝、collection 匹配、meta 单次解析等），本文多处已与实现**相反**。
+> **⚠️ 已废弃 / SUPERSEDED**：本文件是**首个提交**时的实现计划，此后 11 轮 review 修正了大量设计（路径重建、L0/storage_version 处理、非 S3 拒绝、collection 匹配、meta 单次解析、**一致性语义**、动态字段最低版本等），本文多处已与实现**相反**。
 > **请以 [`docs/backup-datasource-design.md`](backup-datasource-design.md)（英文、持续更新、已实现）为准。** 尤其不要按本文件 §5 的"直接解析 `log_path` / 不做 groupID 反推"实现——`log_path` 是原始 Milvus 源 key，照做会把读打到源集群对象路径上。
 
 ## 1. 背景与目标
@@ -116,7 +116,7 @@ Hadoop 侧读（footer/meta/delta）用带 scheme 的 URI（`s3a://...`）；原
 
 ## 7. 边界与限制
 
-- backup 默认 flush，仅含落盘数据；一致时间点快照，与 snapshot 读语义一致。
+- **一致性（已实现，与初稿相反）**：backup 默认 flush，仅含落盘数据，但**不是** server 强制的事务一致点时间视图——GC-pause 为 best-effort（可能静默失败，#1119）、各集合各自 flush 时间戳、skipFlush 不 flush，GC/压缩竞态可撕裂。**不可当作 cutover/对账真值**（那才是 snapshot 的保证）。详见 `docs/backup-datasource-design.md` §7。
 - 空段/无 binlog：`num_of_rows == 0` 且无 binlogs 才发射空 `columnGroups`；有行数但无 binlogs 硬失败。
 - 动态字段 `$meta`（**已实现**）：meta 无 `$meta` 记录（默认 backup 无 etcd 访问）时**拒绝读取**并提示 `--backup_index_extra`；有记录则正常保留。
 - 非 L0 且非 StorageV2 段硬失败；L0 段无版本也保留（删除语义）。

--- a/docs/backup-datasource-plan.md
+++ b/docs/backup-datasource-plan.md
@@ -1,5 +1,8 @@
 # 实现计划：milvus-backup 作为 Milvus 读数据源（spark-milvus）
 
+> **⚠️ 已废弃 / SUPERSEDED**：本文件是**首个提交**时的实现计划，此后 8 轮 review 修正了大量设计（路径重建、L0/storage_version 处理、非 S3 拒绝、collection 匹配、meta 单次解析等），本文多处已与实现**相反**。
+> **请以 [`docs/backup-datasource-design.md`](backup-datasource-design.md)（英文、持续更新、已实现）为准。** 尤其不要按本文件 §5 的"直接解析 `log_path` / 不做 groupID 反推"实现——`log_path` 是原始 Milvus 源 key，照做会把读打到源集群对象路径上。
+
 ## 1. 背景与目标
 
 **场景**：Milvus 2.6，无 snapshot 可用。希望用 `milvus-backup create` 的产物（binlog 格式备份）作为 spark-milvus 的只读数据源，替代 client / snapshot 读，提供一致的离线读能力。
@@ -58,9 +61,11 @@ MilvusScan.computeInputPartitions ──> planInputPartitionsFromBackup()
 Jackson 解析 backup `full_meta.json`（仿 `MilvusSnapshotReader`），对外：
 ```scala
 object BackupMetaReader {
-  def readMeta(hadoopConf: Configuration, backupDir: String): Either[Throwable, BackupInfo]
+  def readMeta(hadoopConf: Configuration, backupDir: String,
+               maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes): Either[Throwable, BackupInfo]
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte]
-  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, bucket: String, applyDeletes: Boolean): Either[Throwable, Seq[V2SegmentInfo]]
+  def toV2Segments(info: BackupInfo, hadoopConf: Configuration, backupDir: String,
+                   applyDeletes: Boolean, collectionId: Long): Either[Throwable, Seq[V2SegmentInfo]]
 }
 ```
 内嵌 JSON 模型：`BackupInfo`、`CollectionBackupInfo`、`PartitionBackupInfo`、`SegmentBackupInfo`、`FieldBinlog`、`Binlog`、`CollectionSchema`/`FieldSchema`（镜像 schemapb，含 `type_params`、`data_type`、`is_primary_key`、`element_type`、`is_dynamic`、`nullable` 等）。
@@ -83,16 +88,24 @@ object BackupMetaReader {
 | `segmentId` | `SegmentBackupInfo.segment_id` | |
 | `partitionId` | `.partition_id` | part=-1 保留（L0/全分区） |
 | `numOfRows` | `.num_of_rows` | |
-| `storageVersion` | `.storage_version` | 仅支持 ==2；>2 报错，<2 跳过 |
+| `storageVersion` | `.storage_version` | **已实现**：L0 段（无版本/`0`）在版本过滤前处理；非 L0 非 V2 一律硬失败（`0`/absent 即 StorageV1） |
 | `columnGroups` | `.binlogs[]` 按 `field_id`(slot) 分组 | slot 即目录名 |
-| `cg.fieldIds` | 每组首个文件 `readFieldIdsFromSchema` | |
-| `cg.filePaths` | 组内 `log_path` 按 `log_id` 升序 | 路径显式，含 `binlogs/` 与 groupID 层级，直接解析 |
-| `cg.fileRowCounts` | 每组每文件 `readRowCount` | **方案 A 补齐**；`size==paths.size` 校验 |
-| `cg.slotFieldId` | 组的 `field_id` | 供 slot 去重 |
-| `deltaLogs` | `.deltalogs[].binlogs[]` → `(log_id, log_path)` | `entriesNum=0`（解码不使用） |
+| `cg.fieldIds` | 每组首个文件 `readFieldIdsAndRowCount` | 单次打开同时取 fieldIDs 与行数 |
+| `cg.filePaths` | **已实现：从 `backupDir`+IDs 重建**（见下），绝不使用 meta 的 `log_path` | 原生 reader 用 bucket 相对 key；Hadoop 读用带 scheme URI |
+| `cg.fileRowCounts` | 首文件合并读取 + 其余并行 `readRowCount` | **方案 A 补齐**；`size==paths.size` 校验 |
+| `cg.slotFieldId` | 组的 `field_id` | 读路径按 slot 去重（`dedupColumnGroupsBySlot`） |
+| `deltaLogs` | **已实现：从 `backupDir`+IDs 重建**；`partitionId != -1` 含 group 层级 | `entriesNum=0`（解码不使用） |
 | L0 段 | `is_l0=true` → `columnGroups=Seq.empty` + deltaLogs | 走 inherited plan |
 
-路径解析：`V2SegmentLoader.resolvePath(logPath, bucket)` 加 `s3a://bucket/`；不做 groupID 反推。
+路径解析（**已实现**，与初稿相反）：meta 的 `log_path` 是原始 Milvus 源 key，**不能直接解析**。备份对象路径按 milvus-backup 的 `DestKey` 布局从 `backupDir` + collection/partition/group/segment/field/log ID **重建**：
+
+```
+insert: {backupDir}/binlogs/insert_log/{coll}/{part}/{group}/{seg}/{field}/{log}
+delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}          (part == -1)
+        {backupDir}/binlogs/delta_log/{coll}/{part}/{group}/{seg}/{log}  (part != -1)
+```
+
+Hadoop 侧读（footer/meta/delta）用带 scheme 的 URI（`s3a://...`）；原生 JNI reader 的 `filePaths` 用 bucket 相对 key，`fs.bucket_name` 由 backup URI 规范化。**读必须用 S3（`s3a://`）backup dir，本地/`file://` 在规划期被拒绝。**
 
 ## 6. 删除语义（复用现有逻辑）
 
@@ -104,10 +117,11 @@ object BackupMetaReader {
 ## 7. 边界与限制
 
 - backup 默认 flush，仅含落盘数据；一致时间点快照，与 snapshot 读语义一致。
-- 空段/无 binlog：`columnGroups=Seq.empty`，planning 跳过（沿用 `skippedDeleteOnlySegments`）。
-- 动态字段 `$meta`：保留 `enableDynamicField` 与 `$meta`（packed 读 `ToleratedUnmappedColumns` 容忍）。
-- V3 段直接报"不支持"，避免静默读错。
-- 本地路径（`/data/backup/xxx`）走本地 FS，便于 dev/test。
+- 空段/无 binlog：`num_of_rows == 0` 且无 binlogs 才发射空 `columnGroups`；有行数但无 binlogs 硬失败。
+- 动态字段 `$meta`（**已实现**）：meta 无 `$meta` 记录（默认 backup 无 etcd 访问）时**拒绝读取**并提示 `--backup_index_extra`；有记录则正常保留。
+- 非 L0 且非 StorageV2 段硬失败；L0 段无版本也保留（删除语义）。
+- 本地路径（`/data/backup/xxx` / `file://`）：仅 meta/footer 映射层与单测可用；**实际读在规划期拒绝**（JNI reader 需 S3）。
+- collection 按 `milvus.database.name` + `milvus.collection.name` 匹配（`default` 与空库名等价），不允许 `.head` 兜底。
 
 ## 8. 测试计划
 

--- a/docs/backup-datasource-plan.md
+++ b/docs/backup-datasource-plan.md
@@ -1,64 +1,81 @@
-# 实现计划：milvus-backup 作为 Milvus 读数据源（spark-milvus）
+# Implementation Plan — milvus-backup as a Milvus Read Data Source (spark-milvus)
 
-> **⚠️ 已废弃 / SUPERSEDED**：本文件是**首个提交**时的实现计划，此后 11 轮 review 修正了大量设计（路径重建、L0/storage_version 处理、非 S3 拒绝、collection 匹配、meta 单次解析、**一致性语义**、动态字段最低版本等），本文多处已与实现**相反**。
-> **请以 [`docs/backup-datasource-design.md`](backup-datasource-design.md)（英文、持续更新、已实现）为准。** 尤其不要按本文件 §5 的"直接解析 `log_path` / 不做 groupID 反推"实现——`log_path` 是原始 Milvus 源 key，照做会把读打到源集群对象路径上。
+> **⚠️ SUPERSEDED**: This file is the implementation plan from the **first commit**. Eleven
+> subsequent review rounds corrected large parts of the design (path reconstruction,
+> L0/storage_version handling, non-S3 rejection, collection matching, single meta parse,
+> **consistency semantics**, dynamic-field minimum version, and more); much of this document
+> now contradicts the implementation.
+> **Please treat [`docs/backup-datasource-design.md`](backup-datasource-design.md) (English,
+> continuously updated, implemented) as authoritative.** In particular, do NOT implement
+> §5's "parse `log_path` directly / no groupID reverse-engineering" — `log_path` is the
+> original Milvus source key; following it would point reads at the source cluster's objects.
 
-## 1. 背景与目标
+## 1. Background & Goals
 
-**场景**：Milvus 2.6，无 snapshot 可用。希望用 `milvus-backup create` 的产物（binlog 格式备份）作为 spark-milvus 的只读数据源，替代 client / snapshot 读，提供一致的离线读能力。
+**Scenario**: Milvus 2.6 with no snapshot available. Use `milvus-backup create`'s output
+(a binlog-format backup) as a read-only data source for spark-milvus, in place of the client /
+snapshot read, providing an offline read capability.
 
-**目标**：
-- 输入：一个 backup 目录（`milvus.backup.dir`，形如 `s3a://bucket/backup/<name>` 或本地路径）。
-- 输出：Spark DataFrame，支持列裁剪、`milvus.extra.columns`（partition / `$segment_id` / `$row_offset`）、删除语义（apply deletes）。
-- 完全复用现有 StorageV2 packed read 栈（`MilvusPackedV2PartitionReader` + milvus-storage JNI），**不改 milvus-backup**。
-- **排除**：StorageV3(loon manifest) 段、写入/回填、client snapshot 快路径。
+**Goals**:
+- Input: an S3 backup directory (`milvus.backup.dir`, e.g. `s3a://bucket/backup/<name>`).
+  Local / `file://` dirs are exercised by the meta/footer mapping layer and unit tests only;
+  actual reads require S3 (see §7).
+- Output: a Spark DataFrame with column pruning, `milvus.extra.columns` (partition /
+  `$segment_id` / `$row_offset`), and delete semantics (apply deletes).
+- Reuse the existing StorageV2 packed read stack (`MilvusPackedV2PartitionReader` +
+  milvus-storage JNI) — **no changes to milvus-backup**.
+- **Excluded**: StorageV3 (loon manifest) segments, write/backfill, the client snapshot fast path.
 
-**核心缺口与方案**：backup meta 的 `Binlog` 只写 `log_path/log_size/log_id`，`entries_num`（每文件行数）未填充；而 packed 读要求精确的 `fileRowCounts`（累加出 `(start_index,end_index)`，缺失即拒/错读）。**方案 A：连接器读各 parquet footer 的总行数补齐**，对现有 backup 零改动。
+**Core gap & approach**: backup meta's `Binlog` only records `log_path/log_size/log_id`;
+`entries_num` (per-file row count) is not populated. The packed read requires exact
+`fileRowCounts` (cumulatively forming `(start_index,end_index)`; missing values are rejected /
+mis-read). **Approach A: recover each file's row count by reading its parquet footer** —
+zero changes to existing backups.
 
-## 2. 关键事实（已核实）
+## 2. Verified Key Facts
 
-| 事实 | 出处 |
+| Fact | Source |
 |---|---|
-| backup 的 binlog 对象与 Milvus 存储逐字节一致 | `milvus-backup/core/backup/coll_dml_task.go:511-546`（CopyObjectsTask 原样复制） |
-| backup 布局 `binlogs/insert_log/{coll}/{part}/{groupID}/{seg}/{field}/{log}`；`groupID` 为虚拟 partition，仅 restore 用 | `milvus-backup/internal/storage/mpath/path.go:17-26, 288-297` |
-| 完整 meta 在 `meta/full_meta.json`（schema + partitions + segments + L0） | `milvus-backup/internal/meta/meta.go:129-139`；`meta_builder.go:327-337` |
-| `SegmentBackupInfo`：id / `num_of_rows` / `storage_version` / `group_id` / `is_l0` / `binlogs` / `deltalogs` | `milvus-backup/core/proto/backup.proto:102-120` |
-| `Binlog` 仅填 `log_path/log_size/log_id`，`entries_num` 字段存在但 deprecate 未填充 | `backup.proto:494-501`；`coll_dml_task.go:101,131` |
-| packed 读要求 `fileRowCounts` 精确 | `src/main/scala/read/MilvusPackedV2PartitionReader.scala:253-260`；`milvus-storage/cpp/include/milvus-storage/ffi_internal/v2_column_groups_builder.h:35-43` |
-| 真实 field ID 可从 parquet 自带 schema 的 `PARQUET:field_id` 恢复 | `src/main/scala/read/MilvusParquetFooterReader.readFieldIdsFromSchema` |
-| delta log 解码只用 `logPath`，`entriesNum` 不参与 | `src/main/scala/read/MilvusDeltaLogReader.scala:127-145` |
-| L0 段无 column groups、只有 delta log → inherited partition 级 delete plan | `src/main/scala/sources/MilvusDataSource.scala:1628-1662, 2269-2303` |
+| Backup binlog objects are byte-identical to Milvus storage objects | `milvus-backup/core/backup/coll_dml_task.go:511-546` (CopyObjectsTask copies as-is) |
+| Backup layout `binlogs/insert_log/{coll}/{part}/{groupID}/{seg}/{field}/{log}`; `groupID` is a virtual partition, restore-only | `milvus-backup/internal/storage/mpath/path.go:17-26, 288-297` |
+| Full meta in `meta/full_meta.json` (schema + partitions + segments + L0) | `milvus-backup/internal/meta/meta.go:129-139`; `meta_builder.go:327-337` |
+| `SegmentBackupInfo`: id / `num_of_rows` / `storage_version` / `group_id` / `is_l0` / `binlogs` / `deltalogs` | `milvus-backup/core/proto/backup.proto:102-120` |
+| `Binlog` only records `log_path/log_size/log_id`; `entries_num` exists but is deprecated/unset | `backup.proto:494-501`; `coll_dml_task.go:101,131` |
+| Packed read requires exact `fileRowCounts` | `src/main/scala/read/MilvusPackedV2PartitionReader.scala:253-260`; `milvus-storage/cpp/include/milvus-storage/ffi_internal/v2_column_groups_builder.h:35-43` |
+| Real field IDs recoverable from the parquet's own schema `PARQUET:field_id` | `src/main/scala/read/MilvusParquetFooterReader.readFieldIdsFromSchema` |
+| Delta-log decoding uses only `logPath`; `entriesNum` unused | `src/main/scala/read/MilvusDeltaLogReader.scala:127-145` |
+| L0 segments have no column groups, only delta logs → inherited partition-level delete plan | `src/main/scala/sources/MilvusDataSource.scala:1628-1662, 2269-2303` |
 
-## 3. 总体设计
+## 3. Overall Design
 
-新增 **backup 离线模式**，与 snapshot 模式平级：
+Add a **backup offline mode**, parallel to snapshot mode:
 
 ```
 MilvusDataSource / MilvusTable  isBackupMode? ─┐
                                               ▼
 MilvusScan.computeInputPartitions ──> planInputPartitionsFromBackup()
-                                              │  用 BackupMetaReader 产出
+                                              │   produced via BackupMetaReader
                                               ▼
                            (schemaBytes, Seq[V2SegmentInfo])
-                                              │  复用
+                                              │   reuse
                                               ▼
                     buildSnapshotPartitions() → MilvusPackedV2InputPartition[]
                                               │
-              createReaderFactory() → MilvusPackedV2PartitionReader（不变）
+              createReaderFactory() → MilvusPackedV2PartitionReader (unchanged)
 ```
 
-分支优先级：`isSnapshotMode` > `isBackupMode` > client。
+Branch precedence: `isSnapshotMode` > `isBackupMode` > client.
 
-## 4. 改动文件清单
+## 4. Changed Files
 
 ### 4.1 `src/main/scala/MilvusOption.scala`
-- 新增 `MilvusOption.BackupDir = "milvus.backup.dir"`。
-- 新增 `isBackupMode(options)`：`BackupDir` 非空即开启。
-- `MilvusDataSource.getTable/inferSchema`：backup 模式下允许无 `milvus.uri`；`validateSnapshotModeOptions` 处新增 snapshot/backup 互斥校验。
-- S3 配置复用现有 `fs.*` / `s3.*`。
+- New `MilvusOption.BackupDir = "milvus.backup.dir"`.
+- New `isBackupMode(options)`: enabled when `BackupDir` is non-empty.
+- `MilvusDataSource.getTable/inferSchema`: allow backup mode without `milvus.uri`; add snapshot/backup mutual-exclusion validation at `validateSnapshotModeOptions`.
+- S3 config reuses existing `fs.*` / `s3.*`.
 
-### 4.2 新增 `src/main/scala/read/BackupMetaReader.scala`（核心）
-Jackson 解析 backup `full_meta.json`（仿 `MilvusSnapshotReader`），对外：
+### 4.2 New `src/main/scala/read/BackupMetaReader.scala` (core)
+Parses backup `full_meta.json` with Jackson (mirroring `MilvusSnapshotReader`):
 ```scala
 object BackupMetaReader {
   def readMeta(hadoopConf: Configuration, backupDir: String,
@@ -68,36 +85,45 @@ object BackupMetaReader {
                    applyDeletes: Boolean, collectionId: Long): Either[Throwable, Seq[V2SegmentInfo]]
 }
 ```
-内嵌 JSON 模型：`BackupInfo`、`CollectionBackupInfo`、`PartitionBackupInfo`、`SegmentBackupInfo`、`FieldBinlog`、`Binlog`、`CollectionSchema`/`FieldSchema`（镜像 schemapb，含 `type_params`、`data_type`、`is_primary_key`、`element_type`、`is_dynamic`、`nullable` 等）。
+Embedded JSON model: `BackupInfo`, `CollectionBackupInfo`, `PartitionBackupInfo`,
+`SegmentBackupInfo`, `FieldBinlog`, `Binlog`, `CollectionSchema`/`FieldSchema` (a mirror of
+schemapb, including `type_params`, `data_type`, `is_primary_key`, `element_type`, `is_dynamic`,
+`nullable`, etc.).
 
 ### 4.3 `src/main/scala/read/MilvusParquetFooterReader.scala`
-- 新增 `readRowCount(path, hadoopConf): Either[Throwable, Long]`：`ParquetFileReader.getFooter.getBlocks` 求和（每文件总行数），复用现有 `readWithFileSystem`。
+- New `readRowCount(path, hadoopConf): Either[Throwable, Long]`: sums
+  `ParquetFileReader.getFooter.getBlocks` (per-file total row count), reusing the existing
+  `readWithFileSystem`.
 
 ### 4.4 `src/main/scala/sources/MilvusDataSource.scala`
-- `MilvusTable.isBackupMode` → `initFromBackup()`（跳过 client，schema 由 `BackupMetaReader` 或用户 `.schema()` 提供）。
-- `MilvusScan.planInputPartitionsFromBackup()`：
-  1. 构建 backup bucket hadoop conf（复用 `buildSnapshotHadoopConf`）。
-  2. `BackupMetaReader.readMeta` → schema bytes + `V2SegmentInfo`。
-  3. 复用 `loadV2DeletePlans`（L1 段）与 `loadPartitionScopedDeletePlans`（L0 段）。
-  4. 调用现有 `buildSnapshotPartitions(v2Segments=..., v2DeletePlans=...)`。
+- `MilvusTable.isBackupMode` → `initFromBackup()` (skips the client; schema from
+  `BackupMetaReader` or the user's `.schema()`).
+- `MilvusScan.planInputPartitionsFromBackup()`:
+  1. Build the backup-bucket Hadoop conf (reuse `buildSnapshotHadoopConf`).
+  2. `BackupMetaReader.readMeta` → schema bytes + `V2SegmentInfo`.
+  3. Reuse `loadV2DeletePlans` (L1 segments) and `loadPartitionScopedDeletePlans` (L0 segments).
+  4. Call the existing `buildSnapshotPartitions(v2Segments=..., v2DeletePlans=...)`.
 
-## 5. 数据映射（`full_meta.json → V2SegmentInfo`）
+## 5. Data Mapping (`full_meta.json → V2SegmentInfo`)
 
-| `V2SegmentInfo` | 来源 | 备注 |
+| `V2SegmentInfo` | Source | Notes |
 |---|---|---|
 | `segmentId` | `SegmentBackupInfo.segment_id` | |
-| `partitionId` | `.partition_id` | part=-1 保留（L0/全分区） |
+| `partitionId` | `.partition_id` | part=-1 preserved (L0 / all-partition) |
 | `numOfRows` | `.num_of_rows` | |
-| `storageVersion` | `.storage_version` | **已实现**：L0 段（无版本/`0`）在版本过滤前处理；非 L0 非 V2 一律硬失败（`0`/absent 即 StorageV1） |
-| `columnGroups` | `.binlogs[]` 按 `field_id`(slot) 分组 | slot 即目录名 |
-| `cg.fieldIds` | 每组首个文件 `readFieldIdsAndRowCount` | 单次打开同时取 fieldIDs 与行数 |
-| `cg.filePaths` | **已实现：从 `backupDir`+IDs 重建**（见下），绝不使用 meta 的 `log_path` | 原生 reader 用 bucket 相对 key；Hadoop 读用带 scheme URI |
-| `cg.fileRowCounts` | 首文件合并读取 + 其余并行 `readRowCount` | **方案 A 补齐**；`size==paths.size` 校验 |
-| `cg.slotFieldId` | 组的 `field_id` | 读路径按 slot 去重（`dedupColumnGroupsBySlot`） |
-| `deltaLogs` | **已实现：从 `backupDir`+IDs 重建**；`partitionId != -1` 含 group 层级 | `entriesNum=0`（解码不使用） |
-| L0 段 | `is_l0=true` → `columnGroups=Seq.empty` + deltaLogs | 走 inherited plan |
+| `storageVersion` | `.storage_version` | **Implemented**: L0 (no version / `0`) handled before the version filter; non-L0 non-V2 fails hard (`0`/absent = StorageV1) |
+| `columnGroups` | `.binlogs[]` grouped by `field_id` (slot) | slot = directory name |
+| `cg.fieldIds` | head file of each group via `readFieldIdsAndRowCount` | a single open yields fieldIDs + row count |
+| `cg.filePaths` | **Implemented: reconstructed from `backupDir`+IDs** (below); never the meta `log_path` | native reader uses bucket-relative keys; Hadoop reads use scheme-qualified URIs |
+| `cg.fileRowCounts` | head file combined read + remaining in parallel `readRowCount` | **Approach A gap-closer**; `size==paths.size` enforced |
+| `cg.slotFieldId` | group's `field_id` | read path dedups by slot (`dedupColumnGroupsBySlot`) |
+| `deltaLogs` | **Implemented: reconstructed from `backupDir`+IDs**; `partitionId != -1` carries the group level | `entriesNum=0` (unused by the decoder) |
+| L0 segment | `is_l0=true` → `columnGroups=Seq.empty` + deltaLogs | inherited delete-plan path |
 
-路径解析（**已实现**，与初稿相反）：meta 的 `log_path` 是原始 Milvus 源 key，**不能直接解析**。备份对象路径按 milvus-backup 的 `DestKey` 布局从 `backupDir` + collection/partition/group/segment/field/log ID **重建**：
+Path resolution (**implemented**, opposite of the initial draft): the meta's `log_path` is the
+original Milvus source key and must **not** be parsed directly. Backup object paths are
+**reconstructed** from `backupDir` + collection/partition/group/segment/field/log IDs following
+milvus-backup's `DestKey` layout:
 
 ```
 insert: {backupDir}/binlogs/insert_log/{coll}/{part}/{group}/{seg}/{field}/{log}
@@ -105,33 +131,57 @@ delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}          (part =
         {backupDir}/binlogs/delta_log/{coll}/{part}/{group}/{seg}/{log}  (part != -1)
 ```
 
-Hadoop 侧读（footer/meta/delta）用带 scheme 的 URI（`s3a://...`）；原生 JNI reader 的 `filePaths` 用 bucket 相对 key，`fs.bucket_name` 由 backup URI 规范化。**读必须用 S3（`s3a://`）backup dir，本地/`file://` 在规划期被拒绝。**
+Hadoop-side reads (footer/meta/delta) use scheme-qualified URIs (`s3a://...`); the native JNI
+reader's `filePaths` use bucket-relative keys with `fs.bucket_name` canonicalized from the
+backup URI. **Reads require an S3 (`s3a://`) backup dir; local / `file://` is rejected at
+planning.**
 
-## 6. 删除语义（复用现有逻辑）
+## 6. Delete Semantics (reuses existing logic)
 
-- `milvus.read.apply.deletes`（默认 true）。
-- L1 段 `delta_log` → `loadV2DeletePlans`（段级 plan）。
-- L0 段 → `loadPartitionScopedDeletePlans`（`-1` = 全集合删除）。
-- 读时按 `(pk, timestamp)` 在 packed reader 内过滤（`isDeleted`）。
+- `milvus.read.apply.deletes` (default true).
+- L1 segment `delta_log` → `loadV2DeletePlans` (segment-level plan).
+- L0 segment → `loadPartitionScopedDeletePlans` (`-1` = collection-wide delete).
+- Rows are filtered at read time by `(pk, timestamp)` inside the packed reader (`isDeleted`).
 
-## 7. 边界与限制
+## 7. Edge Cases & Limitations
 
-- **一致性（已实现，与初稿相反）**：backup 默认 flush，仅含落盘数据，但**不是** server 强制的事务一致点时间视图——GC-pause 为 best-effort（可能静默失败，#1119）、各集合各自 flush 时间戳、skipFlush 不 flush，GC/压缩竞态可撕裂。**不可当作 cutover/对账真值**（那才是 snapshot 的保证）。详见 `docs/backup-datasource-design.md` §7。
-- 空段/无 binlog：`num_of_rows == 0` 且无 binlogs 才发射空 `columnGroups`；有行数但无 binlogs 硬失败。
-- 动态字段 `$meta`（**已实现**）：meta 无 `$meta` 记录（默认 backup 无 etcd 访问）时**拒绝读取**并提示 `--backup_index_extra`；有记录则正常保留。
-- 非 L0 且非 StorageV2 段硬失败；L0 段无版本也保留（删除语义）。
-- 本地路径（`/data/backup/xxx` / `file://`）：仅 meta/footer 映射层与单测可用；**实际读在规划期拒绝**（JNI reader 需 S3）。
-- collection 按 `milvus.database.name` + `milvus.collection.name` 匹配（`default` 与空库名等价），不允许 `.head` 兜底。
+- **Consistency (implemented, opposite of the initial draft)**: backups default to a flush and
+  contain only disk-resident data, but they are **not** a server-enforced transactionally
+  consistent point-in-time view — the GC pause is best-effort (may fail silently, #1119), each
+  collection is sealed at its own flush timestamp, and skipFlush omits the flush, so a
+  GC/compaction race can tear the view. **Do not use it as a cutover/reconciliation source of
+  truth** (that guarantee belongs to a snapshot). See `docs/backup-datasource-design.md` §7.
+- Empty segment / no binlogs: an empty `columnGroups` is emitted only when `num_of_rows == 0`;
+  a segment with rows but no binlogs fails hard.
+- Dynamic field `$meta` (**implemented**): when the meta lacks the `$meta` record (a default
+  backup without etcd access) the read is **rejected** with a pointer to `--backup_index_extra`;
+  when present it is preserved.
+- Non-L0 non-StorageV2 segments fail hard; L0 segments without a version are preserved (delete
+  semantics).
+- Local paths (`/data/backup/xxx` / `file://`): usable by the meta/footer mapping layer and unit
+  tests only; actual reads are rejected at planning (the JNI reader requires S3).
+- The collection is matched by `milvus.database.name` + `milvus.collection.name` (never
+  `.head`). Passing `"default"` selects the default-database collection (matching a meta that
+  records `""` or `"default"`), while leaving the database name empty performs
+  single-candidate/ambiguity resolution — so with `default.orders` and `db2.orders` present,
+  pass `"default"` (or `"db2"`) to disambiguate.
 
-## 8. 测试计划
+## 8. Test Plan
 
-1. **单元测试**
-   - `BackupMetaReaderSpec`：fixture `full_meta.json`（1 个 L1 段 + 1 个 L0 段 + 多列分组）→ 断言 schema bytes、`V2SegmentInfo` 的 fieldIds/filePaths/排序、L0 空 columnGroups。
-   - `readRowCountSpec`：本地 parquet 行数正确性。
-2. **集成脚本**（仿现有 demo）：MinIO + Milvus 2.6 → 灌数据/flush → `milvus-backup create -n b1` → `spark.read.format(...).options("milvus.backup.dir", ...)`，对比 `count(*)` 与 distinct PK。
-3. **回归**：snapshot 模式、client 读不受影响。
+1. **Unit tests**
+   - `BackupMetaReaderSpec`: fixture `full_meta.json` (one L1 segment + one L0 segment + multiple
+     column groups) → assert schema bytes, `V2SegmentInfo` fieldIds/filePaths/order, L0 empty
+     columnGroups.
+   - `readRowCountSpec`: local parquet row-count correctness.
+2. **Integration script** (mirroring existing demos): MinIO + Milvus 2.6 → ingest/flush →
+   `milvus-backup create -n b1` → `spark.read.format(...).options("milvus.backup.dir", ...)`,
+   comparing `count(*)` and distinct PK.
+3. **Regression**: snapshot mode and client read unaffected.
 
-## 9. 不在本次范围 / 后续可选
+## 9. Out of Scope / Future
 
-- StorageV3(loon) 段：需 milvus-backup 拷贝 `.milvus_manifest` 或 footer 反推 V3 布局。
-- 方案 B：milvus-backup 填充 `entries_num`（**已实现：连接器总是读 footer 行数，不优先 meta 的 entries_num**；若未来 milvus-backup 填充该字段，可加"有则用"的 fallback）。
+- StorageV3 (loon) segments: requires milvus-backup to copy `.milvus_manifest` or footer-based
+  V3 layout recovery.
+- Option B: milvus-backup populating `entries_num` (**implemented: the connector always reads
+  the footer row count, not preferring the meta's entries_num**; if milvus-backup populates it
+  in the future, an "use-if-present" fallback could be added).

--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -110,7 +110,7 @@ val s3Options = Map(
 
 | 参数名 | 类型 | 必需 | 默认值 | 描述 |
 |--------|------|------|--------|------|
-| `MilvusOption.MilvusUri` | String | 是 | - | Milvus 服务器连接 URI，格式：`http://host:port` 或 `https://host:port` |
+| `MilvusOption.MilvusUri` | String | 条件 | - | Milvus 服务器连接 URI，格式：`http://host:port` 或 `https://host:port`。客户端模式必需；snapshot/backup 模式（离线读）不要求。 |
 | `MilvusOption.MilvusToken` | String | 否 | "" | Milvus 服务器认证令牌 |
 | `MilvusOption.MilvusDatabaseName` | String | 否 | "" | 数据库名称，默认为 default 数据库 |
 
@@ -127,7 +127,7 @@ val s3Options = Map(
 
 | 参数名 | 类型 | 必需 | 默认值 | 描述 |
 |--------|------|------|--------|------|
-| `MilvusOption.MilvusCollectionName` | String | 是 | - | 集合名称 |
+| `MilvusOption.MilvusCollectionName` | String | 条件 | - | 集合名称。客户端模式必需；backup 模式仅当备份含多个集合时必需。 |
 | `MilvusOption.MilvusPartitionName` | String | 否 | "" | 分区名称，为空时操作所有分区 |
 | `MilvusOption.MilvusCollectionID` | String | 否 | "" | 集合 ID，通常自动获取 |
 | `MilvusOption.MilvusPartitionID` | String | 否 | "" | 分区 ID，通常自动获取 |
@@ -151,11 +151,11 @@ val s3Options = Map(
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.BackupDir` | String | 否 | "" | `milvus.backup.dir` — 备份目录，如 `s3a://bucket/backup/<name>`。**仅支持 S3**（`s3://` 自动归一化为 `s3a://`）；本地/`file://` 目录在规划期被拒绝（packed reader 需要 S3）。 |
 | `MilvusOption.MilvusDatabaseName` | String | 否 | "" | collection 所在库。传 `"default"` 选择默认库的 collection（匹配 meta 记录为 `""` 或 `"default"`）；留空则走单候选/歧义判定——当同时存在 `default.orders` 与 `db2.orders` 时，需传 `"default"`（或 `"db2"`）消除歧义。 |
-| `MilvusOption.MilvusCollectionName` | String | 否 | - | 备份内的 collection 名（与库名联合匹配，不用 `.head`）。备份含多个 collection 时必须指定。 |
+| `MilvusOption.MilvusCollectionName` | String | 条件 | - | 备份内的 collection 名（与库名联合匹配，不用 `.head`）。备份含多个 collection 时必须指定。 |
 | `MilvusOption.ReadApplyDeletes` | Boolean | 否 | true | `milvus.read.apply.deletes` — 读取时应用删除日志（L0/L1）。 |
 | `MilvusOption.SnapshotMaxJsonBytes` | Long | 否 | 67108864 | `milvus.snapshot.max.json.bytes` — backup `full_meta.json` 大小上限。 |
 
-读取 schema 需通过 `.schema()` 提供，或从备份 meta 推导；未提供 `.schema()` 且 meta 读取失败时读取硬失败。读取动态集合（`enable_dynamic_field=true`）要求备份 meta 记录 `$meta` 字段——仅当 milvus-backup 带 etcd 访问（`--backup_index_extra`）且 **≥ v0.5.13** 时才捕获。S3 凭证复用现有 `fs.*` 选项（`fs.address`、`fs.access_key_id`、`fs.access_key_value` ...）；桶取自 `milvus.backup.dir` URI。
+读取 schema 需通过 `.schema()` 提供，或从备份 meta 推导；未提供 `.schema()` 且 meta 读取失败时读取硬失败。读取动态集合（`enable_dynamic_field=true`）要求备份 meta 记录 `$meta` 字段——仅当 milvus-backup 带 etcd 访问（`--backup_index_extra`）且 **≥ v0.5.13** 时才捕获。两种备份形态会在规划期中止读取：跨多个 binlog 文件的 column group（未修复的 milvus-storage bug，见设计文档）与含 struct-array 字段（`struct_array_fields`）的集合。S3 凭证复用现有 `fs.*` 选项（`fs.address`、`fs.access_key_id`、`fs.access_key_value` ...）；桶取自 `milvus.backup.dir` URI。
 
 ## 3. 使用示例
 

--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -143,6 +143,20 @@ val s3Options = Map(
 | `MilvusOption.MilvusRetryCount` | Int | 否 | 3 | 操作失败时的重试次数 |
 | `MilvusOption.MilvusRetryInterval` | Int | 否 | 1000 | 重试间隔时间（毫秒） |
 
+### 2.5 离线备份读取参数
+
+读取 milvus-backup 导出的 **binlog 格式**备份（`milvus-backup create --format binlog`），无需任何 Milvus client 连接。完整设计见 `docs/backup-datasource-design.md`。
+
+| 参数 | 类型 | 必填 | 默认 | 说明 |
+|-----------|------|----------|---------|-------------|
+| `MilvusOption.BackupDir` | String | 否 | "" | `milvus.backup.dir` — 备份目录，如 `s3a://bucket/backup/<name>`。**仅支持 S3**（`s3://` 自动归一化为 `s3a://`）；本地/`file://` 目录在规划期被拒绝（packed reader 需要 S3）。 |
+| `MilvusOption.MilvusDatabaseName` | String | 否 | "" | collection 所在库（`"default"` 与空名等价）。与 `milvus.collection.name` 一起选库；未限定且有歧义时拒绝。 |
+| `MilvusOption.MilvusCollectionName` | String | 否 | - | 备份内的 collection 名（与库名联合匹配，不用 `.head`）。备份含多个 collection 时必须指定。 |
+| `MilvusOption.ReadApplyDeletes` | Boolean | 否 | true | `milvus.read.apply.deletes` — 读取时应用删除日志（L0/L1）。 |
+| `MilvusOption.SnapshotMaxJsonBytes` | Long | 否 | 67108864 | `milvus.snapshot.max.json.bytes` — backup `full_meta.json` 大小上限。 |
+
+读取 schema 需通过 `.schema()` 提供，或从备份 meta 推导；未提供 `.schema()` 且 meta 读取失败时读取硬失败。S3 凭证复用现有 `fs.*` 选项（`fs.address`、`fs.access_key_id`、`fs.access_key_value` ...）；桶取自 `milvus.backup.dir` URI。
+
 ## 3. 使用示例
 
 ### 3.1 读取数据

--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -155,7 +155,7 @@ val s3Options = Map(
 | `MilvusOption.ReadApplyDeletes` | Boolean | 否 | true | `milvus.read.apply.deletes` — 读取时应用删除日志（L0/L1）。 |
 | `MilvusOption.SnapshotMaxJsonBytes` | Long | 否 | 67108864 | `milvus.snapshot.max.json.bytes` — backup `full_meta.json` 大小上限。 |
 
-读取 schema 需通过 `.schema()` 提供，或从备份 meta 推导；未提供 `.schema()` 且 meta 读取失败时读取硬失败。S3 凭证复用现有 `fs.*` 选项（`fs.address`、`fs.access_key_id`、`fs.access_key_value` ...）；桶取自 `milvus.backup.dir` URI。
+读取 schema 需通过 `.schema()` 提供，或从备份 meta 推导；未提供 `.schema()` 且 meta 读取失败时读取硬失败。读取动态集合（`enable_dynamic_field=true`）要求备份 meta 记录 `$meta` 字段——仅当 milvus-backup 带 etcd 访问（`--backup_index_extra`）且 **≥ v0.5.13** 时才捕获。S3 凭证复用现有 `fs.*` 选项（`fs.address`、`fs.access_key_id`、`fs.access_key_value` ...）；桶取自 `milvus.backup.dir` URI。
 
 ## 3. 使用示例
 

--- a/docs/reference-cn.md
+++ b/docs/reference-cn.md
@@ -145,12 +145,12 @@ val s3Options = Map(
 
 ### 2.5 离线备份读取参数
 
-读取 milvus-backup 导出的 **binlog 格式**备份（`milvus-backup create --format binlog`），无需任何 Milvus client 连接。完整设计见 `docs/backup-datasource-design.md`。
+读取 milvus-backup 导出的 **binlog 格式**备份，无需任何 Milvus client 连接。已发布版本（v0.5.x）的 `milvus-backup create` 默认即 binlog 格式；`--format binlog` 仅存在于 milvus-backup master 分支（面向 Milvus 3.x，默认 snapshot）。完整设计见 `docs/backup-datasource-design.md`。
 
 | 参数 | 类型 | 必填 | 默认 | 说明 |
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.BackupDir` | String | 否 | "" | `milvus.backup.dir` — 备份目录，如 `s3a://bucket/backup/<name>`。**仅支持 S3**（`s3://` 自动归一化为 `s3a://`）；本地/`file://` 目录在规划期被拒绝（packed reader 需要 S3）。 |
-| `MilvusOption.MilvusDatabaseName` | String | 否 | "" | collection 所在库（`"default"` 与空名等价）。与 `milvus.collection.name` 一起选库；未限定且有歧义时拒绝。 |
+| `MilvusOption.MilvusDatabaseName` | String | 否 | "" | collection 所在库。传 `"default"` 选择默认库的 collection（匹配 meta 记录为 `""` 或 `"default"`）；留空则走单候选/歧义判定——当同时存在 `default.orders` 与 `db2.orders` 时，需传 `"default"`（或 `"db2"`）消除歧义。 |
 | `MilvusOption.MilvusCollectionName` | String | 否 | - | 备份内的 collection 名（与库名联合匹配，不用 `.head`）。备份含多个 collection 时必须指定。 |
 | `MilvusOption.ReadApplyDeletes` | Boolean | 否 | true | `milvus.read.apply.deletes` — 读取时应用删除日志（L0/L1）。 |
 | `MilvusOption.SnapshotMaxJsonBytes` | Long | 否 | 67108864 | `milvus.snapshot.max.json.bytes` — backup `full_meta.json` 大小上限。 |

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -110,7 +110,7 @@ val s3Options = Map(
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `MilvusOption.MilvusUri` | String | Yes | - | Milvus server connection URI, format: `http://host:port` or `https://host:port` |
+| `MilvusOption.MilvusUri` | String | Conditional | - | Milvus server connection URI, format: `http://host:port` or `https://host:port`. Required for client mode; not required for snapshot/backup mode (offline reads). |
 | `MilvusOption.MilvusToken` | String | No | "" | Milvus server authentication token |
 | `MilvusOption.MilvusDatabaseName` | String | No | "" | Database name, defaults to default database |
 
@@ -127,7 +127,7 @@ val s3Options = Map(
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `MilvusOption.MilvusCollectionName` | String | Yes | - | Collection name |
+| `MilvusOption.MilvusCollectionName` | String | Conditional | - | Collection name. Required for client mode; in backup mode required only when the backup holds more than one collection. |
 | `MilvusOption.MilvusPartitionName` | String | No | "" | Partition name, operates on all partitions when empty |
 | `MilvusOption.MilvusCollectionID` | String | No | "" | Collection ID, usually auto-retrieved |
 | `MilvusOption.MilvusPartitionID` | String | No | "" | Partition ID, usually auto-retrieved |
@@ -155,7 +155,7 @@ to snapshot). See `docs/backup-datasource-design.md` for the full design.
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.BackupDir` | String | No | "" | `milvus.backup.dir` — the backup directory, e.g. `s3a://bucket/backup/<name>`. **S3 only** (`s3://` is normalized to `s3a://`); local/`file://` dirs are rejected at planning because the packed reader requires S3. |
 | `MilvusOption.MilvusDatabaseName` | String | No | "" | Database the collection lives in. Passing `"default"` selects the default-database collection (matching a meta that records `""` or `"default"`); leaving the option empty performs single-candidate / ambiguity resolution instead — with both `default.orders` and `db2.orders` present, pass `"default"` (or `"db2"`) to disambiguate. |
-| `MilvusOption.MilvusCollectionName` | String | No | - | Collection name inside the backup (matched with the database name, never `.head`). Required when the backup holds more than one collection. |
+| `MilvusOption.MilvusCollectionName` | String | Conditional | - | Collection name inside the backup (matched with the database name, never `.head`). Required when the backup holds more than one collection. |
 | `MilvusOption.ReadApplyDeletes` | Boolean | No | true | `milvus.read.apply.deletes` — apply delete logs (L0/L1) while reading. |
 | `MilvusOption.SnapshotMaxJsonBytes` | Long | No | 67108864 | `milvus.snapshot.max.json.bytes` — max size of the backup `full_meta.json`. |
 
@@ -163,8 +163,11 @@ The Spark read schema must be provided via `.schema()` or is derived from the
 backup meta; without `.schema()` the read fails loudly if the meta cannot be
 read. Reading a dynamic collection (`enable_dynamic_field=true`) requires the
 backup meta to record the `$meta` field — captured only with milvus-backup
-etcd access (`--backup_index_extra`) and **v0.5.13+**. S3 credentials use the
-existing `fs.*` options (`fs.address`,
+etcd access (`--backup_index_extra`) and **v0.5.13+**. Two backup shapes abort
+the read at planning time: a column group spanning more than one binlog file
+(an unfixed milvus-storage bug — see the design doc) and a collection with
+struct-array fields (`struct_array_fields`). S3 credentials use the existing
+`fs.*` options (`fs.address`,
 `fs.access_key_id`, `fs.access_key_value`, ...); the bucket comes from the
 `milvus.backup.dir` URI.
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -145,14 +145,16 @@ val s3Options = Map(
 
 ### 2.5 Offline Backup Read Parameters
 
-Read a binlog-format milvus-backup export (`milvus-backup create --format binlog`)
-as a DataFrame without any Milvus client connection. See
-`docs/backup-datasource-design.md` for the full design.
+Read a binlog-format milvus-backup export as a DataFrame without any Milvus
+client connection. A plain `milvus-backup create` on released versions
+(v0.5.x) already produces binlog format; the `--format binlog` flag exists
+only on milvus-backup's master branch (which targets Milvus 3.x and defaults
+to snapshot). See `docs/backup-datasource-design.md` for the full design.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `MilvusOption.BackupDir` | String | No | "" | `milvus.backup.dir` — the backup directory, e.g. `s3a://bucket/backup/<name>`. **S3 only** (`s3://` is normalized to `s3a://`); local/`file://` dirs are rejected at planning because the packed reader requires S3. |
-| `MilvusOption.MilvusDatabaseName` | String | No | "" | Database the collection lives in (`"default"` is equivalent to an empty name). Used together with `milvus.collection.name` to select the collection; an ambiguous unqualified name is rejected. |
+| `MilvusOption.MilvusDatabaseName` | String | No | "" | Database the collection lives in. Passing `"default"` selects the default-database collection (matching a meta that records `""` or `"default"`); leaving the option empty performs single-candidate / ambiguity resolution instead — with both `default.orders` and `db2.orders` present, pass `"default"` (or `"db2"`) to disambiguate. |
 | `MilvusOption.MilvusCollectionName` | String | No | - | Collection name inside the backup (matched with the database name, never `.head`). Required when the backup holds more than one collection. |
 | `MilvusOption.ReadApplyDeletes` | Boolean | No | true | `milvus.read.apply.deletes` — apply delete logs (L0/L1) while reading. |
 | `MilvusOption.SnapshotMaxJsonBytes` | Long | No | 67108864 | `milvus.snapshot.max.json.bytes` — max size of the backup `full_meta.json`. |

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -143,6 +143,26 @@ val s3Options = Map(
 | `MilvusOption.MilvusRetryCount` | Int | No | 3 | Number of retries on operation failure |
 | `MilvusOption.MilvusRetryInterval` | Int | No | 1000 | Retry interval in milliseconds |
 
+### 2.5 Offline Backup Read Parameters
+
+Read a binlog-format milvus-backup export (`milvus-backup create --format binlog`)
+as a DataFrame without any Milvus client connection. See
+`docs/backup-datasource-design.md` for the full design.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `MilvusOption.BackupDir` | String | No | "" | `milvus.backup.dir` — the backup directory, e.g. `s3a://bucket/backup/<name>`. **S3 only** (`s3://` is normalized to `s3a://`); local/`file://` dirs are rejected at planning because the packed reader requires S3. |
+| `MilvusOption.MilvusDatabaseName` | String | No | "" | Database the collection lives in (`"default"` is equivalent to an empty name). Used together with `milvus.collection.name` to select the collection; an ambiguous unqualified name is rejected. |
+| `MilvusOption.MilvusCollectionName` | String | No | - | Collection name inside the backup (matched with the database name, never `.head`). Required when the backup holds more than one collection. |
+| `MilvusOption.ReadApplyDeletes` | Boolean | No | true | `milvus.read.apply.deletes` — apply delete logs (L0/L1) while reading. |
+| `MilvusOption.SnapshotMaxJsonBytes` | Long | No | 67108864 | `milvus.snapshot.max.json.bytes` — max size of the backup `full_meta.json`. |
+
+The Spark read schema must be provided via `.schema()` or is derived from the
+backup meta; without `.schema()` the read fails loudly if the meta cannot be
+read. S3 credentials use the existing `fs.*` options (`fs.address`,
+`fs.access_key_id`, `fs.access_key_value`, ...); the bucket comes from the
+`milvus.backup.dir` URI.
+
 ## 3. Usage Examples
 
 ### 3.1 Reading Data

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -161,7 +161,10 @@ to snapshot). See `docs/backup-datasource-design.md` for the full design.
 
 The Spark read schema must be provided via `.schema()` or is derived from the
 backup meta; without `.schema()` the read fails loudly if the meta cannot be
-read. S3 credentials use the existing `fs.*` options (`fs.address`,
+read. Reading a dynamic collection (`enable_dynamic_field=true`) requires the
+backup meta to record the `$meta` field — captured only with milvus-backup
+etcd access (`--backup_index_extra`) and **v0.5.13+**. S3 credentials use the
+existing `fs.*` options (`fs.address`,
 `fs.access_key_id`, `fs.access_key_value`, ...); the bucket comes from the
 `milvus.backup.dir` URI.
 

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -240,7 +240,16 @@ object MilvusOption {
   private def backupDirFrom(
       getOption: String => Option[String]
   ): Option[String] =
-    getOption(BackupDir).map(_.trim).filter(_.nonEmpty)
+    getOption(BackupDir)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(normalizeBackupScheme)
+
+  /** Normalize the `s3://` alias to `s3a://` at entry so Hadoop (which drops
+    * the `s3://` provider) and the connector's path reconstruction agree.
+    */
+  private def normalizeBackupScheme(dir: String): String =
+    if (dir.startsWith("s3://")) "s3a://" + dir.stripPrefix("s3://") else dir
 
   def backupDir(options: Map[String, String]): Option[String] = {
     backupDirFrom { key =>

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -149,9 +149,6 @@ object MilvusOption {
   // points at a binlog-format backup produced by milvus-backup (the directory
   // whose `meta/full_meta.json` holds the collection schema + segment layout).
   val BackupDir = "milvus.backup.dir"
-  // Internal: the already-parsed `full_meta.json` threaded from table init to
-  // the scan planner so the meta is read/parsed once per read.
-  val BackupMetaJson = "milvus.backup.meta.json"
 
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
   // JSON array of StorageV2ManifestItem. Despite the "V2" in the class name,

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -149,6 +149,9 @@ object MilvusOption {
   // points at a binlog-format backup produced by milvus-backup (the directory
   // whose `meta/full_meta.json` holds the collection schema + segment layout).
   val BackupDir = "milvus.backup.dir"
+  // Internal: the already-parsed `full_meta.json` threaded from table init to
+  // the scan planner so the meta is read/parsed once per read.
+  val BackupMetaJson = "milvus.backup.meta.json"
 
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
   // JSON array of StorageV2ManifestItem. Despite the "V2" in the class name,

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -145,6 +145,11 @@ object MilvusOption {
   val BackfillModeOverwrite = "overwrite"
 
   // Snapshot-based reading options (for offline/client-free mode)
+  // Backup-based reading options (offline/client-free). `milvus.backup.dir`
+  // points at a binlog-format backup produced by milvus-backup (the directory
+  // whose `meta/full_meta.json` holds the collection schema + segment layout).
+  val BackupDir = "milvus.backup.dir"
+
   val SnapshotMode = "milvus.snapshot.mode" // "true" to enable snapshot mode
   // JSON array of StorageV2ManifestItem. Despite the "V2" in the class name,
   // these are StorageV3 loon manifests (segment-info storage_version = 3).
@@ -230,6 +235,50 @@ object MilvusOption {
 
   def validateSnapshotModeOptions(options: CaseInsensitiveStringMap): Unit = {
     validateSnapshotModeOptionsFrom(key => Option(options.get(key)))
+  }
+
+  private def backupDirFrom(
+      getOption: String => Option[String]
+  ): Option[String] =
+    getOption(BackupDir).map(_.trim).filter(_.nonEmpty)
+
+  def backupDir(options: Map[String, String]): Option[String] = {
+    backupDirFrom { key =>
+      options.collectFirst {
+        case (optionKey, value) if optionKey.equalsIgnoreCase(key) =>
+          value
+      }
+    }
+  }
+
+  def backupDir(options: CaseInsensitiveStringMap): Option[String] = {
+    backupDirFrom(key => Option(options.get(key)))
+  }
+
+  def isBackupMode(options: Map[String, String]): Boolean =
+    backupDir(options).isDefined
+
+  def isBackupMode(options: CaseInsensitiveStringMap): Boolean =
+    backupDir(options).isDefined
+
+  /** Backup mode reads a milvus-backup binlog-format export offline. It is
+    * mutually exclusive with snapshot mode: pick one source of truth for the
+    * segment layout.
+    */
+  def validateBackupModeOptions(options: Map[String, String]): Unit = {
+    if (isBackupMode(options) && isSnapshotMode(options)) {
+      throw new IllegalArgumentException(
+        s"$BackupDir and snapshot mode ($SnapshotMode/$SnapshotManifests/$SnapshotV2Segments) are mutually exclusive"
+      )
+    }
+  }
+
+  def validateBackupModeOptions(options: CaseInsensitiveStringMap): Unit = {
+    if (isBackupMode(options) && isSnapshotMode(options)) {
+      throw new IllegalArgumentException(
+        s"$BackupDir and snapshot mode ($SnapshotMode/$SnapshotManifests/$SnapshotV2Segments) are mutually exclusive"
+      )
+    }
   }
 
   private def readApplyDeletesFrom(

--- a/src/main/scala/MilvusOption.scala
+++ b/src/main/scala/MilvusOption.scala
@@ -195,8 +195,11 @@ object MilvusOption {
       .filter(_.nonEmpty)
       .map(_.equalsIgnoreCase("true"))
       .getOrElse {
-        getOption(SnapshotManifests).isDefined ||
-        getOption(SnapshotV2Segments).isDefined
+        // Only a non-empty hint enables snapshot mode: config templates that
+        // keep optional keys with empty values (e.g. milvus.snapshot.manifests="")
+        // must not trip the snapshot/backup mutual-exclusion check.
+        nonEmptyOption(getOption, SnapshotManifests) ||
+        nonEmptyOption(getOption, SnapshotV2Segments)
       }
   }
 

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -1595,31 +1595,15 @@ object MilvusBackfill {
   private[backfill] def dedupColumnGroupsBySlot(
       seg: com.zilliz.spark.connector.read.V2SegmentInfo
   ): com.zilliz.spark.connector.read.V2SegmentInfo = {
-    val groups = seg.columnGroups
-    if (groups.isEmpty || groups.exists(_.slotFieldId < 0L)) return seg
-
-    val maxSlotPerField: Map[Long, Long] =
-      groups
-        .flatMap(g => g.fieldIds.map(fid => fid -> g.slotFieldId))
-        .groupBy(_._1)
-        .map { case (fid, pairs) => fid -> pairs.map(_._2).max }
-
-    val rebuilt = groups.flatMap { g =>
-      val keptFids =
-        g.fieldIds.filter(fid => maxSlotPerField(fid) == g.slotFieldId)
-      val stripped = g.fieldIds.diff(keptFids)
-      if (stripped.nonEmpty) {
-        logger.info(
-          s"V2 dedup segment=${seg.segmentId} slot=${g.slotFieldId}: " +
-            s"stripped fieldIds=${stripped.mkString(",")} " +
-            s"(owned by larger slots ${stripped.map(maxSlotPerField).mkString(",")})"
-        )
-      }
-      if (keptFids.isEmpty) None
-      else Some(g.copy(fieldIds = keptFids))
+    val before = seg.columnGroups
+    val deduped = seg.dedupColumnGroupsBySlot
+    if (before != deduped.columnGroups) {
+      logger.info(
+        s"V2 dedup segment=${seg.segmentId}: removed overlapping field ids " +
+          "claimed by older slots"
+      )
     }
-
-    seg.copy(columnGroups = rebuilt)
+    deduped
   }
 
   /** Decode the StorageV2 segments referenced by the snapshot's

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -437,6 +437,7 @@ object BackupMetaReader extends Logging {
       applyDeletes: Boolean = true,
       collectionId: Long
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
+    var fs: FileSystem = null
     try {
       if (info.isSnapshotFormat) {
         throw new IllegalStateException(
@@ -444,6 +445,10 @@ object BackupMetaReader extends Logging {
             "backups can be read as a datasource"
         )
       }
+      // One FileSystem reused across every segment's footer reads: with
+      // fs.s3a.impl.disable.cache=true, per-file FileSystem.get would otherwise
+      // construct a whole S3A client + thread pool for each binlog.
+      fs = FileSystem.get(new java.net.URI(backupBase(backupDir)), hadoopConf)
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
       info.collectionBackups
         .filter(_.collectionId == collectionId)
@@ -457,7 +462,7 @@ object BackupMetaReader extends Logging {
             SegmentReadPool.submit(
               new Callable[Either[Throwable, Option[V2SegmentInfo]]] {
                 override def call(): Either[Throwable, Option[V2SegmentInfo]] =
-                  buildV2Segment(seg, hadoopConf, backupDir, applyDeletes)
+                  buildV2SegmentWithFs(seg, fs, backupDir, applyDeletes)
               }
             )
           }
@@ -476,10 +481,18 @@ object BackupMetaReader extends Logging {
       Right(out.toSeq)
     } catch {
       case NonFatal(e) => Left(e)
+    } finally {
+      try {
+        if (fs != null) fs.close()
+      } catch {
+        case NonFatal(_) => // close is best-effort; the read result already won
+      }
     }
   }
 
-  /** Convert one backup segment into a `V2SegmentInfo` (or skip it).
+  /** Convert one backup segment into a `V2SegmentInfo` (or skip it), reusing
+    * the caller-supplied `FileSystem` for all footer reads (a backup read opens
+    * one FS for all segments, so per-file S3A client construction is avoided).
     *
     * L0 delete-only segments are handled before any storage-version filtering:
     * Milvus creates them without a `StorageVersion` (0/omitted in the meta), so
@@ -490,9 +503,9 @@ object BackupMetaReader extends Logging {
     *   `Right(Some(seg))` for readable segments; `Left` for unsupported data
     *   segments (fails hard rather than returning a partial dataset).
     */
-  private[read] def buildV2Segment(
+  private[read] def buildV2SegmentWithFs(
       seg: SegmentBackup,
-      hadoopConf: Configuration,
+      fs: FileSystem,
       backupDir: String,
       applyDeletes: Boolean
   ): Either[Throwable, Option[V2SegmentInfo]] = {
@@ -558,8 +571,8 @@ object BackupMetaReader extends Logging {
           // (which live in the parquet schema, not the backup meta) and its row
           // count; the remaining files' row counts are read in parallel.
           val headInfo = MilvusParquetFooterReader.readFieldIdsAndRowCount(
-            hadoopPaths.head,
-            hadoopConf
+            fs,
+            hadoopPaths.head
           ) match {
             case Right(info) => info
             case Left(err) =>
@@ -572,8 +585,8 @@ object BackupMetaReader extends Logging {
           }
           val tailRowCounts = if (hadoopPaths.size > 1) {
             readRowCountsInParallel(
+              fs,
               hadoopPaths.tail,
-              hadoopConf,
               seg.segmentId,
               fieldBinlog.fieldId
             ) match {
@@ -629,6 +642,30 @@ object BackupMetaReader extends Logging {
     }
   }
 
+  /** [[buildV2SegmentWithFs]] opening a fresh `FileSystem` from the config —
+    * for tests / single-segment use. Batch reads should go through
+    * [[toV2Segments]], which opens one `FileSystem` for all segments and reuses
+    * it across every footer read.
+    */
+  private[read] def buildV2Segment(
+      seg: SegmentBackup,
+      hadoopConf: Configuration,
+      backupDir: String,
+      applyDeletes: Boolean
+  ): Either[Throwable, Option[V2SegmentInfo]] = {
+    var fs: FileSystem = null
+    try {
+      fs = FileSystem.get(new java.net.URI(backupBase(backupDir)), hadoopConf)
+      buildV2SegmentWithFs(seg, fs, backupDir, applyDeletes)
+    } finally {
+      try {
+        if (fs != null) fs.close()
+      } catch {
+        case NonFatal(_) => // close is best-effort; the read result already
+      }
+    }
+  }
+
   private def emptyColumnGroupSegment(
       seg: SegmentBackup,
       backupDir: String
@@ -657,10 +694,13 @@ object BackupMetaReader extends Logging {
         )
       )
 
-  /** Read the row count of every path concurrently, preserving input order. */
+  /** Read the row count of every path concurrently, preserving input order. All
+    * reads share the caller-supplied `FileSystem` (thread-safe for concurrent
+    * opens), so no per-file S3A client is constructed.
+    */
   private def readRowCountsInParallel(
+      fs: FileSystem,
       paths: Seq[String],
-      hadoopConf: Configuration,
       segmentId: Long,
       slotFieldId: Long
   ): Either[Throwable, Seq[Long]] = {
@@ -668,7 +708,7 @@ object BackupMetaReader extends Logging {
       val futures = paths.map { p =>
         FooterReadPool.submit(new Callable[Long] {
           override def call(): Long =
-            MilvusParquetFooterReader.readRowCount(p, hadoopConf) match {
+            MilvusParquetFooterReader.readRowCount(fs, p) match {
               case Right(n) => n
               case Left(err) =>
                 throw new RuntimeException(

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -704,12 +704,20 @@ object BackupMetaReader extends Logging {
         )
       )
 
-  /** Build the L0 (delete-only) `V2SegmentInfo` list for a collection with no
-    * footer reads. Used by the reader factory to compute the shared
-    * partition-scoped L0 delete plans independently of partition planning, so
-    * delete handling does not depend on Spark evaluating partitions first.
+  /** Build the delete-only `V2SegmentInfo` list for a collection with no footer
+    * reads. Used by the reader factory to compute the shared partition-scoped
+    * delete plans independently of partition planning, so delete handling does
+    * not depend on Spark evaluating partitions first.
+    *
+    * The predicate MUST match the planner's `inheritedDeleteSegments`
+    * (`columnGroups.isEmpty && deltaLogs.nonEmpty` after
+    * `buildV2SegmentWithFs`): every L0 segment, plus a non-L0 StorageV2 segment
+    * with no binlogs and zero rows (emitted as an empty column-group segment).
+    * Otherwise a partition can be stamped with an inherited-delete marker that
+    * has no matching plan entry and silently resolves to
+    * `MilvusDeletePlan.empty`.
     */
-  private[connector] def l0DeleteSegments(
+  private[connector] def deleteOnlySegments(
       info: BackupInfo,
       collectionId: Long,
       backupDir: String
@@ -717,8 +725,16 @@ object BackupMetaReader extends Logging {
     info.collectionBackups
       .filter(_.collectionId == collectionId)
       .flatMap(_.allSegments)
-      .filter(seg => seg.isL0 && seg.deltalogs.exists(_.binlogs.nonEmpty))
+      .filter(isDeleteOnlySegment)
       .map(seg => emptyColumnGroupSegment(seg, backupDir))
+
+  private def isDeleteOnlySegment(seg: SegmentBackup): Boolean = {
+    val hasDeltas = seg.deltalogs.exists(_.binlogs.nonEmpty)
+    val binlogsEmpty =
+      seg.binlogs.isEmpty || seg.binlogs.forall(_.binlogs.isEmpty)
+    hasDeltas && (seg.isL0 ||
+      (seg.storageVersion == 2L && binlogsEmpty && seg.numOfRows == 0L))
+  }
 
   // -------------------------------------------------------------------------
   // Backup path reconstruction

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -202,7 +202,9 @@ object BackupMetaReader extends Logging {
     if (base.isEmpty) {
       throw new IllegalArgumentException("backup dir must not be empty")
     }
-    val stripped = if (base.endsWith("/")) base.stripSuffix("/") else base
+    // Strip ALL trailing slashes: `.../b1//` is the same location as `.../b1`
+    // but a different S3 key, so a single stripSuffix("/") would miss it.
+    val stripped = base.replaceAll("/+$", "")
     s"$stripped/meta/full_meta.json"
   }
 
@@ -375,23 +377,40 @@ object BackupMetaReader extends Logging {
     math.max(2, math.min(cores, 8))
   }
 
-  /** Bounded, daemon thread pool for parallel parquet footer reads on the
-    * driver. Footer reads are I/O-bound (a HEAD + one tail range GET each), so
+  /** Bounded, daemon thread pool for per-file parquet footer reads on the
+    * driver (a HEAD + one tail range GET each). Footer reads are I/O-bound, so
     * fanning them out avoids a serialized round trip per binlog before any
     * Spark task is scheduled.
+    *
+    * The inner tail-file reads run on their own pool, separate from
+    * [[SegmentReadPool]], so a segment worker blocked on `Future.get()` for its
+    * tail reads can never starve those reads of threads (a single shared pool
+    * would deadlock when every worker waits on tasks that are queued behind
+    * it).
     */
   private val FooterReadPool: ExecutorService = Executors.newFixedThreadPool(
     FooterReadThreadCount,
+    daemonThreadFactory("backup-footer-read")
+  )
+
+  /** Bounded, daemon thread pool for segment-level conversion (each segment's
+    * footer reads are independent). See [[FooterReadPool]] for the deadlock
+    * rationale for keeping this separate from the per-file pool.
+    */
+  private val SegmentReadPool: ExecutorService = Executors.newFixedThreadPool(
+    FooterReadThreadCount,
+    daemonThreadFactory("backup-segment-read")
+  )
+
+  private def daemonThreadFactory(namePrefix: String): ThreadFactory =
     new ThreadFactory {
       private val counter = new AtomicInteger(0)
       override def newThread(r: Runnable): Thread = {
-        val t =
-          new Thread(r, s"backup-footer-read-${counter.incrementAndGet()}")
+        val t = new Thread(r, s"$namePrefix-${counter.incrementAndGet()}")
         t.setDaemon(true)
         t
       }
     }
-  )
 
   /** Build the runtime `V2SegmentInfo` list for the segments of the collection
     * identified by `collectionId`. L0 delete-only segments keep an empty
@@ -433,7 +452,7 @@ object BackupMetaReader extends Logging {
           // segments (not just across a group's tail files) is what keeps a
           // large backup from stalling the driver.
           val futures = coll.allSegments.map { seg =>
-            FooterReadPool.submit(
+            SegmentReadPool.submit(
               new Callable[Either[Throwable, Option[V2SegmentInfo]]] {
                 override def call(): Either[Throwable, Option[V2SegmentInfo]] =
                   buildV2Segment(seg, hadoopConf, backupDir, applyDeletes)
@@ -670,7 +689,7 @@ object BackupMetaReader extends Logging {
     Option(backupDir)
       .map(_.trim)
       .filter(_.nonEmpty)
-      .map(_.stripSuffix("/"))
+      .map(_.replaceAll("/+$", ""))
       .getOrElse(
         throw new IllegalArgumentException("backup dir must not be empty")
       )
@@ -700,14 +719,21 @@ object BackupMetaReader extends Logging {
     }
   }
 
+  /** Join a path prefix with "/" without introducing a leading slash when the
+    * prefix is empty (a backup at the bucket root has an empty bucket-relative
+    * prefix, and `/binlogs/...` is a different S3 key than `binlogs/...`).
+    */
+  private def joinPrefix(prefix: String): String =
+    if (prefix.isEmpty) "" else prefix + "/"
+
   private def insertLogPath(
       prefix: String,
       seg: SegmentBackup,
       slotFieldId: Long,
       logId: Long
   ): String =
-    s"$prefix/binlogs/insert_log/${seg.collectionId}/${seg.partitionId}/" +
-      s"${seg.groupId}/${seg.segmentId}/$slotFieldId/$logId"
+    s"${joinPrefix(prefix)}binlogs/insert_log/${seg.collectionId}/" +
+      s"${seg.partitionId}/${seg.groupId}/${seg.segmentId}/$slotFieldId/$logId"
 
   private def deltaLogPath(
       prefix: String,
@@ -715,11 +741,11 @@ object BackupMetaReader extends Logging {
       logId: Long
   ): String =
     if (seg.partitionId == AllPartitionId) {
-      s"$prefix/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
-        s"${seg.segmentId}/$logId"
+      s"${joinPrefix(prefix)}binlogs/delta_log/${seg.collectionId}/" +
+        s"${seg.partitionId}/${seg.segmentId}/$logId"
     } else {
-      s"$prefix/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
-        s"${seg.groupId}/${seg.segmentId}/$logId"
+      s"${joinPrefix(prefix)}binlogs/delta_log/${seg.collectionId}/" +
+        s"${seg.partitionId}/${seg.groupId}/${seg.segmentId}/$logId"
     }
 
   /** Hadoop-qualified insert-log path (e.g.

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -220,12 +220,13 @@ object BackupMetaReader extends Logging {
       backupDir: String,
       maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes
   ): Either[Throwable, BackupInfo] = {
-    val cached = metaCache.get(backupDir)
+    val cacheKey = metaCacheKey(backupDir, maxBytes)
+    val cached = metaCache.get(cacheKey)
     if (cached != null) {
       Right(cached)
     } else {
       readMetaUncached(hadoopConf, backupDir, maxBytes).map { info =>
-        metaCache.putIfAbsent(backupDir, info)
+        metaCache.putIfAbsent(cacheKey, info)
         info
       }
     }
@@ -377,12 +378,17 @@ object BackupMetaReader extends Logging {
     */
   private val AllPartitionId = -1L
 
-  /** Process-wide cache of parsed `full_meta.json` keyed by backup dir. Backups
-    * are immutable exports, and both table init and scan planning need the
-    * meta, so a successful parse is reused instead of reading+parsing twice.
+  /** Process-wide cache of parsed `full_meta.json` keyed by backup dir + size
+    * limit. Backups are immutable exports, and both table init and scan
+    * planning need the meta, so a successful parse is reused instead of
+    * reading+parsing twice. The limit is part of the key so a later read with a
+    * different `milvus.snapshot.max.json.bytes` cannot alias a cached parse.
     */
   private val metaCache =
     new ConcurrentHashMap[String, BackupInfo]()
+
+  private def metaCacheKey(backupDir: String, maxBytes: Long): String =
+    s"$backupDir\u0000$maxBytes"
 
   private val FooterReadThreadCount: Int = {
     val cores = Runtime.getRuntime.availableProcessors()
@@ -675,7 +681,15 @@ object BackupMetaReader extends Logging {
     } else {
       val rest = base.substring(schemeIdx + 3)
       val slash = rest.indexOf('/')
-      if (slash < 0) "" else rest.substring(slash + 1)
+      if (slash < 0) {
+        ""
+      } else if (slash == 0) {
+        // Empty authority (e.g. file:///data/backup/b1): keep the leading
+        // slash so both spellings of the same local location agree.
+        rest
+      } else {
+        rest.substring(slash + 1)
+      }
     }
   }
 

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -2,7 +2,6 @@ package com.zilliz.spark.connector.read
 
 import java.util.concurrent.{
   Callable,
-  ConcurrentHashMap,
   ExecutorService,
   Executors,
   ThreadFactory
@@ -211,31 +210,15 @@ object BackupMetaReader extends Logging {
     *
     * The read is bounded ([[MilvusSnapshotReader.readUtf8WithLimit]]) so an
     * oversized or pathological meta fails on the driver instead of being
-    * slurped into memory. Successful parses are cached per backup dir — a
-    * backup is an immutable export, and both table init and scan planning need
-    * it.
+    * slurped into memory. No process-global cache is kept: the parse must
+    * reflect the exact Hadoop configuration (credentials/endpoint) and the
+    * current object at that path, and an unbounded cache would retain every
+    * backup dir read over the driver's lifetime.
     */
   def readMeta(
       hadoopConf: Configuration,
       backupDir: String,
       maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes
-  ): Either[Throwable, BackupInfo] = {
-    val cacheKey = metaCacheKey(backupDir, maxBytes)
-    val cached = metaCache.get(cacheKey)
-    if (cached != null) {
-      Right(cached)
-    } else {
-      readMetaUncached(hadoopConf, backupDir, maxBytes).map { info =>
-        metaCache.putIfAbsent(cacheKey, info)
-        info
-      }
-    }
-  }
-
-  private def readMetaUncached(
-      hadoopConf: Configuration,
-      backupDir: String,
-      maxBytes: Long
   ): Either[Throwable, BackupInfo] = {
     var uri: java.net.URI = null
     var fs: FileSystem = null
@@ -378,18 +361,6 @@ object BackupMetaReader extends Logging {
     */
   private val AllPartitionId = -1L
 
-  /** Process-wide cache of parsed `full_meta.json` keyed by backup dir + size
-    * limit. Backups are immutable exports, and both table init and scan
-    * planning need the meta, so a successful parse is reused instead of
-    * reading+parsing twice. The limit is part of the key so a later read with a
-    * different `milvus.snapshot.max.json.bytes` cannot alias a cached parse.
-    */
-  private val metaCache =
-    new ConcurrentHashMap[String, BackupInfo]()
-
-  private def metaCacheKey(backupDir: String, maxBytes: Long): String =
-    s"$backupDir\u0000$maxBytes"
-
   private val FooterReadThreadCount: Int = {
     val cores = Runtime.getRuntime.availableProcessors()
     math.max(2, math.min(cores, 8))
@@ -413,9 +384,10 @@ object BackupMetaReader extends Logging {
     }
   )
 
-  /** Build the runtime `V2SegmentInfo` list for every segment of the backup. L0
-    * delete-only segments keep an empty `columnGroups` so they feed the
-    * inherited delete-plan path, exactly like the snapshot reader.
+  /** Build the runtime `V2SegmentInfo` list for the segments of the collection
+    * identified by `collectionId`. L0 delete-only segments keep an empty
+    * `columnGroups` so they feed the inherited delete-plan path, exactly like
+    * the snapshot reader.
     *
     * @param backupDir
     *   The full `milvus.backup.dir` (e.g. `s3a://bucket/backup/<name>` or a
@@ -423,12 +395,17 @@ object BackupMetaReader extends Logging {
     *   the segment's collection/partition/group/segment/field/log IDs — the
     *   `log_path` values in the meta are the original Milvus source keys and
     *   must never be read directly.
+    * @param collectionId
+    *   Only the segments of this collection are materialized; a backup holding
+    *   several collections must never leak another collection's segments into
+    *   the read.
     */
   def toV2Segments(
       info: BackupInfo,
       hadoopConf: Configuration,
       backupDir: String,
-      applyDeletes: Boolean = true
+      applyDeletes: Boolean = true,
+      collectionId: Long
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
     try {
       if (info.isSnapshotFormat) {
@@ -438,15 +415,17 @@ object BackupMetaReader extends Logging {
         )
       }
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
-      info.collectionBackups.foreach { coll =>
-        coll.allSegments.foreach { seg =>
-          buildV2Segment(seg, hadoopConf, backupDir, applyDeletes) match {
-            case Right(Some(v2)) => out += v2
-            case Right(None)     => // L0 segment skipped (applyDeletes=false)
-            case Left(e)         => throw e
+      info.collectionBackups
+        .filter(_.collectionId == collectionId)
+        .foreach { coll =>
+          coll.allSegments.foreach { seg =>
+            buildV2Segment(seg, hadoopConf, backupDir, applyDeletes) match {
+              case Right(Some(v2)) => out += v2
+              case Right(None)     => // L0 segment skipped (applyDeletes=false)
+              case Left(e)         => throw e
+            }
           }
         }
-      }
       Right(out.toSeq)
     } catch {
       case NonFatal(e) => Left(e)
@@ -481,10 +460,16 @@ object BackupMetaReader extends Logging {
         Right(Some(emptyColumnGroupSegment(seg, backupDir)))
       }
     } else if (seg.storageVersion != 2L) {
+      val storageVersionNote =
+        if (seg.storageVersion == 0L) {
+          "0/absent means StorageV1 (legacy per-field binlogs)"
+        } else {
+          s"${seg.storageVersion}"
+        }
       Left(
         new IllegalStateException(
           s"backup segment ${seg.segmentId} has storage_version=" +
-            s"${seg.storageVersion}; backup datasource only supports " +
+            s"$storageVersionNote; backup datasource only supports " +
             "StorageV2 (packed parquet) data segments"
         )
       )

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -52,11 +52,12 @@ import io.milvus.grpc.schema.{
   * the collection/partition/group/segment/field/log IDs, never taken from
   * `log_path`. Three gaps vs. a Milvus snapshot are closed here:
   *   1. milvus-backup persists only `log_size` per binlog, not `entries_num`.
-  *      The per-file row count is recovered by reading each parquet footer's
-  *      row count ([MilvusParquetFooterReader.readRowCount]), in parallel. 2.
-  *      The AVRO segment-info (and hence the slot -> real field ID mapping) is
-  *      not copied by the backup; the real field IDs are recovered from the
-  *      **head file** of each column group via that file's own parquet schema
+  *      The per-file row count is recovered by reading each (single) parquet
+  *      footer's row count
+  *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]). 2. The AVRO
+  *      segment-info (and hence the slot -> real field ID mapping) is not
+  *      copied by the backup; the real field IDs are recovered from the **head
+  *      file** of each column group via that file's own parquet schema
   *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]) — matching
   *      V2SegmentLoader, which assumes all files in a group share the schema.
   *      3. L0 delete-only segments are created by Milvus without a
@@ -171,8 +172,15 @@ object BackupMetaReader extends Logging {
       @JsonProperty("fields") fields: Seq[BackupFieldSchema] = Seq.empty,
       @JsonProperty("enable_dynamic_field") enableDynamicField: Boolean = false,
       @JsonProperty("properties") properties: Seq[BackupKeyValuePair] =
-        Seq.empty
-  )
+        Seq.empty,
+      @JsonProperty("struct_array_fields") structArrayFields: Option[JsonNode] =
+        None
+  ) {
+    def hasStructArrayFields: Boolean =
+      structArrayFields.exists(n =>
+        n != null && !n.isNull && n.isArray && n.size() > 0
+      )
+  }
 
   // -------------------------------------------------------------------------
   // Parsing
@@ -288,6 +296,7 @@ object BackupMetaReader extends Logging {
     */
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte] = {
     validateDynamicFieldSchema(schema)
+    validateStructArrayFields(schema)
     // Drop system fields by field ID (0 = RowID, 1 = Timestamp), never by name:
     // milvus-backup's schema comes from DescribeCollection, which only returns
     // user fields, so a legitimately-named user field (e.g. a PK literally
@@ -340,6 +349,25 @@ object BackupMetaReader extends Logging {
           "with etcd access so the dynamic field schema is captured " +
           "(--backup_index_extra requires milvus-backup >= v0.5.13; on " +
           "v0.5.10-v0.5.12 the flag does not capture $meta)"
+      )
+    }
+  }
+
+  /** Reject a collection whose meta carries `struct_array_fields`: these
+    * top-level fields live in a separate repeated message (not in `fields`),
+    * and the connector's read path does not support Struct/ArrayOfStruct data
+    * types end-to-end, so silently dropping them would return a DataFrame
+    * missing whole user columns. Full struct-array support is tracked
+    * separately.
+    */
+  private[connector] def validateStructArrayFields(
+      schema: BackupCollectionSchema
+  ): Unit = {
+    if (schema.hasStructArrayFields) {
+      throw new IllegalArgumentException(
+        s"backup collection '${schema.name}' has struct-array fields " +
+          "(struct_array_fields), which the connector does not support yet; " +
+          "reading it would silently drop those columns"
       )
     }
   }
@@ -632,10 +660,11 @@ object BackupMetaReader extends Logging {
           )
         }
         val totalRows = groupTotals.headOption.getOrElse(0L)
-        if (seg.numOfRows > 0L && totalRows <= 0L) {
+        if (totalRows != seg.numOfRows) {
           throw new IllegalStateException(
             s"backup segment ${seg.segmentId} has num_of_rows=${seg.numOfRows} " +
-              "but the parquet footers recovered 0 rows"
+              s"but the parquet footers recovered $totalRows rows; refusing " +
+              "to read a segment whose meta and data disagree"
           )
         }
         Right(

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -427,8 +427,21 @@ object BackupMetaReader extends Logging {
       info.collectionBackups
         .filter(_.collectionId == collectionId)
         .foreach { coll =>
-          coll.allSegments.foreach { seg =>
-            buildV2Segment(seg, hadoopConf, backupDir, applyDeletes) match {
+          // Segments are independent, so their footer reads run in parallel on
+          // the shared pool; with the common "one file per group" shape each
+          // segment still costs a serial head read, so parallelism across
+          // segments (not just across a group's tail files) is what keeps a
+          // large backup from stalling the driver.
+          val futures = coll.allSegments.map { seg =>
+            FooterReadPool.submit(
+              new Callable[Either[Throwable, Option[V2SegmentInfo]]] {
+                override def call(): Either[Throwable, Option[V2SegmentInfo]] =
+                  buildV2Segment(seg, hadoopConf, backupDir, applyDeletes)
+              }
+            )
+          }
+          futures.foreach { f =>
+            f.get() match {
               case Right(Some(v2)) => out += v2
               case Right(None)     => // L0 segment skipped (applyDeletes=false)
               case Left(e)         => throw e

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -1,5 +1,12 @@
 package com.zilliz.spark.connector.read
 
+import java.util.concurrent.{
+  Callable,
+  ExecutorService,
+  Executors,
+  ThreadFactory
+}
+import java.util.concurrent.atomic.AtomicInteger
 import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -31,23 +38,30 @@ import io.milvus.grpc.schema.{
   *     collection schema plus every segment's binlog / deltalog layout (mirrors
   *     Milvus's `schemapb.CollectionSchema` and `datapb.SegmentInfo`-lite), and
   *   - `binlogs/insert_log/...` and `binlogs/delta_log/...` — byte-identical
-  *     copies of the Milvus storage objects.
+  *     copies of the Milvus storage objects, keyed at a deterministic layout
+  *     derived from the backup dir plus segment IDs (see
+  *     [[backupInsertLogPath]] / [[backupDeltaLogPath]]).
   *
   * This object translates the meta into the same runtime objects the snapshot
   * read path consumes (`V2SegmentInfo`), so the backup can be read offline with
-  * the existing packed-V2 reader. Two gaps vs. a Milvus snapshot are closed
-  * here:
+  * the existing packed-V2 reader. The meta's `log_path` values are the
+  * **original Milvus source keys** — milvus-backup copies each binlog into a
+  * separate `DestKey` under the backup dir and records only the source key in
+  * the meta — so object paths are always reconstructed from `backupDir` plus
+  * the collection/partition/group/segment/field/log IDs, never taken from
+  * `log_path`. Three gaps vs. a Milvus snapshot are closed here:
   *   1. milvus-backup persists only `log_size` per binlog, not `entries_num`.
   *      The per-file row count is recovered by reading each parquet footer's
-  *      row count ([MilvusParquetFooterReader.readRowCount]). 2. The AVRO
-  *      segment-info (and hence the slot -> real field ID mapping) is not
-  *      copied by the backup; the real field IDs are recovered from each
+  *      row count ([MilvusParquetFooterReader.readRowCount]), in parallel. 2.
+  *      The AVRO segment-info (and hence the slot -> real field ID mapping) is
+  *      not copied by the backup; the real field IDs are recovered from each
   *      parquet file's own schema
-  *      ([MilvusParquetFooterReader.readFieldIdsFromSchema]).
+  *      ([MilvusParquetFooterReader.readFieldIdsFromSchema]). 3. L0 delete-only
+  *      segments are created by Milvus without a `StorageVersion` (0/omitted),
+  *      so they are handled before any storage-version filtering.
   *
-  * Only StorageV2 (packed parquet, `storage_version == 2`) segments are
-  * supported — the same format the packed-V2 reader handles. StorageV1 is
-  * skipped and StorageV3 is rejected.
+  * Only StorageV2 (packed parquet, `storage_version == 2`) data segments are
+  * supported; anything else fails hard rather than returning a partial dataset.
   */
 object BackupMetaReader extends Logging {
 
@@ -286,18 +300,49 @@ object BackupMetaReader extends Logging {
   // Segment conversion
   // -------------------------------------------------------------------------
 
-  /** Build the runtime `V2SegmentInfo` list for every StorageV2 segment of the
-    * backup. L0 delete-only segments keep an empty `columnGroups` so they feed
-    * the inherited delete-plan path, exactly like the snapshot reader.
+  /** `_allPartitionID` as used by milvus-backup for collection-wide L0
+    * segments.
+    */
+  private val AllPartitionId = -1L
+
+  private val FooterReadThreadCount: Int = {
+    val cores = Runtime.getRuntime.availableProcessors()
+    math.max(2, math.min(cores, 8))
+  }
+
+  /** Bounded, daemon thread pool for parallel parquet footer reads on the
+    * driver. Footer reads are I/O-bound (a HEAD + one tail range GET each), so
+    * fanning them out avoids a serialized round trip per binlog before any
+    * Spark task is scheduled.
+    */
+  private val FooterReadPool: ExecutorService = Executors.newFixedThreadPool(
+    FooterReadThreadCount,
+    new ThreadFactory {
+      private val counter = new AtomicInteger(0)
+      override def newThread(r: Runnable): Thread = {
+        val t =
+          new Thread(r, s"backup-footer-read-${counter.incrementAndGet()}")
+        t.setDaemon(true)
+        t
+      }
+    }
+  )
+
+  /** Build the runtime `V2SegmentInfo` list for every segment of the backup. L0
+    * delete-only segments keep an empty `columnGroups` so they feed the
+    * inherited delete-plan path, exactly like the snapshot reader.
     *
-    * @param bucket
-    *   Bucket holding the backup's objects (empty for local paths). Bucket-
-    *   relative `log_path` values are resolved to `s3a://bucket/...`.
+    * @param backupDir
+    *   The full `milvus.backup.dir` (e.g. `s3a://bucket/backup/<name>` or a
+    *   local path). Backup object paths are **reconstructed** from this plus
+    *   the segment's collection/partition/group/segment/field/log IDs — the
+    *   `log_path` values in the meta are the original Milvus source keys and
+    *   must never be read directly.
     */
   def toV2Segments(
       info: BackupInfo,
       hadoopConf: Configuration,
-      bucket: String,
+      backupDir: String,
       applyDeletes: Boolean = true
   ): Either[Throwable, Seq[V2SegmentInfo]] = {
     try {
@@ -310,10 +355,10 @@ object BackupMetaReader extends Logging {
       val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
       info.collectionBackups.foreach { coll =>
         coll.allSegments.foreach { seg =>
-          buildV2Segment(seg, hadoopConf, bucket, applyDeletes) match {
+          buildV2Segment(seg, hadoopConf, backupDir, applyDeletes) match {
             case Right(Some(v2)) => out += v2
-            case Right(None) => // skipped (legacy storage or L0 w/o deletes)
-            case Left(e)     => throw e
+            case Right(None)     => // L0 segment skipped (applyDeletes=false)
+            case Left(e)         => throw e
           }
         }
       }
@@ -325,53 +370,45 @@ object BackupMetaReader extends Logging {
 
   /** Convert one backup segment into a `V2SegmentInfo` (or skip it).
     *
+    * L0 delete-only segments are handled before any storage-version filtering:
+    * Milvus creates them without a `StorageVersion` (0/omitted in the meta), so
+    * they must not fall into the StorageV1 skip path.
+    *
     * @return
-    *   `Right(None)` for StorageV1 segments or (when `applyDeletes = false`) L0
-    *   segments; `Right(Some(seg))` for readable StorageV2 segments.
+    *   `Right(None)` for an L0 segment when `applyDeletes = false`;
+    *   `Right(Some(seg))` for readable segments; `Left` for unsupported data
+    *   segments (fails hard rather than returning a partial dataset).
     */
   private[read] def buildV2Segment(
       seg: SegmentBackup,
       hadoopConf: Configuration,
-      bucket: String,
+      backupDir: String,
       applyDeletes: Boolean
   ): Either[Throwable, Option[V2SegmentInfo]] = {
-    if (seg.storageVersion > 2L) {
+    if (seg.isL0) {
+      if (!applyDeletes) {
+        logInfo(
+          s"skipping L0 delete-only segment ${seg.segmentId} because " +
+            "applyDeletes=false"
+        )
+        Right(None)
+      } else {
+        Right(Some(emptyColumnGroupSegment(seg, backupDir)))
+      }
+    } else if (seg.storageVersion != 2L) {
       Left(
         new IllegalStateException(
           s"backup segment ${seg.segmentId} has storage_version=" +
-            s"${seg.storageVersion} (StorageV3+); backup datasource only " +
-            "supports StorageV2 packed parquet"
+            s"${seg.storageVersion}; backup datasource only supports " +
+            "StorageV2 (packed parquet) data segments"
         )
       )
-    } else if (seg.storageVersion < 2L) {
-      logInfo(
-        s"skipping backup segment ${seg.segmentId}: storage_version=" +
-          s"${seg.storageVersion} (< 2, not StorageV2)"
-      )
-      Right(None)
-    } else if (seg.isL0 && !applyDeletes) {
-      logInfo(
-        s"skipping StorageV2 L0 delete-only segment ${seg.segmentId} because " +
-          "applyDeletes=false"
-      )
-      Right(None)
     } else if (seg.binlogs.isEmpty || seg.binlogs.forall(_.binlogs.isEmpty)) {
       logWarning(
         s"backup segment ${seg.segmentId} has no binlogs; emitting as empty " +
           "column-group list"
       )
-      Right(
-        Some(
-          V2SegmentInfo(
-            segmentId = seg.segmentId,
-            partitionId = seg.partitionId,
-            numOfRows = seg.numOfRows,
-            storageVersion = seg.storageVersion,
-            columnGroups = Seq.empty,
-            deltaLogs = toDeltaLogs(seg, bucket)
-          )
-        )
-      )
+      Right(Some(emptyColumnGroupSegment(seg, backupDir)))
     } else {
       try {
         val columnGroups = seg.binlogs.map { fieldBinlog =>
@@ -383,37 +420,40 @@ object BackupMetaReader extends Logging {
             )
           }
           val sorted = fieldBinlog.binlogs.sortBy(_.logId)
-          val paths =
-            sorted.map(b => V2SegmentLoader.resolvePath(b.logPath, bucket))
-          val fieldIds = MilvusParquetFooterReader.readFieldIdsFromSchema(
+          val paths = sorted.map(b =>
+            backupInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
+          )
+          // The head file's footer is read once for both the real field IDs
+          // (which live in the parquet schema, not the backup meta) and its row
+          // count; the remaining files' row counts are read in parallel.
+          val headInfo = MilvusParquetFooterReader.readFieldIdsAndRowCount(
             paths.head,
             hadoopConf
           ) match {
-            case Right(ids) => ids
+            case Right(info) => info
             case Left(err) =>
               throw new RuntimeException(
-                s"failed to read field ids from parquet ${paths.head} " +
+                s"failed to read footer of parquet ${paths.head} " +
                   s"(backup segment ${seg.segmentId}, slot " +
                   s"${fieldBinlog.fieldId}): ${err.getMessage}",
                 err
               )
           }
-          val rowCounts = paths.map { p =>
-            MilvusParquetFooterReader.readRowCount(p, hadoopConf) match {
-              case Right(n) => n
-              case Left(err) =>
-                throw new RuntimeException(
-                  s"failed to read row count from parquet $p " +
-                    s"(backup segment ${seg.segmentId}, slot " +
-                    s"${fieldBinlog.fieldId}): ${err.getMessage}",
-                  err
-                )
+          val tailRowCounts = if (paths.size > 1) {
+            readRowCountsInParallel(
+              paths.tail,
+              hadoopConf,
+              seg.segmentId,
+              fieldBinlog.fieldId
+            ) match {
+              case Right(counts) => counts
+              case Left(err)     => throw err
             }
-          }
+          } else Seq.empty
           V2ColumnGroup(
-            fieldIds = fieldIds,
+            fieldIds = headInfo.fieldIds,
             filePaths = paths,
-            fileRowCounts = rowCounts,
+            fileRowCounts = headInfo.rowCount +: tailRowCounts,
             slotFieldId = fieldBinlog.fieldId
           )
         }
@@ -425,7 +465,7 @@ object BackupMetaReader extends Logging {
               numOfRows = seg.numOfRows,
               storageVersion = seg.storageVersion,
               columnGroups = columnGroups,
-              deltaLogs = toDeltaLogs(seg, bucket)
+              deltaLogs = toDeltaLogs(seg, backupDir)
             )
           )
         )
@@ -435,9 +475,22 @@ object BackupMetaReader extends Logging {
     }
   }
 
+  private def emptyColumnGroupSegment(
+      seg: SegmentBackup,
+      backupDir: String
+  ): V2SegmentInfo =
+    V2SegmentInfo(
+      segmentId = seg.segmentId,
+      partitionId = seg.partitionId,
+      numOfRows = seg.numOfRows,
+      storageVersion = seg.storageVersion,
+      columnGroups = Seq.empty,
+      deltaLogs = toDeltaLogs(seg, backupDir)
+    )
+
   private def toDeltaLogs(
       seg: SegmentBackup,
-      bucket: String
+      backupDir: String
   ): Seq[V2DeltaLogFile] =
     seg.deltalogs
       .flatMap(_.binlogs)
@@ -445,8 +498,90 @@ object BackupMetaReader extends Logging {
       .map(b =>
         V2DeltaLogFile(
           logId = b.logId,
-          logPath = V2SegmentLoader.resolvePath(b.logPath, bucket),
+          logPath = backupDeltaLogPath(backupDir, seg, b.logId),
           entriesNum = b.entriesNum
         )
       )
+
+  /** Read the row count of every path concurrently, preserving input order. */
+  private def readRowCountsInParallel(
+      paths: Seq[String],
+      hadoopConf: Configuration,
+      segmentId: Long,
+      slotFieldId: Long
+  ): Either[Throwable, Seq[Long]] = {
+    try {
+      val futures = paths.map { p =>
+        FooterReadPool.submit(new Callable[Long] {
+          override def call(): Long =
+            MilvusParquetFooterReader.readRowCount(p, hadoopConf) match {
+              case Right(n) => n
+              case Left(err) =>
+                throw new RuntimeException(
+                  s"failed to read row count from parquet $p " +
+                    s"(backup segment $segmentId, slot $slotFieldId): " +
+                    s"${err.getMessage}",
+                  err
+                )
+            }
+        })
+      }
+      Right(futures.map(_.get()))
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Backup path reconstruction
+  // -------------------------------------------------------------------------
+
+  /** milvus-backup copies each binlog into a `DestKey` under the backup dir and
+    * writes only the source key into `full_meta.json`; the meta's `log_path`
+    * values therefore point at the original Milvus storage and must never be
+    * opened directly. The backup copies live at a deterministic layout derived
+    * from the backup dir plus the segment IDs — mirroring `coll_dml_task.go`'s
+    * `insertLogsAttrs` / `deltaLogAttrs`:
+    *
+    * {{{
+    *   insert: {backupDir}/binlogs/insert_log/{coll}/{part}/{group}/{seg}/{field}/{log}
+    *   delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}            (part == -1)
+    *           {backupDir}/binlogs/delta_log/{coll}/{part}/{group}/{seg}/{log}    (part != -1)
+    * }}}
+    */
+  private def backupBase(backupDir: String): String = {
+    Option(backupDir)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(_.stripSuffix("/"))
+      .getOrElse(
+        throw new IllegalArgumentException("backup dir must not be empty")
+      )
+  }
+
+  private def backupInsertLogPath(
+      backupDir: String,
+      seg: SegmentBackup,
+      slotFieldId: Long,
+      logId: Long
+  ): String = {
+    val base = backupBase(backupDir)
+    s"$base/binlogs/insert_log/${seg.collectionId}/${seg.partitionId}/" +
+      s"${seg.groupId}/${seg.segmentId}/$slotFieldId/$logId"
+  }
+
+  private def backupDeltaLogPath(
+      backupDir: String,
+      seg: SegmentBackup,
+      logId: Long
+  ): String = {
+    val base = backupBase(backupDir)
+    if (seg.partitionId == AllPartitionId) {
+      s"$base/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
+        s"${seg.segmentId}/$logId"
+    } else {
+      s"$base/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
+        s"${seg.groupId}/${seg.segmentId}/$logId"
+    }
+  }
 }

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -420,28 +420,33 @@ object BackupMetaReader extends Logging {
             )
           }
           val sorted = fieldBinlog.binlogs.sortBy(_.logId)
-          val paths = sorted.map(b =>
-            backupInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
+          // Hadoop-qualified paths for the footer reads; the native reader
+          // gets bucket-relative keys in `filePaths`.
+          val hadoopPaths = sorted.map(b =>
+            qualifiedInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
+          )
+          val nativePaths = sorted.map(b =>
+            nativeInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
           )
           // The head file's footer is read once for both the real field IDs
           // (which live in the parquet schema, not the backup meta) and its row
           // count; the remaining files' row counts are read in parallel.
           val headInfo = MilvusParquetFooterReader.readFieldIdsAndRowCount(
-            paths.head,
+            hadoopPaths.head,
             hadoopConf
           ) match {
             case Right(info) => info
             case Left(err) =>
               throw new RuntimeException(
-                s"failed to read footer of parquet ${paths.head} " +
+                s"failed to read footer of parquet ${hadoopPaths.head} " +
                   s"(backup segment ${seg.segmentId}, slot " +
                   s"${fieldBinlog.fieldId}): ${err.getMessage}",
                 err
               )
           }
-          val tailRowCounts = if (paths.size > 1) {
+          val tailRowCounts = if (hadoopPaths.size > 1) {
             readRowCountsInParallel(
-              paths.tail,
+              hadoopPaths.tail,
               hadoopConf,
               seg.segmentId,
               fieldBinlog.fieldId
@@ -452,7 +457,7 @@ object BackupMetaReader extends Logging {
           } else Seq.empty
           V2ColumnGroup(
             fieldIds = headInfo.fieldIds,
-            filePaths = paths,
+            filePaths = nativePaths,
             fileRowCounts = headInfo.rowCount +: tailRowCounts,
             slotFieldId = fieldBinlog.fieldId
           )
@@ -498,7 +503,7 @@ object BackupMetaReader extends Logging {
       .map(b =>
         V2DeltaLogFile(
           logId = b.logId,
-          logPath = backupDeltaLogPath(backupDir, seg, b.logId),
+          logPath = qualifiedDeltaLogPath(backupDir, seg, b.logId),
           entriesNum = b.entriesNum
         )
       )
@@ -548,6 +553,17 @@ object BackupMetaReader extends Logging {
     *   delta:  {backupDir}/binlogs/delta_log/{coll}/{part}/{seg}/{log}            (part == -1)
     *           {backupDir}/binlogs/delta_log/{coll}/{part}/{group}/{seg}/{log}    (part != -1)
     * }}}
+    *
+    * Two path forms are produced:
+    *   - **qualified** (`qualifiedInsertLogPath` / `qualifiedDeltaLogPath`),
+    *     e.g. `s3a://bucket/backup/b1/binlogs/...`, consumed by the Hadoop-side
+    *     reads (parquet footers, delta logs).
+    *   - **native** (`nativeInsertLogPath`), e.g. `backup/b1/binlogs/...`,
+    *     consumed by the milvus-storage native packed reader. Its
+    *     `FilesystemCache::resolve_config` rejects scheme-qualified URIs (it
+    *     would demand `extfs.*` config) and the filesystem proxy prepends
+    *     `fs.bucket_name`, so the column-group file keys must be
+    *     bucket-relative.
     */
   private def backupBase(backupDir: String): String = {
     Option(backupDir)
@@ -559,29 +575,70 @@ object BackupMetaReader extends Logging {
       )
   }
 
-  private def backupInsertLogPath(
+  /** Bucket-relative base of the backup dir: strips `scheme://bucket/` for S3
+    * URIs (e.g. `s3a://bucket/backup/b1` -> `backup/b1`); local dirs are
+    * returned unchanged. This is the key form the native reader expects.
+    */
+  private[read] def backupKeyBase(backupDir: String): String = {
+    val base = backupBase(backupDir)
+    val schemeIdx = base.indexOf("://")
+    if (schemeIdx < 0) {
+      base
+    } else {
+      val rest = base.substring(schemeIdx + 3)
+      val slash = rest.indexOf('/')
+      if (slash < 0) "" else rest.substring(slash + 1)
+    }
+  }
+
+  private def insertLogPath(
+      prefix: String,
+      seg: SegmentBackup,
+      slotFieldId: Long,
+      logId: Long
+  ): String =
+    s"$prefix/binlogs/insert_log/${seg.collectionId}/${seg.partitionId}/" +
+      s"${seg.groupId}/${seg.segmentId}/$slotFieldId/$logId"
+
+  private def deltaLogPath(
+      prefix: String,
+      seg: SegmentBackup,
+      logId: Long
+  ): String =
+    if (seg.partitionId == AllPartitionId) {
+      s"$prefix/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
+        s"${seg.segmentId}/$logId"
+    } else {
+      s"$prefix/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
+        s"${seg.groupId}/${seg.segmentId}/$logId"
+    }
+
+  /** Hadoop-qualified insert-log path (e.g.
+    * `s3a://bucket/backup/b1/binlogs/...`).
+    */
+  private[read] def qualifiedInsertLogPath(
       backupDir: String,
       seg: SegmentBackup,
       slotFieldId: Long,
       logId: Long
-  ): String = {
-    val base = backupBase(backupDir)
-    s"$base/binlogs/insert_log/${seg.collectionId}/${seg.partitionId}/" +
-      s"${seg.groupId}/${seg.segmentId}/$slotFieldId/$logId"
-  }
+  ): String = insertLogPath(backupBase(backupDir), seg, slotFieldId, logId)
 
-  private def backupDeltaLogPath(
+  /** Native-reader bucket-relative insert-log key (e.g.
+    * `backup/b1/binlogs/...`).
+    */
+  private[read] def nativeInsertLogPath(
+      backupDir: String,
+      seg: SegmentBackup,
+      slotFieldId: Long,
+      logId: Long
+  ): String = insertLogPath(backupKeyBase(backupDir), seg, slotFieldId, logId)
+
+  /** Hadoop-qualified delta-log path. Delta logs only feed the Hadoop-side
+    * delete-plan reader, so no native form is produced.
+    */
+  private[read] def qualifiedDeltaLogPath(
       backupDir: String,
       seg: SegmentBackup,
       logId: Long
-  ): String = {
-    val base = backupBase(backupDir)
-    if (seg.partitionId == AllPartitionId) {
-      s"$base/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
-        s"${seg.segmentId}/$logId"
-    } else {
-      s"$base/binlogs/delta_log/${seg.collectionId}/${seg.partitionId}/" +
-        s"${seg.groupId}/${seg.segmentId}/$logId"
-    }
-  }
+  ): String = deltaLogPath(backupBase(backupDir), seg, logId)
 }

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -719,6 +719,22 @@ object BackupMetaReader extends Logging {
         )
       )
 
+  /** Build the L0 (delete-only) `V2SegmentInfo` list for a collection with no
+    * footer reads. Used by the reader factory to compute the shared
+    * partition-scoped L0 delete plans independently of partition planning, so
+    * delete handling does not depend on Spark evaluating partitions first.
+    */
+  private[connector] def l0DeleteSegments(
+      info: BackupInfo,
+      collectionId: Long,
+      backupDir: String
+  ): Seq[V2SegmentInfo] =
+    info.collectionBackups
+      .filter(_.collectionId == collectionId)
+      .flatMap(_.allSegments)
+      .filter(seg => seg.isL0 && seg.deltalogs.exists(_.binlogs.nonEmpty))
+      .map(seg => emptyColumnGroupSegment(seg, backupDir))
+
   /** Read the row count of every path concurrently, preserving input order. All
     * reads share the caller-supplied `FileSystem` (thread-safe for concurrent
     * opens), so no per-file S3A client is constructed.

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -279,8 +279,12 @@ object BackupMetaReader extends Logging {
     */
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte] = {
     validateDynamicFieldSchema(schema)
+    // Drop system fields by field ID (0 = RowID, 1 = Timestamp), never by name:
+    // milvus-backup's schema comes from DescribeCollection, which only returns
+    // user fields, so a legitimately-named user field (e.g. a PK literally
+    // called "RowID") must survive and only true system IDs are removed.
     val userFields =
-      schema.fields.filterNot(f => f.name == "RowID" || f.name == "Timestamp")
+      schema.fields.filterNot(f => f.fieldId == 0L || f.fieldId == 1L)
     val protoFields = userFields.map { field =>
       FieldSchema(
         fieldID = field.fieldId,

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -381,25 +381,11 @@ object BackupMetaReader extends Logging {
     math.max(2, math.min(cores, 8))
   }
 
-  /** Bounded, daemon thread pool for per-file parquet footer reads on the
-    * driver (a HEAD + one tail range GET each). Footer reads are I/O-bound, so
-    * fanning them out avoids a serialized round trip per binlog before any
-    * Spark task is scheduled.
-    *
-    * The inner tail-file reads run on their own pool, separate from
-    * [[SegmentReadPool]], so a segment worker blocked on `Future.get()` for its
-    * tail reads can never starve those reads of threads (a single shared pool
-    * would deadlock when every worker waits on tasks that are queued behind
-    * it).
-    */
-  private val FooterReadPool: ExecutorService = Executors.newFixedThreadPool(
-    FooterReadThreadCount,
-    daemonThreadFactory("backup-footer-read")
-  )
-
   /** Bounded, daemon thread pool for segment-level conversion (each segment's
-    * footer reads are independent). See [[FooterReadPool]] for the deadlock
-    * rationale for keeping this separate from the per-file pool.
+    * footer reads are independent). Only column groups with a single binlog
+    * file are supported, so each segment does one footer read per column group
+    * and cross-segment parallelism is what keeps a large backup from stalling
+    * the driver.
     */
   private val SegmentReadPool: ExecutorService = Executors.newFixedThreadPool(
     FooterReadThreadCount,
@@ -582,6 +568,22 @@ object BackupMetaReader extends Logging {
             )
           }
           val sorted = fieldBinlog.binlogs.sortBy(_.logId)
+          // Guard: a column group spanning multiple binlog files is rejected.
+          // milvus-storage's BuildLoonColumnGroups encodes per-file row counts
+          // as group-cumulative ranges, which the packed reader intersects
+          // against each file's own zero-based row-group offsets, so file i > 0
+          // is silently truncated (zero rows when earlier files are at least as
+          // large). Refuse loudly rather than return a short DataFrame; the fix
+          // belongs in milvus-storage (per-file, not cumulative, indices).
+          if (sorted.size > 1) {
+            throw new IllegalStateException(
+              s"backup segment ${seg.segmentId} has a column group (slot " +
+                s"${fieldBinlog.fieldId}) spanning ${sorted.size} binlog files; " +
+                "multi-file column groups are unsupported until " +
+                "milvus-storage BuildLoonColumnGroups is fixed (per-file, not " +
+                "group-cumulative, row ranges)"
+            )
+          }
           // Hadoop-qualified paths for the footer reads; the native reader
           // gets bucket-relative keys in `filePaths`.
           val hadoopPaths = sorted.map(b =>
@@ -590,9 +592,9 @@ object BackupMetaReader extends Logging {
           val nativePaths = sorted.map(b =>
             nativeInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
           )
-          // The head file's footer is read once for both the real field IDs
+          // The (single) file's footer is read once for both the real field IDs
           // (which live in the parquet schema, not the backup meta) and its row
-          // count; the remaining files' row counts are read in parallel.
+          // count.
           val headInfo = MilvusParquetFooterReader.readFieldIdsAndRowCount(
             fs,
             hadoopPaths.head
@@ -606,27 +608,10 @@ object BackupMetaReader extends Logging {
                 err
               )
           }
-          val tailRowCounts = if (hadoopPaths.size > 1) {
-            readRowCountsInParallel(
-              fs,
-              hadoopPaths.tail,
-              seg.segmentId,
-              fieldBinlog.fieldId
-            ) match {
-              case Right(counts) => counts
-              case Left(err)     => throw err
-            }
-          } else Seq.empty
           V2ColumnGroup(
             fieldIds = headInfo.fieldIds,
             filePaths = nativePaths,
-            // NOTE: per-file row counts (the packed reader derives per-file
-            // [0, rc_i) ranges). A KNOWN milvus-storage bug
-            // (BuildLoonColumnGroups, v2_column_groups_builder.cpp) treats these
-            // as group-cumulative, so a column group spanning MULTIPLE binlog
-            // files reads short (file i>0 truncated) until that is fixed and
-            // the submodule is bumped. Single-file groups are unaffected.
-            fileRowCounts = headInfo.rowCount +: tailRowCounts,
+            fileRowCounts = Seq(headInfo.rowCount),
             slotFieldId = fieldBinlog.fieldId
           )
         }
@@ -734,38 +719,6 @@ object BackupMetaReader extends Logging {
       .flatMap(_.allSegments)
       .filter(seg => seg.isL0 && seg.deltalogs.exists(_.binlogs.nonEmpty))
       .map(seg => emptyColumnGroupSegment(seg, backupDir))
-
-  /** Read the row count of every path concurrently, preserving input order. All
-    * reads share the caller-supplied `FileSystem` (thread-safe for concurrent
-    * opens), so no per-file S3A client is constructed.
-    */
-  private def readRowCountsInParallel(
-      fs: FileSystem,
-      paths: Seq[String],
-      segmentId: Long,
-      slotFieldId: Long
-  ): Either[Throwable, Seq[Long]] = {
-    try {
-      val futures = paths.map { p =>
-        FooterReadPool.submit(new Callable[Long] {
-          override def call(): Long =
-            MilvusParquetFooterReader.readRowCount(fs, p) match {
-              case Right(n) => n
-              case Left(err) =>
-                throw new RuntimeException(
-                  s"failed to read row count from parquet $p " +
-                    s"(backup segment $segmentId, slot $slotFieldId): " +
-                    s"${err.getMessage}",
-                  err
-                )
-            }
-        })
-      }
-      Right(futures.map(_.get()))
-    } catch {
-      case NonFatal(e) => Left(e)
-    }
-  }
 
   // -------------------------------------------------------------------------
   // Backup path reconstruction

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -336,8 +336,10 @@ object BackupMetaReader extends Logging {
     if (schema.enableDynamicField && !schema.fields.exists(_.name == "$meta")) {
       throw new IllegalArgumentException(
         s"backup collection '${schema.name}' has enable_dynamic_field=true but " +
-          "its meta does not record the '$meta' field; create the backup with " +
-          "etcd access (--backup_index_extra) so the dynamic field schema is captured"
+          "its meta does not record the '$meta' field; re-create the backup " +
+          "with etcd access so the dynamic field schema is captured " +
+          "(--backup_index_extra requires milvus-backup >= v0.5.13; on " +
+          "v0.5.10-v0.5.12 the flag does not capture $meta)"
       )
     }
   }

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -1,0 +1,452 @@
+package com.zilliz.spark.connector.read
+
+import scala.util.control.NonFatal
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.{
+  DeserializationFeature,
+  JsonNode,
+  ObjectMapper
+}
+import com.fasterxml.jackson.databind.cfg.{CoercionAction, CoercionInputShape}
+import com.fasterxml.jackson.module.scala.{
+  DefaultScalaModule,
+  ScalaObjectMapper
+}
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.internal.Logging
+
+import io.milvus.grpc.common.KeyValuePair
+import io.milvus.grpc.schema.{
+  CollectionSchema => ProtoCollectionSchema,
+  DataType,
+  FieldSchema,
+  FieldState
+}
+
+/** Reader for milvus-backup binlog-format backups.
+  *
+  * A milvus-backup `create` run writes, under the backup directory:
+  *   - `meta/full_meta.json` — a proto-JSON `backuppb.BackupInfo` carrying the
+  *     collection schema plus every segment's binlog / deltalog layout (mirrors
+  *     Milvus's `schemapb.CollectionSchema` and `datapb.SegmentInfo`-lite), and
+  *   - `binlogs/insert_log/...` and `binlogs/delta_log/...` — byte-identical
+  *     copies of the Milvus storage objects.
+  *
+  * This object translates the meta into the same runtime objects the snapshot
+  * read path consumes (`V2SegmentInfo`), so the backup can be read offline with
+  * the existing packed-V2 reader. Two gaps vs. a Milvus snapshot are closed
+  * here:
+  *   1. milvus-backup persists only `log_size` per binlog, not `entries_num`.
+  *      The per-file row count is recovered by reading each parquet footer's
+  *      row count ([MilvusParquetFooterReader.readRowCount]). 2. The AVRO
+  *      segment-info (and hence the slot -> real field ID mapping) is not
+  *      copied by the backup; the real field IDs are recovered from each
+  *      parquet file's own schema
+  *      ([MilvusParquetFooterReader.readFieldIdsFromSchema]).
+  *
+  * Only StorageV2 (packed parquet, `storage_version == 2`) segments are
+  * supported — the same format the packed-V2 reader handles. StorageV1 is
+  * skipped and StorageV3 is rejected.
+  */
+object BackupMetaReader extends Logging {
+
+  // -------------------------------------------------------------------------
+  // Backup meta JSON model (wire keys match backuppb's Go encoding/json tags).
+  // -------------------------------------------------------------------------
+
+  /** Top-level `backuppb.BackupInfo`. */
+  case class BackupInfo(
+      @JsonProperty("id") id: String = "",
+      @JsonProperty("name") name: String = "",
+      @JsonProperty("format") format: String = "",
+      @JsonProperty("milvus_version") milvusVersion: String = "",
+      @JsonProperty("collection_backups") collectionBackups: Seq[
+        CollectionBackup
+      ] = Seq.empty
+  ) {
+    def isSnapshotFormat: Boolean = format == "snapshot"
+  }
+
+  case class CollectionBackup(
+      @JsonProperty("collection_id") collectionId: Long = 0L,
+      @JsonProperty("collection_name") collectionName: String = "",
+      @JsonProperty("db_name") dbName: String = "",
+      @JsonProperty("schema") schema: Option[BackupCollectionSchema] = None,
+      @JsonProperty("partition_backups") partitionBackups: Seq[
+        PartitionBackup
+      ] = Seq.empty,
+      @JsonProperty("l0_segments") l0Segments: Seq[SegmentBackup] = Seq.empty
+  ) {
+    def allSegments: Seq[SegmentBackup] =
+      partitionBackups.flatMap(_.segmentBackups) ++ l0Segments
+  }
+
+  case class PartitionBackup(
+      @JsonProperty("partition_id") partitionId: Long = 0L,
+      @JsonProperty("partition_name") partitionName: String = "",
+      @JsonProperty("segment_backups") segmentBackups: Seq[SegmentBackup] =
+        Seq.empty
+  )
+
+  /** Lite `datapb.SegmentInfo`. */
+  case class SegmentBackup(
+      @JsonProperty("segment_id") segmentId: Long = 0L,
+      @JsonProperty("collection_id") collectionId: Long = 0L,
+      @JsonProperty("partition_id") partitionId: Long = 0L,
+      @JsonProperty("num_of_rows") numOfRows: Long = 0L,
+      @JsonProperty("binlogs") binlogs: Seq[FieldBinlog] = Seq.empty,
+      @JsonProperty("deltalogs") deltalogs: Seq[FieldBinlog] = Seq.empty,
+      @JsonProperty("group_id") groupId: Long = 0L,
+      @JsonProperty("is_l0") isL0: Boolean = false,
+      @JsonProperty("v_channel") vChannel: String = "",
+      @JsonProperty("storage_version") storageVersion: Long = 0L
+  )
+
+  case class FieldBinlog(
+      @JsonProperty("fieldID") fieldId: Long = 0L,
+      @JsonProperty("binlogs") binlogs: Seq[Binlog] = Seq.empty
+  )
+
+  case class Binlog(
+      @JsonProperty("entries_num") entriesNum: Long = 0L,
+      @JsonProperty("log_path") logPath: String = "",
+      @JsonProperty("log_size") logSize: Long = 0L,
+      @JsonProperty("log_id") logId: Long = 0L
+  )
+
+  case class BackupKeyValuePair(
+      @JsonProperty("key") key: String = "",
+      @JsonProperty("value") value: String = ""
+  )
+
+  /** `backuppb.FieldSchema` — a mirror of Milvus's `schemapb.FieldSchema`. */
+  case class BackupFieldSchema(
+      @JsonProperty("fieldID") fieldId: Long = 0L,
+      @JsonProperty("name") name: String = "",
+      @JsonProperty("is_primary_key") isPrimaryKey: Boolean = false,
+      @JsonProperty("description") description: String = "",
+      @JsonProperty("data_type") rawDataType: Option[JsonNode] = None,
+      @JsonProperty("type_params") typeParams: Seq[BackupKeyValuePair] =
+        Seq.empty,
+      @JsonProperty("index_params") indexParams: Seq[BackupKeyValuePair] =
+        Seq.empty,
+      @JsonProperty("autoID") autoId: Boolean = false,
+      @JsonProperty("state") rawState: Option[JsonNode] = None,
+      @JsonProperty("element_type") rawElementType: Option[JsonNode] = None,
+      @JsonProperty("is_dynamic") isDynamic: Boolean = false,
+      @JsonProperty("is_partition_key") isPartitionKey: Boolean = false,
+      @JsonProperty("nullable") nullable: Boolean = false,
+      @JsonProperty("is_function_output") isFunctionOutput: Boolean = false,
+      @JsonProperty("default_value_base64") defaultValueBase64: String = ""
+  ) {
+    def dataType: Int = rawDataType.map(JsonTypeConverter.toInt).getOrElse(0)
+    def elementType: Int =
+      rawElementType.map(JsonTypeConverter.toInt).getOrElse(0)
+    def state: Int = rawState.map(JsonTypeConverter.toInt).getOrElse(0)
+  }
+
+  /** `backuppb.CollectionSchema` — a mirror of Milvus's schemapb. */
+  case class BackupCollectionSchema(
+      @JsonProperty("name") name: String = "",
+      @JsonProperty("description") description: String = "",
+      @JsonProperty("autoID") autoId: Boolean = false,
+      @JsonProperty("fields") fields: Seq[BackupFieldSchema] = Seq.empty,
+      @JsonProperty("enable_dynamic_field") enableDynamicField: Boolean = false,
+      @JsonProperty("properties") properties: Seq[BackupKeyValuePair] =
+        Seq.empty
+  )
+
+  // -------------------------------------------------------------------------
+  // Parsing
+  // -------------------------------------------------------------------------
+
+  private val mapper: ObjectMapper with ScalaObjectMapper = {
+    val m = new ObjectMapper() with ScalaObjectMapper
+    m.registerModule(DefaultScalaModule)
+    m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    m.configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, false)
+    m.coercionConfigFor(classOf[java.lang.Integer])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[java.lang.Long])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[Int])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m.coercionConfigFor(classOf[Long])
+      .setCoercion(CoercionInputShape.String, CoercionAction.TryConvert)
+    m
+  }
+
+  /** Absolute path of the `full_meta.json` of a backup directory.
+    *
+    * Works for both `s3a://bucket/backup/<name>` (or any scheme Hadoop FS
+    * understands) and plain local paths.
+    */
+  def metaPath(backupDir: String): String = {
+    val base = Option(backupDir).map(_.trim).getOrElse("")
+    if (base.isEmpty) {
+      throw new IllegalArgumentException("backup dir must not be empty")
+    }
+    val stripped = if (base.endsWith("/")) base.stripSuffix("/") else base
+    s"$stripped/meta/full_meta.json"
+  }
+
+  /** Read and parse the backup's `full_meta.json`. */
+  def readMeta(
+      hadoopConf: Configuration,
+      backupDir: String
+  ): Either[Throwable, BackupInfo] = {
+    try {
+      val metaFilePath = metaPath(backupDir)
+      val bytes = V2SegmentLoader.readAllBytes(hadoopConf, metaFilePath)
+      val json = new String(bytes, "UTF-8")
+      Right(mapper.readValue[BackupInfo](json))
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  /** Parse an in-memory `full_meta.json` string. Exposed for callers that have
+    * already read the bytes (e.g. tests) — [[readMeta]] covers the hadoop-path
+    * case.
+    */
+  def parse(json: String): Either[Throwable, BackupInfo] = {
+    try {
+      Right(mapper.readValue[BackupInfo](json))
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Schema conversion
+  // -------------------------------------------------------------------------
+
+  /** Convert a backup `CollectionSchema` into Milvus protobuf
+    * `CollectionSchema` bytes — the format the packed-V2 reader expects.
+    */
+  def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte] = {
+    val userFields =
+      schema.fields.filterNot(f => f.name == "RowID" || f.name == "Timestamp")
+    val protoFields = userFields.map { field =>
+      FieldSchema(
+        fieldID = field.fieldId,
+        name = field.name,
+        description = field.description,
+        dataType = DataType.fromValue(field.dataType),
+        isPrimaryKey = field.isPrimaryKey,
+        isClusteringKey = false,
+        typeParams = field.typeParams.map(toProtoKV),
+        indexParams = field.indexParams.map(toProtoKV),
+        autoID = field.autoId,
+        state = FieldState.fromValue(field.state),
+        elementType = DataType.fromValue(field.elementType),
+        isDynamic = field.isDynamic,
+        isPartitionKey = field.isPartitionKey,
+        nullable = field.nullable,
+        isFunctionOutput = field.isFunctionOutput,
+        defaultValue = decodeDefaultValue(field)
+      )
+    }
+    val protoSchema = ProtoCollectionSchema(
+      name = schema.name,
+      description = schema.description,
+      autoID = schema.autoId,
+      fields = protoFields,
+      enableDynamicField = schema.enableDynamicField,
+      properties = schema.properties.map(toProtoKV)
+    )
+    protoSchema.toByteArray
+  }
+
+  private def toProtoKV(kv: BackupKeyValuePair): KeyValuePair =
+    KeyValuePair(key = kv.key, value = kv.value)
+
+  /** milvus-backup stores the default value as base64-encoded, proto-marshalled
+    * `schemapb.ValueField`. The wire format matches
+    * `io.milvus.grpc.schema.ValueField`, so a direct `parseFrom` recovers it.
+    * Best-effort: a malformed or absent value degrades to no default.
+    */
+  private def decodeDefaultValue(
+      field: BackupFieldSchema
+  ): Option[io.milvus.grpc.schema.ValueField] = {
+    val b64 = field.defaultValueBase64
+    if (b64 == null || b64.isEmpty) {
+      None
+    } else {
+      scala.util.Try {
+        io.milvus.grpc.schema.ValueField.parseFrom(
+          java.util.Base64.getDecoder.decode(b64)
+        )
+      }.toOption
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Segment conversion
+  // -------------------------------------------------------------------------
+
+  /** Build the runtime `V2SegmentInfo` list for every StorageV2 segment of the
+    * backup. L0 delete-only segments keep an empty `columnGroups` so they feed
+    * the inherited delete-plan path, exactly like the snapshot reader.
+    *
+    * @param bucket
+    *   Bucket holding the backup's objects (empty for local paths). Bucket-
+    *   relative `log_path` values are resolved to `s3a://bucket/...`.
+    */
+  def toV2Segments(
+      info: BackupInfo,
+      hadoopConf: Configuration,
+      bucket: String,
+      applyDeletes: Boolean = true
+  ): Either[Throwable, Seq[V2SegmentInfo]] = {
+    try {
+      if (info.isSnapshotFormat) {
+        throw new IllegalStateException(
+          s"backup '${info.name}' is in snapshot format; only binlog-format " +
+            "backups can be read as a datasource"
+        )
+      }
+      val out = scala.collection.mutable.ArrayBuffer.empty[V2SegmentInfo]
+      info.collectionBackups.foreach { coll =>
+        coll.allSegments.foreach { seg =>
+          buildV2Segment(seg, hadoopConf, bucket, applyDeletes) match {
+            case Right(Some(v2)) => out += v2
+            case Right(None) => // skipped (legacy storage or L0 w/o deletes)
+            case Left(e)     => throw e
+          }
+        }
+      }
+      Right(out.toSeq)
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
+  }
+
+  /** Convert one backup segment into a `V2SegmentInfo` (or skip it).
+    *
+    * @return
+    *   `Right(None)` for StorageV1 segments or (when `applyDeletes = false`) L0
+    *   segments; `Right(Some(seg))` for readable StorageV2 segments.
+    */
+  private[read] def buildV2Segment(
+      seg: SegmentBackup,
+      hadoopConf: Configuration,
+      bucket: String,
+      applyDeletes: Boolean
+  ): Either[Throwable, Option[V2SegmentInfo]] = {
+    if (seg.storageVersion > 2L) {
+      Left(
+        new IllegalStateException(
+          s"backup segment ${seg.segmentId} has storage_version=" +
+            s"${seg.storageVersion} (StorageV3+); backup datasource only " +
+            "supports StorageV2 packed parquet"
+        )
+      )
+    } else if (seg.storageVersion < 2L) {
+      logInfo(
+        s"skipping backup segment ${seg.segmentId}: storage_version=" +
+          s"${seg.storageVersion} (< 2, not StorageV2)"
+      )
+      Right(None)
+    } else if (seg.isL0 && !applyDeletes) {
+      logInfo(
+        s"skipping StorageV2 L0 delete-only segment ${seg.segmentId} because " +
+          "applyDeletes=false"
+      )
+      Right(None)
+    } else if (seg.binlogs.isEmpty || seg.binlogs.forall(_.binlogs.isEmpty)) {
+      logWarning(
+        s"backup segment ${seg.segmentId} has no binlogs; emitting as empty " +
+          "column-group list"
+      )
+      Right(
+        Some(
+          V2SegmentInfo(
+            segmentId = seg.segmentId,
+            partitionId = seg.partitionId,
+            numOfRows = seg.numOfRows,
+            storageVersion = seg.storageVersion,
+            columnGroups = Seq.empty,
+            deltaLogs = toDeltaLogs(seg, bucket)
+          )
+        )
+      )
+    } else {
+      try {
+        val columnGroups = seg.binlogs.map { fieldBinlog =>
+          if (fieldBinlog.binlogs.isEmpty) {
+            throw new IllegalStateException(
+              s"backup segment ${seg.segmentId} has an empty binlogs entry " +
+                s"(slot ${fieldBinlog.fieldId}) while other entries are " +
+                "populated; cannot recover field ids for this column group"
+            )
+          }
+          val sorted = fieldBinlog.binlogs.sortBy(_.logId)
+          val paths =
+            sorted.map(b => V2SegmentLoader.resolvePath(b.logPath, bucket))
+          val fieldIds = MilvusParquetFooterReader.readFieldIdsFromSchema(
+            paths.head,
+            hadoopConf
+          ) match {
+            case Right(ids) => ids
+            case Left(err) =>
+              throw new RuntimeException(
+                s"failed to read field ids from parquet ${paths.head} " +
+                  s"(backup segment ${seg.segmentId}, slot " +
+                  s"${fieldBinlog.fieldId}): ${err.getMessage}",
+                err
+              )
+          }
+          val rowCounts = paths.map { p =>
+            MilvusParquetFooterReader.readRowCount(p, hadoopConf) match {
+              case Right(n) => n
+              case Left(err) =>
+                throw new RuntimeException(
+                  s"failed to read row count from parquet $p " +
+                    s"(backup segment ${seg.segmentId}, slot " +
+                    s"${fieldBinlog.fieldId}): ${err.getMessage}",
+                  err
+                )
+            }
+          }
+          V2ColumnGroup(
+            fieldIds = fieldIds,
+            filePaths = paths,
+            fileRowCounts = rowCounts,
+            slotFieldId = fieldBinlog.fieldId
+          )
+        }
+        Right(
+          Some(
+            V2SegmentInfo(
+              segmentId = seg.segmentId,
+              partitionId = seg.partitionId,
+              numOfRows = seg.numOfRows,
+              storageVersion = seg.storageVersion,
+              columnGroups = columnGroups,
+              deltaLogs = toDeltaLogs(seg, bucket)
+            )
+          )
+        )
+      } catch {
+        case NonFatal(e) => Left(e)
+      }
+    }
+  }
+
+  private def toDeltaLogs(
+      seg: SegmentBackup,
+      bucket: String
+  ): Seq[V2DeltaLogFile] =
+    seg.deltalogs
+      .flatMap(_.binlogs)
+      .sortBy(_.logId)
+      .map(b =>
+        V2DeltaLogFile(
+          logId = b.logId,
+          logPath = V2SegmentLoader.resolvePath(b.logPath, bucket),
+          entriesNum = b.entriesNum
+        )
+      )
+}

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -620,6 +620,12 @@ object BackupMetaReader extends Logging {
           V2ColumnGroup(
             fieldIds = headInfo.fieldIds,
             filePaths = nativePaths,
+            // NOTE: per-file row counts (the packed reader derives per-file
+            // [0, rc_i) ranges). A KNOWN milvus-storage bug
+            // (BuildLoonColumnGroups, v2_column_groups_builder.cpp) treats these
+            // as group-cumulative, so a column group spanning MULTIPLE binlog
+            // files reads short (file i>0 truncated) until that is fixed and
+            // the submodule is bumped. Single-file groups are unaffected.
             fileRowCounts = headInfo.rowCount +: tailRowCounts,
             slotFieldId = fieldBinlog.fieldId
           )

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -264,6 +264,11 @@ object BackupMetaReader extends Logging {
     }
   }
 
+  /** Serialize a parsed `BackupInfo` back to JSON. Used to thread the meta from
+    * table init to the scan planner so it is read/parsed only once.
+    */
+  def serialize(info: BackupInfo): String = mapper.writeValueAsString(info)
+
   // -------------------------------------------------------------------------
   // Schema conversion
   // -------------------------------------------------------------------------

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -2,6 +2,7 @@ package com.zilliz.spark.connector.read
 
 import java.util.concurrent.{
   Callable,
+  ConcurrentHashMap,
   ExecutorService,
   Executors,
   ThreadFactory
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.module.scala.{
   ScalaObjectMapper
 }
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.internal.Logging
 
 import io.milvus.grpc.common.KeyValuePair
@@ -205,18 +207,64 @@ object BackupMetaReader extends Logging {
     s"$stripped/meta/full_meta.json"
   }
 
-  /** Read and parse the backup's `full_meta.json`. */
+  /** Read and parse the backup's `full_meta.json`.
+    *
+    * The read is bounded ([[MilvusSnapshotReader.readUtf8WithLimit]]) so an
+    * oversized or pathological meta fails on the driver instead of being
+    * slurped into memory. Successful parses are cached per backup dir — a
+    * backup is an immutable export, and both table init and scan planning need
+    * it.
+    */
   def readMeta(
       hadoopConf: Configuration,
-      backupDir: String
+      backupDir: String,
+      maxBytes: Long = MilvusSnapshotReader.MaxSnapshotJsonBytes
   ): Either[Throwable, BackupInfo] = {
+    val cached = metaCache.get(backupDir)
+    if (cached != null) {
+      Right(cached)
+    } else {
+      readMetaUncached(hadoopConf, backupDir, maxBytes).map { info =>
+        metaCache.putIfAbsent(backupDir, info)
+        info
+      }
+    }
+  }
+
+  private def readMetaUncached(
+      hadoopConf: Configuration,
+      backupDir: String,
+      maxBytes: Long
+  ): Either[Throwable, BackupInfo] = {
+    var uri: java.net.URI = null
+    var fs: FileSystem = null
     try {
       val metaFilePath = metaPath(backupDir)
-      val bytes = V2SegmentLoader.readAllBytes(hadoopConf, metaFilePath)
-      val json = new String(bytes, "UTF-8")
-      Right(mapper.readValue[BackupInfo](json))
+      uri = new java.net.URI(metaFilePath)
+      fs = FileSystem.get(uri, hadoopConf)
+      val in = fs.open(new org.apache.hadoop.fs.Path(uri))
+      try {
+        val json =
+          MilvusSnapshotReader.readUtf8WithLimit(in, metaFilePath, maxBytes)
+        Right(mapper.readValue[BackupInfo](json))
+      } finally {
+        in.close()
+      }
     } catch {
       case NonFatal(e) => Left(e)
+    } finally {
+      Option(uri)
+        .flatMap(u => Option(u.getScheme))
+        .foreach { scheme =>
+          if (
+            fs != null && hadoopConf.getBoolean(
+              s"fs.$scheme.impl.disable.cache",
+              false
+            )
+          ) {
+            fs.close()
+          }
+        }
     }
   }
 
@@ -238,8 +286,15 @@ object BackupMetaReader extends Logging {
 
   /** Convert a backup `CollectionSchema` into Milvus protobuf
     * `CollectionSchema` bytes — the format the packed-V2 reader expects.
+    *
+    * Rejects a dynamic collection whose meta lacks the `$meta` field: a default
+    * backup only records it when created with etcd access
+    * (`--backup_index_extra`), and without it the reader would silently return
+    * a null `$meta` column while dropping the real field from the column
+    * groups.
     */
   def toProtobufSchemaBytes(schema: BackupCollectionSchema): Array[Byte] = {
+    validateDynamicFieldSchema(schema)
     val userFields =
       schema.fields.filterNot(f => f.name == "RowID" || f.name == "Timestamp")
     val protoFields = userFields.map { field =>
@@ -273,6 +328,23 @@ object BackupMetaReader extends Logging {
     protoSchema.toByteArray
   }
 
+  /** Validate a backup collection schema before planning. Currently rejects a
+    * dynamic collection whose meta has no `$meta` field (a default backup only
+    * records it with etcd access) — reading it would silently return a null
+    * `$meta` column.
+    */
+  private[connector] def validateDynamicFieldSchema(
+      schema: BackupCollectionSchema
+  ): Unit = {
+    if (schema.enableDynamicField && !schema.fields.exists(_.name == "$meta")) {
+      throw new IllegalArgumentException(
+        s"backup collection '${schema.name}' has enable_dynamic_field=true but " +
+          "its meta does not record the '$meta' field; create the backup with " +
+          "etcd access (--backup_index_extra) so the dynamic field schema is captured"
+      )
+    }
+  }
+
   private def toProtoKV(kv: BackupKeyValuePair): KeyValuePair =
     KeyValuePair(key = kv.key, value = kv.value)
 
@@ -304,6 +376,13 @@ object BackupMetaReader extends Logging {
     * segments.
     */
   private val AllPartitionId = -1L
+
+  /** Process-wide cache of parsed `full_meta.json` keyed by backup dir. Backups
+    * are immutable exports, and both table init and scan planning need the
+    * meta, so a successful parse is reused instead of reading+parsing twice.
+    */
+  private val metaCache =
+    new ConcurrentHashMap[String, BackupInfo]()
 
   private val FooterReadThreadCount: Int = {
     val cores = Runtime.getRuntime.availableProcessors()
@@ -404,11 +483,20 @@ object BackupMetaReader extends Logging {
         )
       )
     } else if (seg.binlogs.isEmpty || seg.binlogs.forall(_.binlogs.isEmpty)) {
-      logWarning(
-        s"backup segment ${seg.segmentId} has no binlogs; emitting as empty " +
-          "column-group list"
-      )
-      Right(Some(emptyColumnGroupSegment(seg, backupDir)))
+      if (seg.numOfRows == 0L) {
+        logWarning(
+          s"backup segment ${seg.segmentId} has no binlogs and no rows; " +
+            "emitting as empty column-group list"
+        )
+        Right(Some(emptyColumnGroupSegment(seg, backupDir)))
+      } else {
+        Left(
+          new IllegalStateException(
+            s"backup segment ${seg.segmentId} has no binlogs but " +
+              s"num_of_rows=${seg.numOfRows}; refusing to silently drop rows"
+          )
+        )
+      }
     } else {
       try {
         val columnGroups = seg.binlogs.map { fieldBinlog =>

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -55,11 +55,13 @@ import io.milvus.grpc.schema.{
   *      The per-file row count is recovered by reading each parquet footer's
   *      row count ([MilvusParquetFooterReader.readRowCount]), in parallel. 2.
   *      The AVRO segment-info (and hence the slot -> real field ID mapping) is
-  *      not copied by the backup; the real field IDs are recovered from each
-  *      parquet file's own schema
-  *      ([MilvusParquetFooterReader.readFieldIdsFromSchema]). 3. L0 delete-only
-  *      segments are created by Milvus without a `StorageVersion` (0/omitted),
-  *      so they are handled before any storage-version filtering.
+  *      not copied by the backup; the real field IDs are recovered from the
+  *      **head file** of each column group via that file's own parquet schema
+  *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]) — matching
+  *      V2SegmentLoader, which assumes all files in a group share the schema.
+  *      3. L0 delete-only segments are created by Milvus without a
+  *      `StorageVersion` (0/omitted), so they are handled before any
+  *      storage-version filtering.
   *
   * Only StorageV2 (packed parquet, `storage_version == 2`) data segments are
   * supported; anything else fails hard rather than returning a partial dataset.
@@ -463,7 +465,11 @@ object BackupMetaReader extends Logging {
             f.get() match {
               case Right(Some(v2)) => out += v2
               case Right(None)     => // L0 segment skipped (applyDeletes=false)
-              case Left(e)         => throw e
+              case Left(e)         =>
+                // One bad segment shouldn't leave a burst of wasted driver-side
+                // S3 footer reads running after the read has already failed.
+                futures.foreach(_.cancel(true))
+                throw e
             }
           }
         }
@@ -580,6 +586,29 @@ object BackupMetaReader extends Logging {
             filePaths = nativePaths,
             fileRowCounts = headInfo.rowCount +: tailRowCounts,
             slotFieldId = fieldBinlog.fieldId
+          )
+        }
+        // Driver-side validation to keep the no-partial-read contract: fail a
+        // malformed backup here instead of dispatching tasks that die late in
+        // the native reader (or silently returning an empty DataFrame).
+        if (columnGroups.exists(_.fieldIds.isEmpty)) {
+          throw new IllegalStateException(
+            s"backup segment ${seg.segmentId} has a column group with no " +
+              "field ids; refusing malformed backup"
+          )
+        }
+        val groupTotals = columnGroups.map(_.fileRowCounts.sum)
+        if (groupTotals.distinct.size > 1) {
+          throw new IllegalStateException(
+            s"backup segment ${seg.segmentId} column groups have " +
+              s"inconsistent row totals: ${groupTotals.mkString(",")}"
+          )
+        }
+        val totalRows = groupTotals.headOption.getOrElse(0L)
+        if (seg.numOfRows > 0L && totalRows <= 0L) {
+          throw new IllegalStateException(
+            s"backup segment ${seg.segmentId} has num_of_rows=${seg.numOfRows} " +
+              "but the parquet footers recovered 0 rows"
           )
         }
         Right(

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -484,11 +484,32 @@ object BackupMetaReader extends Logging {
     } catch {
       case NonFatal(e) => Left(e)
     } finally {
-      try {
-        if (fs != null) fs.close()
-      } catch {
-        case NonFatal(_) => // close is best-effort; the read result already won
+      closeIfNotCached(fs, hadoopConf)
+    }
+  }
+
+  /** Close a `FileSystem` only when its scheme has the cache disabled (i.e. the
+    * instance was created fresh for this read). A cached scheme (e.g. the
+    * process-wide `LocalFileSystem` for local paths) must NOT be closed: that
+    * evicts it from `FileSystem.CACHE` and fails every other holder with
+    * `IOException: Filesystem closed`.
+    */
+  private def closeIfNotCached(
+      fs: FileSystem,
+      hadoopConf: Configuration
+  ): Unit = {
+    try {
+      if (fs != null) {
+        val scheme = fs.getUri.getScheme
+        if (
+          scheme != null && hadoopConf
+            .getBoolean(s"fs.$scheme.impl.disable.cache", false)
+        ) {
+          fs.close()
+        }
       }
+    } catch {
+      case NonFatal(_) => // close is best-effort; the read result already won
     }
   }
 
@@ -660,11 +681,7 @@ object BackupMetaReader extends Logging {
       fs = FileSystem.get(new java.net.URI(backupBase(backupDir)), hadoopConf)
       buildV2SegmentWithFs(seg, fs, backupDir, applyDeletes)
     } finally {
-      try {
-        if (fs != null) fs.close()
-      } catch {
-        case NonFatal(_) => // close is best-effort; the read result already
-      }
+      closeIfNotCached(fs, hadoopConf)
     }
   }
 

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -166,6 +166,32 @@ object MilvusParquetFooterReader extends Logging {
     }
   }
 
+  /** Read the total number of rows a parquet file contains by summing its row
+    * groups' row counts from the footer.
+    *
+    * Used by the backup datasource to recover per-file row counts that
+    * milvus-backup's meta does not persist (only `log_size` is recorded), which
+    * the packed V2 reader requires to build valid `(start_index, end_index)`
+    * ranges per file. Like the other footer reads this issues a `HEAD` + a
+    * single range `GET` for the last few KB of the file.
+    *
+    * @return
+    *   `Right(rowCount)` on success. `Left(throwable)` on I/O or parse failure.
+    */
+  def readRowCount(
+      path: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Long] = {
+    readWithFileSystem(path, hadoopConf) { inputFile =>
+      val parquet = ParquetFileReader.open(inputFile)
+      try {
+        parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
+      } finally {
+        parquet.close()
+      }
+    }
+  }
+
   /** Parse the kv-metadata string `"100,0,1;101;102"` into `Seq(Seq(100, 0, 1),
     * Seq(101), Seq(102))`.
     *

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -116,22 +116,34 @@ object MilvusParquetFooterReader extends Logging {
     readWithFileSystem(path, hadoopConf) { inputFile =>
       val parquet = ParquetFileReader.open(inputFile)
       try {
-        val schema = parquet.getFooter.getFileMetaData.getSchema
-        val fields = schema.getFields.asScala
-        fields.map { t: Type =>
-          val id = t.getId
-          if (id == null) {
-            throw new IllegalStateException(
-              s"parquet column '${t.getName}' in $path has no PARQUET:field_id " +
-                s"metadata; cannot recover StorageV2 column-group field ids"
-            )
-          }
-          id.intValue().toLong
-        }.toSeq
+        fieldIdsFromMessageType(
+          parquet.getFooter.getFileMetaData.getSchema,
+          path
+        )
       } finally {
         parquet.close()
       }
     }
+  }
+
+  /** Shared field-ID extraction from a parquet `MessageType`, keeping the
+    * single-open callers (`readFieldIdsFromSchema`, `readFieldIdsAndRowCount`)
+    * in lock-step.
+    */
+  private[read] def fieldIdsFromMessageType(
+      schema: org.apache.parquet.schema.MessageType,
+      path: String
+  ): Seq[Long] = {
+    schema.getFields.asScala.map { t: Type =>
+      val id = t.getId
+      if (id == null) {
+        throw new IllegalStateException(
+          s"parquet column '${t.getName}' in $path has no PARQUET:field_id " +
+            s"metadata; cannot recover StorageV2 column-group field ids"
+        )
+      }
+      id.intValue().toLong
+    }.toSeq
   }
 
   private def readWithFileSystem[T](
@@ -216,17 +228,10 @@ object MilvusParquetFooterReader extends Logging {
       val parquet = ParquetFileReader.open(inputFile)
       try {
         val footer = parquet.getFooter
-        val schema = footer.getFileMetaData.getSchema
-        val fieldIds = schema.getFields.asScala.map { t: Type =>
-          val id = t.getId
-          if (id == null) {
-            throw new IllegalStateException(
-              s"parquet column '${t.getName}' in $path has no PARQUET:field_id " +
-                s"metadata; cannot recover StorageV2 column-group field ids"
-            )
-          }
-          id.intValue().toLong
-        }.toSeq
+        val fieldIds = fieldIdsFromMessageType(
+          footer.getFileMetaData.getSchema,
+          path
+        )
         val rowCount = footer.getBlocks.asScala.map(_.getRowCount).sum
         ParquetFooterInfo(fieldIds, rowCount)
       } finally {

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -166,6 +166,15 @@ object MilvusParquetFooterReader extends Logging {
     }
   }
 
+  /** The projection of a parquet footer the backup datasource needs to build a
+    * `V2ColumnGroup`: the file's own top-level field IDs plus its total row
+    * count, recovered from a single footer read.
+    */
+  private[read] case class ParquetFooterInfo(
+      fieldIds: Seq[Long],
+      rowCount: Long
+  )
+
   /** Read the total number of rows a parquet file contains by summing its row
     * groups' row counts from the footer.
     *
@@ -186,6 +195,40 @@ object MilvusParquetFooterReader extends Logging {
       val parquet = ParquetFileReader.open(inputFile)
       try {
         parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
+      } finally {
+        parquet.close()
+      }
+    }
+  }
+
+  /** Read a parquet file's own field IDs and total row count with a single
+    * footer open.
+    *
+    * Used by the backup datasource to avoid opening the head file of a column
+    * group twice — once for [[readFieldIdsFromSchema]] and again for
+    * [[readRowCount]].
+    */
+  def readFieldIdsAndRowCount(
+      path: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, ParquetFooterInfo] = {
+    readWithFileSystem(path, hadoopConf) { inputFile =>
+      val parquet = ParquetFileReader.open(inputFile)
+      try {
+        val footer = parquet.getFooter
+        val schema = footer.getFileMetaData.getSchema
+        val fieldIds = schema.getFields.asScala.map { t: Type =>
+          val id = t.getId
+          if (id == null) {
+            throw new IllegalStateException(
+              s"parquet column '${t.getName}' in $path has no PARQUET:field_id " +
+                s"metadata; cannot recover StorageV2 column-group field ids"
+            )
+          }
+          id.intValue().toLong
+        }.toSeq
+        val rowCount = footer.getBlocks.asScala.map(_.getRowCount).sum
+        ParquetFooterInfo(fieldIds, rowCount)
       } finally {
         parquet.close()
       }

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -204,54 +204,9 @@ object MilvusParquetFooterReader extends Logging {
       rowCount: Long
   )
 
-  /** Read the total number of rows a parquet file contains by summing its row
-    * groups' row counts from the footer.
-    *
-    * Used by the backup datasource to recover per-file row counts that
-    * milvus-backup's meta does not persist (only `log_size` is recorded), which
-    * the packed V2 reader requires to build valid `(start_index, end_index)`
-    * ranges per file. Like the other footer reads this issues a `HEAD` + a
-    * single range `GET` for the last few KB of the file.
-    *
-    * @return
-    *   `Right(rowCount)` on success. `Left(throwable)` on I/O or parse failure.
-    */
-  def readRowCount(
-      path: String,
-      hadoopConf: Configuration
-  ): Either[Throwable, Long] = {
-    readWithFileSystem(path, hadoopConf) { inputFile =>
-      sumRowGroups(inputFile)
-    }
-  }
-
-  /** [[readRowCount]] with a caller-supplied `FileSystem` (reused across many
-    * files, e.g. all binlogs of a backup read).
-    */
-  def readRowCount(
-      fs: FileSystem,
-      path: String
-  ): Either[Throwable, Long] = {
-    readWithFileSystem(fs, path) { inputFile =>
-      sumRowGroups(inputFile)
-    }
-  }
-
-  private def sumRowGroups(inputFile: InputFile): Long = {
-    val parquet = ParquetFileReader.open(inputFile)
-    try {
-      parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
-    } finally {
-      parquet.close()
-    }
-  }
-
   /** Read a parquet file's own field IDs and total row count with a single
-    * footer open.
-    *
-    * Used by the backup datasource to avoid opening the head file of a column
-    * group twice — once for [[readFieldIdsFromSchema]] and again for
-    * [[readRowCount]].
+    * footer open — the production path the backup datasource uses to recover
+    * both the column-group field IDs and the per-file row count.
     */
   def readFieldIdsAndRowCount(
       path: String,

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -156,14 +156,7 @@ object MilvusParquetFooterReader extends Logging {
       uri = new URI(path)
       val hadoopPath = new Path(uri)
       fs = hadoopPath.getFileSystem(hadoopConf)
-      val fileStatus = fs.getFileStatus(hadoopPath)
-      val inputFile = new InputFile {
-        override def getLength: Long = fileStatus.getLen
-
-        override def newStream(): org.apache.parquet.io.SeekableInputStream =
-          HadoopStreams.wrap(fs.open(hadoopPath))
-      }
-      Right(read(inputFile))
+      readWithFileSystem(fs, path)(read)
     } catch {
       case NonFatal(e) => Left(e)
     } finally {
@@ -175,6 +168,30 @@ object MilvusParquetFooterReader extends Logging {
           fs.close()
         }
       }
+    }
+  }
+
+  /** Read with a caller-supplied `FileSystem` (reused across many footer reads,
+    * e.g. all binlogs of a backup) instead of resolving a fresh one per file —
+    * with `fs.s3a.impl.disable.cache=true` every `FileSystem.get` otherwise
+    * constructs a whole S3A client + thread pool.
+    */
+  private[read] def readWithFileSystem[T](
+      fs: FileSystem,
+      path: String
+  )(read: InputFile => T): Either[Throwable, T] = {
+    try {
+      val hadoopPath = new Path(path)
+      val fileStatus = fs.getFileStatus(hadoopPath)
+      val inputFile = new InputFile {
+        override def getLength: Long = fileStatus.getLen
+
+        override def newStream(): org.apache.parquet.io.SeekableInputStream =
+          HadoopStreams.wrap(fs.open(hadoopPath))
+      }
+      Right(read(inputFile))
+    } catch {
+      case NonFatal(e) => Left(e)
     }
   }
 
@@ -204,12 +221,28 @@ object MilvusParquetFooterReader extends Logging {
       hadoopConf: Configuration
   ): Either[Throwable, Long] = {
     readWithFileSystem(path, hadoopConf) { inputFile =>
-      val parquet = ParquetFileReader.open(inputFile)
-      try {
-        parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
-      } finally {
-        parquet.close()
-      }
+      sumRowGroups(inputFile)
+    }
+  }
+
+  /** [[readRowCount]] with a caller-supplied `FileSystem` (reused across many
+    * files, e.g. all binlogs of a backup read).
+    */
+  def readRowCount(
+      fs: FileSystem,
+      path: String
+  ): Either[Throwable, Long] = {
+    readWithFileSystem(fs, path) { inputFile =>
+      sumRowGroups(inputFile)
+    }
+  }
+
+  private def sumRowGroups(inputFile: InputFile): Long = {
+    val parquet = ParquetFileReader.open(inputFile)
+    try {
+      parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
+    } finally {
+      parquet.close()
     }
   }
 
@@ -225,18 +258,35 @@ object MilvusParquetFooterReader extends Logging {
       hadoopConf: Configuration
   ): Either[Throwable, ParquetFooterInfo] = {
     readWithFileSystem(path, hadoopConf) { inputFile =>
-      val parquet = ParquetFileReader.open(inputFile)
-      try {
-        val footer = parquet.getFooter
-        val fieldIds = fieldIdsFromMessageType(
-          footer.getFileMetaData.getSchema,
-          path
-        )
-        val rowCount = footer.getBlocks.asScala.map(_.getRowCount).sum
-        ParquetFooterInfo(fieldIds, rowCount)
-      } finally {
-        parquet.close()
-      }
+      footerInfo(inputFile, path)
+    }
+  }
+
+  /** [[readFieldIdsAndRowCount]] with a caller-supplied `FileSystem`. */
+  def readFieldIdsAndRowCount(
+      fs: FileSystem,
+      path: String
+  ): Either[Throwable, ParquetFooterInfo] = {
+    readWithFileSystem(fs, path) { inputFile =>
+      footerInfo(inputFile, path)
+    }
+  }
+
+  private def footerInfo(
+      inputFile: InputFile,
+      path: String
+  ): ParquetFooterInfo = {
+    val parquet = ParquetFileReader.open(inputFile)
+    try {
+      val footer = parquet.getFooter
+      val fieldIds = fieldIdsFromMessageType(
+        footer.getFileMetaData.getSchema,
+        path
+      )
+      val rowCount = footer.getBlocks.asScala.map(_.getRowCount).sum
+      ParquetFooterInfo(fieldIds, rowCount)
+    } finally {
+      parquet.close()
     }
   }
 

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -433,7 +433,40 @@ case class V2SegmentInfo(
     storageVersion: Long, // always 2L for StorageV2
     columnGroups: Seq[V2ColumnGroup],
     deltaLogs: Seq[V2DeltaLogFile] = Seq.empty
-)
+) {
+
+  /** Dedup column groups by slot, keeping only the largest slot that owns each
+    * real field ID.
+    *
+    * A segment that went through add-field + backfill can carry two groups
+    * declaring the same field: the old multi-field parquet still physically
+    * holds the column (so its own schema reports it) while the newer
+    * single-field group reports it too. Without dedup the packed reader maps
+    * each group's field IDs to column names and lets the C++ side pick a
+    * source, which can return the older group's stale/null data.
+    *
+    * `slotFieldId < 0L` means "slot unknown" (e.g. the snapshot-JSON DTO path),
+    * where dedup cannot be trusted, so it is skipped.
+    */
+  def dedupColumnGroupsBySlot: V2SegmentInfo = {
+    val groups = columnGroups
+    if (groups.isEmpty || groups.exists(_.slotFieldId < 0L)) {
+      return this
+    }
+    val maxSlotPerField: Map[Long, Long] =
+      groups
+        .flatMap(g => g.fieldIds.map(fid => fid -> g.slotFieldId))
+        .groupBy(_._1)
+        .map { case (fid, pairs) => fid -> pairs.map(_._2).max }
+    val rebuilt = groups.flatMap { g =>
+      val keptFids =
+        g.fieldIds.filter(fid => maxSlotPerField(fid) == g.slotFieldId)
+      if (keptFids.isEmpty) None
+      else Some(g.copy(fieldIds = keptFids))
+    }
+    copy(columnGroups = rebuilt)
+  }
+}
 
 case class SnapshotBinlogEntry(
     @JsonProperty("entries_num") rawEntriesNum: Option[JsonNode] = None,

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -451,6 +451,17 @@ case class V2SegmentInfo(
     * each group's field IDs to column names and lets the C++ side pick a
     * source, which can return the older group's stale/null data.
     *
+    * PREMISE (why slot magnitude is a recency proxy): milvus-storage assigns a
+    * column-group slot id equal to the group's directory name. Multi-field
+    * groups (e.g. RowID+Timestamp or several fields) use small synthetic slots
+    * (< 100), while a single-field group uses its real field id (>= 100), and
+    * Milvus allocates field ids monotonically increasing over time. So the
+    * backfill-written single-field group for a new field always has a larger
+    * slot than the older multi-field group it overlaps, and "max slot" ==
+    * "newest owner". This is a heuristic, not a documented guarantee; if the
+    * slot assignment ever diverges from monotonicity, dedup could attribute a
+    * field to an older group.
+    *
     * `slotFieldId < 0L` means "slot unknown" (e.g. the snapshot-JSON DTO path),
     * where dedup cannot be trusted, so it is skipped.
     */

--- a/src/main/scala/read/MilvusSnapshotReader.scala
+++ b/src/main/scala/read/MilvusSnapshotReader.scala
@@ -357,8 +357,14 @@ object StorageV2ManifestItem {
 case class V2ColumnGroupDTO(
     @JsonProperty("field_ids") fieldIds: Seq[JsonNode] = Seq.empty,
     @JsonProperty("file_paths") filePaths: Seq[String] = Seq.empty,
-    @JsonProperty("file_row_counts") fileRowCounts: Seq[JsonNode] = Seq.empty
-)
+    @JsonProperty("file_row_counts") fileRowCounts: Seq[JsonNode] = Seq.empty,
+    @JsonProperty("slot_field_id") rawSlotFieldId: Option[JsonNode] = None
+) {
+  // -1 = unknown slot (legacy JSON that predates the field). Kept so
+  // `dedupColumnGroupsBySlot` in the read path does not silently no-op.
+  def slotFieldId: Long =
+    rawSlotFieldId.map(JsonTypeConverter.toLong).getOrElse(-1L)
+}
 
 case class V2DeltaLogFileDTO(
     @JsonProperty("log_id") rawLogId: Option[JsonNode] = None,
@@ -1063,7 +1069,8 @@ object MilvusSnapshotReader {
             fieldIds = cg.fieldIds.map(fid => LongNode.valueOf(fid): JsonNode),
             filePaths = cg.filePaths,
             fileRowCounts =
-              cg.fileRowCounts.map(n => LongNode.valueOf(n): JsonNode)
+              cg.fileRowCounts.map(n => LongNode.valueOf(n): JsonNode),
+            rawSlotFieldId = Some(LongNode.valueOf(cg.slotFieldId): JsonNode)
           )
         ),
         deltaLogs = s.deltaLogs.map(log =>
@@ -1103,7 +1110,8 @@ object MilvusSnapshotReader {
               fieldIds = cg.fieldIds.map(v => JsonTypeConverter.toLong(v)),
               filePaths = cg.filePaths,
               fileRowCounts =
-                cg.fileRowCounts.map(v => JsonTypeConverter.toLong(v))
+                cg.fileRowCounts.map(v => JsonTypeConverter.toLong(v)),
+              slotFieldId = cg.slotFieldId
             )
           ),
           deltaLogs = d.deltaLogs.map(log =>

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1685,13 +1685,6 @@ class MilvusScan(
     with Logging {
   private val milvusOption = MilvusOption(options)
 
-  // Partition-scoped L0 delete plans computed during backup planning; the
-  // reader factory resolves the shared plan from this single map (partitions
-  // carry only a marker), so a delete-heavy backup is not duplicated per
-  // segment. Driver-side only; never serialized to executors directly.
-  private var backupInheritedDeletePlans
-      : Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = Map.empty
-
   // Get vector search configuration from MilvusOption
   private val vectorSearchConfig = milvusOption.vectorSearchConfig
 
@@ -2730,7 +2723,6 @@ class MilvusScan(
             )
         }
       }
-    backupInheritedDeletePlans = inheritedDeletePlansByPartition
 
     // inlineInheritedDeletePlans=false: partitions carry a partition-scoped
     // marker instead of a copy of the L0 delete plan, and the reader factory
@@ -2805,11 +2797,9 @@ class MilvusScan(
         MilvusOption
           .isBackupMode(options) && MilvusOption.readApplyDeletes(options)
       ) {
-        // Backup partitions carry a partition-scoped marker (inline=false), so
-        // the shared L0 delete plan must be supplied here. Reuse the map the
-        // planner already computed — it is built once on the driver and
-        // serialized once with this factory, not per segment.
-        backupInheritedDeletePlans
+        // Computed here (not read from a planning side effect) so delete
+        // handling does not depend on Spark evaluating partitions first.
+        computeBackupInheritedDeletePlans()
       } else {
         Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
       }
@@ -2820,5 +2810,55 @@ class MilvusScan(
       pushedFilters,
       MilvusPackedV2DeleteContext(inheritedPlansByPartition)
     )
+  }
+
+  /** Compute the shared partition-scoped L0 delete plans for a backup read from
+    * the parsed meta, independent of partition planning. Returns `Map.empty`
+    * when no deletes apply or the meta/schema cannot be resolved (the planner
+    * would already have failed loudly for those cases).
+    */
+  private def computeBackupInheritedDeletePlans()
+      : Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
+    val backupDir = MilvusOption.backupDir(options).getOrElse {
+      return Map.empty
+    }
+    val meta = preParsedBackupMeta.getOrElse {
+      return Map.empty
+    }
+    val coll = MilvusScan
+      .resolveBackupCollection(
+        meta,
+        milvusOption.databaseName,
+        milvusOption.collectionName
+      )
+      .getOrElse { return Map.empty }
+    val schemaBytes = coll.schema
+      .map(BackupMetaReader.toProtobufSchemaBytes)
+      .getOrElse { return Map.empty }
+    val pkField = CollectionSchema
+      .parseFrom(schemaBytes)
+      .fields
+      .find(_.isPrimaryKey)
+      .getOrElse { return Map.empty }
+    val l0Segments =
+      BackupMetaReader.l0DeleteSegments(meta, coll.collectionId, backupDir)
+    if (l0Segments.isEmpty) {
+      Map.empty
+    } else {
+      val hadoopConf = buildSnapshotHadoopConf(backupDir)
+      MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
+        l0Segments,
+        pkField,
+        MilvusScan.snapshotBucket(backupDir).getOrElse(""),
+        hadoopConf
+      ) match {
+        case Right(plans) => plans
+        case Left(err) =>
+          throw new IllegalStateException(
+            s"Failed to load inherited StorageV2 delete logs for reader factory: ${err.getMessage}",
+            err
+          )
+      }
+    }
   }
 }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -182,6 +182,9 @@ case class MilvusTable(
     with Logging {
   var milvusCollection: MilvusCollectionInfo = _
   var partitionID: Long = 0L
+  // Serialized full_meta.json parsed during initFromBackup; threaded to the
+  // scan planner via the BackupMetaJson option so the meta is read/parsed once.
+  private var backupMetaJson: Option[String] = None
   initInfo()
   var fieldIDs =
     if (milvusOption.fieldIDs.nonEmpty) {
@@ -237,7 +240,9 @@ case class MilvusTable(
   private def initFromBackup(): Unit = {
     partitionID = 0L
 
-    val parsedCollection =
+    val parsedMeta: Option[
+      (BackupMetaReader.BackupInfo, Option[BackupMetaReader.CollectionBackup])
+    ] =
       MilvusOption.backupDir(milvusOption.options).flatMap { dir =>
         val conf =
           MilvusScan.buildHadoopConfForOptions(milvusOption.options, dir)
@@ -250,8 +255,8 @@ case class MilvusTable(
             )
           )
           .toOption
-          .flatMap { meta =>
-            MilvusScan
+          .map { meta =>
+            val resolved = MilvusScan
               .resolveBackupCollection(
                 meta,
                 milvusOption.databaseName,
@@ -267,9 +272,14 @@ case class MilvusTable(
                 )
                 None
             }
+            (meta, resolved)
           }
       }
+    backupMetaJson = parsedMeta.map { case (meta, _) =>
+      BackupMetaReader.serialize(meta)
+    }
 
+    val parsedCollection = parsedMeta.flatMap(_._2)
     val collectionId = parsedCollection.map(_.collectionId).getOrElse(0L)
 
     val schemaFromMeta = parsedCollection.flatMap(_.schema).map { s =>
@@ -436,6 +446,9 @@ case class MilvusTable(
         MilvusOption.MilvusPartitionID,
         partitionID.toString
       )
+    }
+    backupMetaJson.foreach { json =>
+      mergedOptions.put(MilvusOption.BackupMetaJson, json)
     }
 
     val allOptions = new CaseInsensitiveStringMap(mergedOptions)
@@ -2516,19 +2529,36 @@ class MilvusScan(
     )
 
     val hadoopConf = buildSnapshotHadoopConf(backupDir)
-    val meta = BackupMetaReader.readMeta(
-      hadoopConf,
-      backupDir,
-      MilvusScan.backupMaxJsonBytes(options)
-    ) match {
-      case Right(m) => m
-      case Left(err) =>
-        throw new IllegalArgumentException(
-          s"Failed to parse backup meta at ${BackupMetaReader
-              .metaPath(backupDir)}: ${err.getMessage}",
-          err
-        )
-    }
+    // Prefer the meta already parsed during table init (threaded via the
+    // BackupMetaJson option) so full_meta.json is read/parsed once per read;
+    // fall back to a fresh read otherwise (e.g. direct scan without table init).
+    val meta = Option(options.get(MilvusOption.BackupMetaJson))
+      .filter(_.nonEmpty)
+      .map { json =>
+        BackupMetaReader.parse(json) match {
+          case Right(m) => m
+          case Left(err) =>
+            throw new IllegalArgumentException(
+              s"Failed to parse threaded backup meta for '$backupDir': ${err.getMessage}",
+              err
+            )
+        }
+      }
+      .getOrElse {
+        BackupMetaReader.readMeta(
+          hadoopConf,
+          backupDir,
+          MilvusScan.backupMaxJsonBytes(options)
+        ) match {
+          case Right(m) => m
+          case Left(err) =>
+            throw new IllegalArgumentException(
+              s"Failed to parse backup meta at ${BackupMetaReader
+                  .metaPath(backupDir)}: ${err.getMessage}",
+              err
+            )
+        }
+      }
     if (meta.isSnapshotFormat) {
       throw new IllegalArgumentException(
         s"Backup '${meta.name}' is in snapshot format; only binlog-format " +
@@ -2580,6 +2610,16 @@ class MilvusScan(
     // never opened. The native packed reader receives bucket-relative keys, so
     // its `fs.bucket_name` must be canonicalized to the backup URI's bucket.
     val canonicalBucket = MilvusScan.snapshotBucket(backupDir)
+    if (canonicalBucket.isEmpty) {
+      // The JNI packed reader requires S3: with a local/file:// dir it would
+      // fall back to a-bucket/localhost:9000 and fail on every task, so reject
+      // here rather than after footer planning and partition dispatch.
+      throw new IllegalArgumentException(
+        s"${MilvusOption.BackupDir} must be an S3 URI (s3a://...) for reads; " +
+          s"got '$backupDir'. Local or file:// backup dirs are only supported " +
+          "by the meta/footer mapping layer, not the native packed reader"
+      )
+    }
     val v2Segments = BackupMetaReader.toV2Segments(
       meta,
       hadoopConf,

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -979,11 +979,11 @@ object MilvusScan extends Logging {
               .map(_.split(":").head)
               .filter(_.nonEmpty)
           }
-        case Some(other) =>
-          throw new IllegalArgumentException(
-            s"Unsupported snapshot s3_location scheme '$other': $trimmed"
-          )
-        case None => None
+        // Non-S3 schemes (e.g. `file://` for a local snapshot/backup dir) carry
+        // no bucket to configure; treat them as "no bucket". Explicit scheme
+        // validation lives in resolveClientSnapshotLocation.
+        case Some(_) => None
+        case None    => None
       }
     }
   }
@@ -2443,13 +2443,30 @@ class MilvusScan(
     val coll = meta.collectionBackups.head
     val schemaBytes = coll.schema
       .map(BackupMetaReader.toProtobufSchemaBytes)
-      .getOrElse(Array.empty[Byte])
-    val bucket = backupBucket(backupDir)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          s"Backup '${meta.name}' meta has no schema for collection " +
+            s"'${coll.collectionName}'; cannot plan a read"
+        )
+      }
+    val pkField = CollectionSchema
+      .parseFrom(schemaBytes)
+      .fields
+      .find(_.isPrimaryKey)
+      .getOrElse {
+        throw new IllegalArgumentException(
+          s"Backup '${meta.name}' collection '${coll.collectionName}' schema " +
+            "has no primary key; cannot plan a read"
+        )
+      }
     val applyDeletes = MilvusOption.readApplyDeletes(options)
+    // Object paths are reconstructed from `backupDir` plus segment IDs inside
+    // BackupMetaReader; the meta's `log_path` values are source keys and are
+    // never opened. No separate bucket is needed for delete-plan resolution.
     val v2Segments = BackupMetaReader.toV2Segments(
       meta,
       hadoopConf,
-      bucket,
+      backupDir,
       applyDeletes
     ) match {
       case Right(segs) => segs
@@ -2465,11 +2482,10 @@ class MilvusScan(
       coll.collectionName
     )
 
-    val bucketOpt = if (bucket.nonEmpty) Some(bucket) else None
     val v2DeletePlans = loadV2DeletePlans(
       v2Segments,
       schemaBytes,
-      bucketOpt,
+      snapshotBucket = None,
       hadoopConf,
       errorContext = "backup"
     )
@@ -2481,19 +2497,10 @@ class MilvusScan(
       if (!applyDeletes || inheritedDeleteSegments.isEmpty) {
         Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
       } else {
-        val pkField = CollectionSchema
-          .parseFrom(schemaBytes)
-          .fields
-          .find(_.isPrimaryKey)
-          .getOrElse {
-            throw new IllegalArgumentException(
-              "No primary key field found in schema"
-            )
-          }
         MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
           inheritedDeleteSegments,
           pkField,
-          bucketOpt.getOrElse(""),
+          bucket = "",
           hadoopConf
         ) match {
           case Right(plans) => plans
@@ -2515,16 +2522,6 @@ class MilvusScan(
       inlineInheritedDeletePlans = true
     )
   }
-
-  /** Bucket holding the backup's objects: explicit `fs.bucket_name` wins,
-    * otherwise the bucket is parsed out of the backup dir URI (e.g.
-    * `s3a://bucket/backup/<name>`). Empty means local paths.
-    */
-  private def backupBucket(backupDir: String): String =
-    MilvusScan
-      .connectorS3BucketOption(milvusOption.options)
-      .orElse(MilvusScan.snapshotBucket(backupDir))
-      .getOrElse("")
 
   override def createReaderFactory(): PartitionReaderFactory = {
     val optionsMap = options.asScala.toMap

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -59,6 +59,7 @@ import com.zilliz.spark.connector.{
 }
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
+  BackupMetaReader,
   MilvusDeltaLogReader,
   MilvusPackedV2DeleteContext,
   MilvusPackedV2InputPartition,
@@ -86,8 +87,10 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
     val options = new CaseInsensitiveStringMap(properties)
     val milvusOption = MilvusOption(options)
     MilvusOption.validateSnapshotModeOptions(options)
+    MilvusOption.validateBackupModeOptions(options)
     val isSnapshotMode = MilvusOption.isSnapshotMode(options)
-    if (milvusOption.uri.isEmpty && !isSnapshotMode) {
+    val isBackupMode = MilvusOption.isBackupMode(options)
+    if (milvusOption.uri.isEmpty && !isSnapshotMode && !isBackupMode) {
       throw new IllegalArgumentException(
         s"Option '${MilvusOption.MilvusUri}' is required for reading milvus data."
       )
@@ -103,7 +106,9 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
 
     // Check for snapshot mode - use snapshot schema if provided
     MilvusOption.validateSnapshotModeOptions(options)
+    MilvusOption.validateBackupModeOptions(options)
     val isSnapshotMode = MilvusOption.isSnapshotMode(options)
+    val isBackupMode = MilvusOption.isBackupMode(options)
 
     if (isSnapshotMode) {
       // Try to get schema from snapshot JSON
@@ -126,6 +131,11 @@ case class MilvusDataSource() extends TableProvider with DataSourceRegister {
           // The actual schema should be provided via .schema() call
           StructType(Seq.empty)
         }
+    } else if (isBackupMode) {
+      // Backup mode is fully offline: the schema is materialized from the
+      // backup's full_meta.json when the read plans its partitions. Return an
+      // empty schema here; callers supply the real schema via .schema().
+      StructType(Seq.empty)
     } else {
       // Client-based mode (existing behavior)
       if (milvusOption.collectionName.isEmpty) {
@@ -191,6 +201,12 @@ case class MilvusTable(
   private def isSnapshotMode: Boolean =
     MilvusOption.isSnapshotMode(milvusOption.options)
 
+  /** Check if backup mode is enabled (data comes from a milvus-backup export,
+    * not client). Requires [[MilvusOption.BackupDir]] to be set.
+    */
+  private def isBackupMode: Boolean =
+    MilvusOption.isBackupMode(milvusOption.options)
+
   def initInfo(): Unit = {
     // Check for snapshot mode first - skip client calls if snapshot data is provided
     if (isSnapshotMode) {
@@ -198,10 +214,69 @@ case class MilvusTable(
         "Snapshot mode enabled - skipping Milvus client connection for collection info"
       )
       initFromSnapshot()
+    } else if (isBackupMode) {
+      logInfo(
+        "Backup mode enabled - skipping Milvus client connection for collection info"
+      )
+      initFromBackup()
     } else {
       // Client-based mode (existing behavior)
       initFromClient()
     }
+  }
+
+  /** Initialize collection info from a milvus-backup export (no client
+    * connection). The collection schema is materialized from the backup's
+    * `full_meta.json` so downstream metadata rehydration (e.g. Milvus data type
+    * / vector dimension on Spark fields) works identically to snapshot mode.
+    * Best-effort: if the meta cannot be read or parsed, we fall back to an
+    * empty schema and rely on the caller-supplied Spark schema.
+    */
+  private def initFromBackup(): Unit = {
+    val collectionId = milvusOption.options
+      .get(MilvusOption.SnapshotCollectionId)
+      .map(_.toLong)
+      .getOrElse(0L)
+    partitionID = 0L
+
+    val schemaFromMeta =
+      MilvusOption.backupDir(milvusOption.options).flatMap { dir =>
+        val conf =
+          MilvusScan.buildHadoopConfForOptions(milvusOption.options, dir)
+        BackupMetaReader
+          .readMeta(conf, dir)
+          .toOption
+          .flatMap(_.collectionBackups.headOption.flatMap(_.schema))
+          .flatMap(s =>
+            scala.util
+              .Try(
+                CollectionSchema.parseFrom(
+                  BackupMetaReader.toProtobufSchemaBytes(s)
+                )
+              )
+              .toOption
+          )
+      }
+
+    schemaFromMeta match {
+      case Some(schema) =>
+        logInfo(
+          s"Initialized from backup: collectionID=$collectionId, " +
+            s"schema='${schema.name}' with ${schema.fields.size} fields"
+        )
+      case None =>
+        logWarning(
+          "Could not materialize collection schema from backup meta; " +
+            "relying on the caller-provided Spark schema"
+        )
+    }
+
+    milvusCollection = MilvusCollectionInfo(
+      dbName = milvusOption.databaseName,
+      collectionName = milvusOption.collectionName,
+      collectionID = collectionId,
+      schema = schemaFromMeta.getOrElse(createMinimalCollectionSchema(None))
+    )
   }
 
   /** Initialize collection info from snapshot metadata (no client connection)
@@ -475,7 +550,9 @@ case class MilvusTable(
   override def schema(): StructType = {
     // In snapshot mode with provided sparkSchema, use it directly
     // This avoids the need to parse milvusCollection.schema which may be incomplete
-    if (isSnapshotMode && sparkSchema.isDefined && sparkSchema.get.nonEmpty) {
+    if (
+      (isSnapshotMode || isBackupMode) && sparkSchema.isDefined && sparkSchema.get.nonEmpty
+    ) {
       logInfo(
         s"Using provided sparkSchema in snapshot mode: ${sparkSchema.get.fieldNames.mkString(", ")}"
       )
@@ -666,7 +743,8 @@ class MilvusScanBuilder(
     // TODO: implement filter pushdown for V2 packed reader in a separate PR.
     val isPackedV2 = Option(options.get(MilvusOption.SnapshotV2Segments))
       .exists(_.nonEmpty)
-    if (isPackedV2) {
+    val isBackupMode = MilvusOption.isBackupMode(options)
+    if (isPackedV2 || isBackupMode) {
       pushedFilterArray = Array.empty
       return filters
     }
@@ -1363,6 +1441,87 @@ object MilvusScan extends Logging {
     metadata
   }
 
+  /** Build a Hadoop `Configuration` for reading objects referenced by a
+    * snapshot/backup path, applying the connector's `fs.*` options plus any
+    * per-bucket S3A configuration. Extracted as a companion method so both the
+    * scan planner and table-level schema rehydration (backup mode) share it.
+    */
+  private[sources] def buildHadoopConfForOptions(
+      rawOptions: scala.collection.Map[String, String],
+      path: String
+  ): Configuration = {
+    val conf = SparkSession.getActiveSession
+      .orElse(SparkSession.getDefaultSession)
+      .map(_.sessionState.newHadoopConf())
+      .getOrElse(new Configuration())
+    val endpoint = optionValue(rawOptions, Properties.FsConfig.FsAddress)
+    val accessKey = optionValue(rawOptions, Properties.FsConfig.FsAccessKeyId)
+    val secretKey =
+      optionValue(rawOptions, Properties.FsConfig.FsAccessKeyValue)
+    val useSsl = optionValue(rawOptions, Properties.FsConfig.FsUseSSL)
+    val region = optionValue(rawOptions, Properties.FsConfig.FsRegion)
+    val useIam = optionValue(rawOptions, Properties.FsConfig.FsUseIam)
+      .exists(_.trim.equalsIgnoreCase("true"))
+    val useVirtualHost =
+      optionValue(rawOptions, Properties.FsConfig.FsUseVirtualHost)
+        .filter(_.trim.nonEmpty)
+    val pathStyle = optionValue(rawOptions, "fs.s3a.path.style.access")
+      .orElse(
+        useVirtualHost.map(v => (!v.trim.equalsIgnoreCase("true")).toString)
+      )
+
+    def setIfDefined(key: String, value: Option[String]): Unit = {
+      value.map(_.trim).filter(_.nonEmpty).foreach(conf.set(key, _))
+    }
+
+    def configureS3A(prefix: String): Unit = {
+      setIfDefined(s"$prefix.endpoint", endpoint)
+      setIfDefined(s"$prefix.connection.ssl.enabled", useSsl)
+      setIfDefined(s"$prefix.path.style.access", pathStyle)
+      setIfDefined(s"$prefix.endpoint.region", region)
+      setIfDefined(s"$prefix.region", region)
+      if (useIam) {
+        conf.unset(s"$prefix.access.key")
+        conf.unset(s"$prefix.secret.key")
+        conf.set(
+          s"$prefix.aws.credentials.provider",
+          DefaultAwsCredentialsProvider
+        )
+      } else {
+        setIfDefined(s"$prefix.access.key", accessKey)
+        setIfDefined(s"$prefix.secret.key", secretKey)
+        if (
+          accessKey.exists(_.trim.nonEmpty) && secretKey.exists(_.trim.nonEmpty)
+        ) {
+          conf.set(
+            s"$prefix.aws.credentials.provider",
+            SimpleAwsCredentialsProvider
+          )
+        }
+      }
+    }
+
+    if (conf.get("fs.s3a.impl") == null) {
+      conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+    }
+    conf.set("fs.s3a.impl.disable.cache", "true")
+    if (
+      !useIam && (accessKey
+        .forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty))
+    ) {
+      logWarning(
+        "Snapshot/backup S3 credentials were not provided; Hadoop S3A will use the default AWS credential provider chain."
+      )
+    }
+    configureS3A("fs.s3a")
+
+    snapshotBucketsToConfigure(
+      path,
+      connectorS3BucketOption(rawOptions).getOrElse("")
+    ).foreach(bucket => configureS3A(s"fs.s3a.bucket.$bucket"))
+    conf
+  }
+
 }
 
 class MilvusScan(
@@ -1400,6 +1559,7 @@ class MilvusScan(
 
   private[sources] def shouldCacheInputPartitions: Boolean =
     MilvusOption.isSnapshotMode(options) ||
+      MilvusOption.isBackupMode(options) ||
       MilvusScan.canUseClientSnapshotFastPath(milvusOption)
 
   private def computeInputPartitions(): Array[InputPartition] = {
@@ -1409,6 +1569,10 @@ class MilvusScan(
         options.get(MilvusOption.SnapshotManifests)
       )
       return planInputPartitionsFromSnapshot(snapshotManifests.getOrElse(""))
+    }
+
+    if (MilvusOption.isBackupMode(options)) {
+      return planInputPartitionsFromBackup()
     }
 
     if (milvusOption.collectionName.isEmpty) {
@@ -1777,87 +1941,8 @@ class MilvusScan(
 
   private[sources] def buildSnapshotHadoopConf(
       snapshotPath: String
-  ): Configuration = {
-    val conf = SparkSession.getActiveSession
-      .orElse(SparkSession.getDefaultSession)
-      .map(_.sessionState.newHadoopConf())
-      .getOrElse(new Configuration())
-    val rawOptions = milvusOption.options
-    val endpoint =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAddress)
-    val accessKey =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyId)
-    val secretKey =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsAccessKeyValue)
-    val useSsl =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsUseSSL)
-    val region =
-      MilvusScan.optionValue(rawOptions, Properties.FsConfig.FsRegion)
-    val useIam = MilvusScan
-      .optionValue(rawOptions, Properties.FsConfig.FsUseIam)
-      .exists(_.trim.equalsIgnoreCase("true"))
-    val useVirtualHost = MilvusScan
-      .optionValue(rawOptions, Properties.FsConfig.FsUseVirtualHost)
-      .filter(_.trim.nonEmpty)
-    val pathStyle = MilvusScan
-      .optionValue(rawOptions, "fs.s3a.path.style.access")
-      .orElse(
-        useVirtualHost.map(v => (!v.trim.equalsIgnoreCase("true")).toString)
-      )
-
-    def setIfDefined(key: String, value: Option[String]): Unit = {
-      value.map(_.trim).filter(_.nonEmpty).foreach(conf.set(key, _))
-    }
-
-    def configureS3A(prefix: String): Unit = {
-      setIfDefined(s"$prefix.endpoint", endpoint)
-      setIfDefined(s"$prefix.connection.ssl.enabled", useSsl)
-      setIfDefined(s"$prefix.path.style.access", pathStyle)
-      setIfDefined(s"$prefix.endpoint.region", region)
-      setIfDefined(s"$prefix.region", region)
-      if (useIam) {
-        conf.unset(s"$prefix.access.key")
-        conf.unset(s"$prefix.secret.key")
-        conf.set(
-          s"$prefix.aws.credentials.provider",
-          MilvusScan.DefaultAwsCredentialsProvider
-        )
-      } else {
-        setIfDefined(s"$prefix.access.key", accessKey)
-        setIfDefined(s"$prefix.secret.key", secretKey)
-        if (
-          accessKey.exists(_.trim.nonEmpty) && secretKey.exists(_.trim.nonEmpty)
-        ) {
-          conf.set(
-            s"$prefix.aws.credentials.provider",
-            MilvusScan.SimpleAwsCredentialsProvider
-          )
-        }
-      }
-    }
-
-    if (conf.get("fs.s3a.impl") == null) {
-      conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-    }
-    conf.set("fs.s3a.impl.disable.cache", "true")
-    if (
-      !useIam && (accessKey
-        .forall(_.trim.isEmpty) || secretKey.forall(_.trim.isEmpty))
-    ) {
-      logWarning(
-        "Snapshot S3 credentials were not provided; Hadoop S3A will use the default AWS credential provider chain."
-      )
-    }
-    configureS3A("fs.s3a")
-
-    MilvusScan
-      .snapshotBucketsToConfigure(
-        snapshotPath,
-        MilvusScan.connectorS3BucketOption(rawOptions).getOrElse("")
-      )
-      .foreach(bucket => configureS3A(s"fs.s3a.bucket.$bucket"))
-    conf
-  }
+  ): Configuration =
+    MilvusScan.buildHadoopConfForOptions(milvusOption.options, snapshotPath)
 
   private[sources] def readAllBytes(
       conf: Configuration,
@@ -2313,6 +2398,133 @@ class MilvusScan(
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition
     )
   }
+
+  /** Plan input partitions from a milvus-backup binlog-format export (offline,
+    * no Milvus client connection).
+    *
+    * `[[MilvusOption.BackupDir]]` points at the backup directory (the parent of
+    * `meta/full_meta.json`). The meta is translated by [[BackupMetaReader]]
+    * into the same `V2SegmentInfo` objects the snapshot path uses, then handed
+    * to the shared [[buildSnapshotPartitions]] so delete planning, extra
+    * columns, vector projection and the packed-V2 reader are all reused.
+    */
+  private def planInputPartitionsFromBackup(): Array[InputPartition] = {
+    val backupDir = MilvusOption.backupDir(options).getOrElse {
+      throw new IllegalArgumentException(
+        s"${MilvusOption.BackupDir} is not set"
+      )
+    }
+    logInfo(
+      s"Using backup mode for partition planning (no Milvus client connection): $backupDir"
+    )
+
+    val hadoopConf = buildSnapshotHadoopConf(backupDir)
+    val meta = BackupMetaReader.readMeta(hadoopConf, backupDir) match {
+      case Right(m) => m
+      case Left(err) =>
+        throw new IllegalArgumentException(
+          s"Failed to parse backup meta at ${BackupMetaReader
+              .metaPath(backupDir)}: ${err.getMessage}",
+          err
+        )
+    }
+    if (meta.isSnapshotFormat) {
+      throw new IllegalArgumentException(
+        s"Backup '${meta.name}' is in snapshot format; only binlog-format " +
+          "backups can be read as a datasource"
+      )
+    }
+    if (meta.collectionBackups.size != 1) {
+      throw new IllegalArgumentException(
+        s"Backup '${meta.name}' must contain exactly one collection for a " +
+          s"datasource read, got ${meta.collectionBackups.size}"
+      )
+    }
+    val coll = meta.collectionBackups.head
+    val schemaBytes = coll.schema
+      .map(BackupMetaReader.toProtobufSchemaBytes)
+      .getOrElse(Array.empty[Byte])
+    val bucket = backupBucket(backupDir)
+    val applyDeletes = MilvusOption.readApplyDeletes(options)
+    val v2Segments = BackupMetaReader.toV2Segments(
+      meta,
+      hadoopConf,
+      bucket,
+      applyDeletes
+    ) match {
+      case Right(segs) => segs
+      case Left(err) =>
+        throw new IllegalStateException(
+          s"Failed to load StorageV2 segments from backup: ${err.getMessage}",
+          err
+        )
+    }
+    MilvusScan.ensureClientSnapshotHasPackedSegments(
+      Seq.empty,
+      v2Segments,
+      coll.collectionName
+    )
+
+    val bucketOpt = if (bucket.nonEmpty) Some(bucket) else None
+    val v2DeletePlans = loadV2DeletePlans(
+      v2Segments,
+      schemaBytes,
+      bucketOpt,
+      hadoopConf,
+      errorContext = "backup"
+    )
+
+    val inheritedDeleteSegments = v2Segments.filter(seg =>
+      seg.columnGroups.isEmpty && seg.deltaLogs.nonEmpty
+    )
+    val inheritedDeletePlansByPartition =
+      if (!applyDeletes || inheritedDeleteSegments.isEmpty) {
+        Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
+      } else {
+        val pkField = CollectionSchema
+          .parseFrom(schemaBytes)
+          .fields
+          .find(_.isPrimaryKey)
+          .getOrElse {
+            throw new IllegalArgumentException(
+              "No primary key field found in schema"
+            )
+          }
+        MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
+          inheritedDeleteSegments,
+          pkField,
+          bucketOpt.getOrElse(""),
+          hadoopConf
+        ) match {
+          case Right(plans) => plans
+          case Left(err) =>
+            throw new IllegalStateException(
+              s"Failed to load inherited StorageV2 delete logs from backup: ${err.getMessage}",
+              err
+            )
+        }
+      }
+
+    buildSnapshotPartitions(
+      manifestList = Seq.empty,
+      defaultPartitionId = "0",
+      schemaBytes = schemaBytes,
+      v2Segments = v2Segments,
+      v2DeletePlans = v2DeletePlans,
+      inheritedDeletePlansByPartition = inheritedDeletePlansByPartition,
+      inlineInheritedDeletePlans = true
+    )
+  }
+
+  /** Bucket holding the backup's objects: explicit `fs.bucket_name` wins,
+    * otherwise the bucket is parsed out of the backup dir URI (e.g.
+    * `s3a://bucket/backup/<name>`). Empty means local paths.
+    */
+  private def backupBucket(backupDir: String): String =
+    MilvusScan
+      .connectorS3BucketOption(milvusOption.options)
+      .orElse(MilvusScan.snapshotBucket(backupDir))
+      .getOrElse("")
 
   override def createReaderFactory(): PartitionReaderFactory = {
     val optionsMap = options.asScala.toMap

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -256,8 +256,17 @@ case class MilvusTable(
                 meta,
                 milvusOption.databaseName,
                 milvusOption.collectionName
-              )
-              .toOption
+              ) match {
+              case Right(coll) => Some(coll)
+              case Left(msg)   =>
+                // Not an I/O failure — the user asked for a collection that is
+                // not in the backup. Surface it now (the planner re-raises it)
+                // instead of silently degrading to a minimal schema.
+                logWarning(
+                  s"Backup collection resolution failed at table init: $msg"
+                )
+                None
+            }
           }
       }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -1528,7 +1528,10 @@ object MilvusScan extends Logging {
   ): Either[String, BackupMetaReader.CollectionBackup] = {
     // Milvus's default database is named "default", but older milvus-backup
     // versions / single-db clusters omit db_name from the meta (omitempty), so
-    // "default" and "" are the same database for matching purposes.
+    // a candidate with db_name "" or "default" both mean the default database.
+    // The normalization applies to the MATCHING side only: an explicitly
+    // supplied dbName (even "default") still selects the per-database branch,
+    // otherwise `default.orders` + `db2.orders` would be unreachable.
     def normalizedDb(d: String): String = {
       val t = Option(d).map(_.trim).getOrElse("")
       if (t == "default") "" else t
@@ -1539,12 +1542,13 @@ object MilvusScan extends Logging {
       s"${if (db.nonEmpty) db + "." else ""}${c.collectionName}"
     }
 
+    val rawDb = Option(dbName).map(_.trim).getOrElse("")
     val reqDb = normalizedDb(dbName)
 
     if (collectionName.nonEmpty) {
       val candidates =
         meta.collectionBackups.filter(_.collectionName == collectionName)
-      if (reqDb.nonEmpty) {
+      if (rawDb.nonEmpty) {
         candidates.find(c => normalizedDb(c.dbName) == reqDb) match {
           case Some(coll) => Right(coll)
           case None =>
@@ -2738,7 +2742,10 @@ class MilvusScan(
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {
-    val optionsMap = options.asScala.toMap
+    // The threaded backup meta is consumed on the driver only; strip it before
+    // this map is serialized into the task binary and deserialized on every
+    // executor, where nothing reads it.
+    val optionsMap = options.asScala.toMap - MilvusOption.BackupMetaJson
     val inheritedPlansByPartition =
       if (
         MilvusOption

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2642,7 +2642,9 @@ class MilvusScan(
             s"'${coll.collectionName}'; cannot plan a read"
         )
       }
-    val pkField = CollectionSchema
+    // Driver-side validation only: a backup read requires a primary key for
+    // delete handling; the reader factory re-derives it independently.
+    CollectionSchema
       .parseFrom(schemaBytes)
       .fields
       .find(_.isPrimaryKey)
@@ -2705,23 +2707,22 @@ class MilvusScan(
     val inheritedDeleteSegments = v2Segments.filter(seg =>
       seg.columnGroups.isEmpty && seg.deltaLogs.nonEmpty
     )
+    // With inlineInheritedDeletePlans=false, buildSnapshotPartitions only
+    // consults the KEYS of this map (inheritedDeletePlanPartitionMarker does
+    // `.contains`); the full partition-scoped delete plans are loaded once, by
+    // createReaderFactory. Passing empty placeholder plans keeps the marker
+    // semantics without downloading and PK-decoding the entire L0 delete set
+    // twice on the driver.
     val inheritedDeletePlansByPartition =
       if (!applyDeletes || inheritedDeleteSegments.isEmpty) {
         Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
       } else {
-        MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
-          inheritedDeleteSegments,
-          pkField,
-          canonicalBucket.getOrElse(""),
-          hadoopConf
-        ) match {
-          case Right(plans) => plans
-          case Left(err) =>
-            throw new IllegalStateException(
-              s"Failed to load inherited StorageV2 delete logs from backup: ${err.getMessage}",
-              err
-            )
-        }
+        inheritedDeleteSegments
+          .map(seg =>
+            seg.partitionId ->
+              com.zilliz.spark.connector.read.MilvusDeletePlan.empty
+          )
+          .toMap
       }
 
     // inlineInheritedDeletePlans=false: partitions carry a partition-scoped

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2363,9 +2363,23 @@ class MilvusScan(
 
     // Dedup column groups by slot so a field carried by both an old multi-field
     // group and a newer single-field group (add-field + backfill) is read from
-    // the newest owner, not whichever the native reader picks.
-    val packedV2Partitions = v2Segments
-      .map(_.dedupColumnGroupsBySlot)
+    // the newest owner, not whichever the native reader picks. This changes
+    // which parquet a field is read from on every read path, so log loudly
+    // whenever it actually re-attributes a field — a silent mis-attribute would
+    // otherwise surface as stale/null values with no explanation.
+    val packedV2Segments = v2Segments.map { seg =>
+      val deduped = seg.dedupColumnGroupsBySlot
+      if (deduped.columnGroups != seg.columnGroups) {
+        logWarning(
+          s"V2 slot dedup re-attributed fields for segment ${seg.segmentId}: " +
+            "overlapping fields are now read from their max-slot group. This " +
+            "assumes slot ids grow with write time; if they do not, the read " +
+            "may return an older group's values."
+        )
+      }
+      deduped
+    }
+    val packedV2Partitions = packedV2Segments
       .filter(_.columnGroups.nonEmpty)
       .map { seg =>
         val ownDeletePlan = v2DeletePlans.getOrElse(

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -241,11 +241,24 @@ case class MilvusTable(
       MilvusOption.backupDir(milvusOption.options).flatMap { dir =>
         val conf =
           MilvusScan.buildHadoopConfForOptions(milvusOption.options, dir)
-        BackupMetaReader.readMeta(conf, dir).toOption.flatMap { meta =>
-          MilvusScan
-            .resolveBackupCollection(meta, milvusOption.collectionName)
-            .toOption
-        }
+        BackupMetaReader
+          .readMeta(
+            conf,
+            dir,
+            MilvusScan.backupMaxJsonBytes(
+              new CaseInsensitiveStringMap(milvusOption.options.asJava)
+            )
+          )
+          .toOption
+          .flatMap { meta =>
+            MilvusScan
+              .resolveBackupCollection(
+                meta,
+                milvusOption.databaseName,
+                milvusOption.collectionName
+              )
+              .toOption
+          }
       }
 
     val collectionId = parsedCollection.map(_.collectionId).getOrElse(0L)
@@ -600,7 +613,12 @@ case class MilvusTable(
     // Safely get maxFieldID, default to 100 if empty
     val maxFieldID =
       if (fieldName2ID.values.nonEmpty) fieldName2ID.values.max else 100L
+    // Only append $meta if the schema loop did not already emit it (backup
+    // mode materializes $meta from the meta, unlike client mode where
+    // DescribeCollection omits dynamic fields).
+    val alreadyHasMeta = fields.exists(_.name == "$meta")
     if (
+      !alreadyHasMeta &&
       milvusCollection.schema.enableDynamicField &&
       (fieldIDs.isEmpty || fieldIDs.contains((maxFieldID + 1).toString))
     ) {
@@ -1139,6 +1157,18 @@ object MilvusScan extends Logging {
     value
   }
 
+  /** Backup `full_meta.json` size limit, honoring
+    * `milvus.snapshot.max.json.bytes` (the same option the snapshot read uses).
+    */
+  private[sources] def backupMaxJsonBytes(
+      options: CaseInsensitiveStringMap
+  ): Long =
+    parsePositiveLongOption(
+      options,
+      MilvusOption.SnapshotMaxJsonBytes,
+      MilvusSnapshotReader.MaxSnapshotJsonBytes
+    )
+
   private[sources] def parseClientSnapshotCompactionProtectionSeconds(
       options: CaseInsensitiveStringMap
   ): Long = {
@@ -1439,23 +1469,48 @@ object MilvusScan extends Logging {
   }
 
   /** Resolve the collection to read from a backup meta, matching on
-    * `milvus.collection.name`. Returns `Left(message)` when no collection
-    * matches, or when the name is unset and the backup holds multiple
-    * collections (so callers never silently read the wrong `.head`).
+    * `milvus.database.name` + `milvus.collection.name`. Returns `Left(message)`
+    * when nothing matches, when an unqualified name is ambiguous across
+    * databases, or when the name is unset and the backup holds multiple
+    * collections — so callers never silently read the wrong `.head`.
     */
   private[sources] def resolveBackupCollection(
       meta: BackupMetaReader.BackupInfo,
+      dbName: String,
       collectionName: String
   ): Either[String, BackupMetaReader.CollectionBackup] = {
+    def qualified(c: BackupMetaReader.CollectionBackup): String =
+      s"${if (c.dbName.nonEmpty) c.dbName + "." else ""}${c.collectionName}"
+
     if (collectionName.nonEmpty) {
-      meta.collectionBackups.find(_.collectionName == collectionName) match {
-        case Some(coll) => Right(coll)
-        case None =>
-          Left(
-            s"Backup '${meta.name}' does not contain collection " +
-              s"'$collectionName'; available: " +
-              meta.collectionBackups.map(_.collectionName).mkString(",")
-          )
+      val candidates =
+        meta.collectionBackups.filter(_.collectionName == collectionName)
+      if (dbName.nonEmpty) {
+        candidates.find(_.dbName == dbName) match {
+          case Some(coll) => Right(coll)
+          case None =>
+            Left(
+              s"Backup '${meta.name}' does not contain collection " +
+                s"'$collectionName' in database '$dbName'; available: " +
+                meta.collectionBackups.map(qualified).mkString(",")
+            )
+        }
+      } else {
+        candidates match {
+          case Seq(single) => Right(single)
+          case Seq() =>
+            Left(
+              s"Backup '${meta.name}' does not contain collection " +
+                s"'$collectionName'; available: " +
+                meta.collectionBackups.map(qualified).mkString(",")
+            )
+          case many =>
+            Left(
+              s"Backup '${meta.name}' has multiple collections named " +
+                s"'$collectionName' (${many.map(qualified).mkString(",")}); " +
+                s"set ${MilvusOption.MilvusDatabaseName} to disambiguate"
+            )
+        }
       }
     } else {
       meta.collectionBackups match {
@@ -2231,7 +2286,11 @@ class MilvusScan(
       )
     }
 
+    // Dedup column groups by slot so a field carried by both an old multi-field
+    // group and a newer single-field group (add-field + backfill) is read from
+    // the newest owner, not whichever the native reader picks.
     val packedV2Partitions = v2Segments
+      .map(_.dedupColumnGroupsBySlot)
       .filter(_.columnGroups.nonEmpty)
       .map { seg =>
         val ownDeletePlan = v2DeletePlans.getOrElse(
@@ -2448,7 +2507,11 @@ class MilvusScan(
     )
 
     val hadoopConf = buildSnapshotHadoopConf(backupDir)
-    val meta = BackupMetaReader.readMeta(hadoopConf, backupDir) match {
+    val meta = BackupMetaReader.readMeta(
+      hadoopConf,
+      backupDir,
+      MilvusScan.backupMaxJsonBytes(options)
+    ) match {
       case Right(m) => m
       case Left(err) =>
         throw new IllegalArgumentException(
@@ -2465,6 +2528,7 @@ class MilvusScan(
     }
     val coll = MilvusScan.resolveBackupCollection(
       meta,
+      milvusOption.databaseName,
       milvusOption.collectionName
     ) match {
       case Right(c) => c

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -232,59 +232,84 @@ case class MilvusTable(
     * connection). The collection schema is materialized from the backup's
     * `full_meta.json` so downstream metadata rehydration (e.g. Milvus data type
     * / vector dimension on Spark fields) works identically to snapshot mode.
-    * The collection is selected by `milvus.collection.name`, and its id is read
-    * from the meta. Best-effort only for I/O: if the meta cannot be read we
-    * fall back to an empty schema, but a meta-level contract violation (e.g. a
-    * dynamic collection without a `$meta` record) surfaces loudly.
+    * The collection is selected by `milvus.database.name` +
+    * `milvus.collection.name`, and its id is read from the meta.
+    *
+    * When no `.schema()` is provided, the backup meta is the only source of the
+    * Spark schema, so a read failure (or a missing collection / schema) fails
+    * loudly rather than degrading to a RowID/Timestamp-only schema that
+    * silently drops user columns. With an explicit `.schema()` the meta read is
+    * best-effort (it only feeds metadata rehydration).
     */
   private def initFromBackup(): Unit = {
     partitionID = 0L
 
+    // Without an explicit .schema(), the Spark schema is derived from the
+    // backup meta; failing to read it must surface loudly rather than degrade
+    // to a RowID/Timestamp-only schema that silently drops every user column.
+    val needsSchema = !sparkSchema.exists(_.nonEmpty)
+
     val parsedMeta: Option[
-      (BackupMetaReader.BackupInfo, Option[BackupMetaReader.CollectionBackup])
+      (BackupMetaReader.BackupInfo, BackupMetaReader.CollectionBackup)
     ] =
       MilvusOption.backupDir(milvusOption.options).flatMap { dir =>
         val conf =
           MilvusScan.buildHadoopConfForOptions(milvusOption.options, dir)
-        BackupMetaReader
-          .readMeta(
-            conf,
-            dir,
-            MilvusScan.backupMaxJsonBytes(
-              new CaseInsensitiveStringMap(milvusOption.options.asJava)
-            )
-          )
-          .toOption
-          .map { meta =>
-            val resolved = MilvusScan
+        val maxBytes = MilvusScan.backupMaxJsonBytes(
+          new CaseInsensitiveStringMap(milvusOption.options.asJava)
+        )
+        BackupMetaReader.readMeta(conf, dir, maxBytes) match {
+          case Left(err) =>
+            if (needsSchema) {
+              throw new IllegalArgumentException(
+                s"Failed to read backup meta at ${BackupMetaReader
+                    .metaPath(dir)} (required because no .schema() was " +
+                  s"provided): ${err.getMessage}",
+                err
+              )
+            } else {
+              logWarning(
+                s"Could not read backup meta at table init: ${err.getMessage}"
+              )
+              None
+            }
+          case Right(meta) =>
+            MilvusScan
               .resolveBackupCollection(
                 meta,
                 milvusOption.databaseName,
                 milvusOption.collectionName
               ) match {
-              case Right(coll) => Some(coll)
-              case Left(msg)   =>
-                // Not an I/O failure — the user asked for a collection that is
-                // not in the backup. Surface it now (the planner re-raises it)
-                // instead of silently degrading to a minimal schema.
-                logWarning(
-                  s"Backup collection resolution failed at table init: $msg"
-                )
-                None
+              case Right(coll) => Some((meta, coll))
+              case Left(msg) =>
+                if (needsSchema) {
+                  throw new IllegalArgumentException(msg)
+                } else {
+                  logWarning(
+                    s"Backup collection resolution failed at table init: $msg"
+                  )
+                  None
+                }
             }
-            (meta, resolved)
-          }
+        }
       }
     backupMetaJson = parsedMeta.map { case (meta, _) =>
       BackupMetaReader.serialize(meta)
     }
 
-    val parsedCollection = parsedMeta.flatMap(_._2)
+    val parsedCollection = parsedMeta.map(_._2)
     val collectionId = parsedCollection.map(_.collectionId).getOrElse(0L)
 
     val schemaFromMeta = parsedCollection.flatMap(_.schema).map { s =>
       BackupMetaReader.validateDynamicFieldSchema(s)
       CollectionSchema.parseFrom(BackupMetaReader.toProtobufSchemaBytes(s))
+    }
+
+    if (needsSchema && parsedCollection.nonEmpty && schemaFromMeta.isEmpty) {
+      throw new IllegalArgumentException(
+        s"Backup collection '${parsedCollection.get.collectionName}' has no " +
+          "schema; cannot derive a read schema without .schema()"
+      )
     }
 
     schemaFromMeta match {
@@ -1501,14 +1526,26 @@ object MilvusScan extends Logging {
       dbName: String,
       collectionName: String
   ): Either[String, BackupMetaReader.CollectionBackup] = {
-    def qualified(c: BackupMetaReader.CollectionBackup): String =
-      s"${if (c.dbName.nonEmpty) c.dbName + "." else ""}${c.collectionName}"
+    // Milvus's default database is named "default", but older milvus-backup
+    // versions / single-db clusters omit db_name from the meta (omitempty), so
+    // "default" and "" are the same database for matching purposes.
+    def normalizedDb(d: String): String = {
+      val t = Option(d).map(_.trim).getOrElse("")
+      if (t == "default") "" else t
+    }
+
+    def qualified(c: BackupMetaReader.CollectionBackup): String = {
+      val db = normalizedDb(c.dbName)
+      s"${if (db.nonEmpty) db + "." else ""}${c.collectionName}"
+    }
+
+    val reqDb = normalizedDb(dbName)
 
     if (collectionName.nonEmpty) {
       val candidates =
         meta.collectionBackups.filter(_.collectionName == collectionName)
-      if (dbName.nonEmpty) {
-        candidates.find(_.dbName == dbName) match {
+      if (reqDb.nonEmpty) {
+        candidates.find(c => normalizedDb(c.dbName) == reqDb) match {
           case Some(coll) => Right(coll)
           case None =>
             Left(
@@ -1638,6 +1675,18 @@ class MilvusScan(
     with Batch
     with Logging {
   private val milvusOption = MilvusOption(options)
+
+  // The threaded backup meta (if any) is consumed on the driver only; it must
+  // not ride along on every InputPartition to the executors (it can be tens of
+  // MB and has no executor-side consumer).
+  private val partitionMilvusOption: MilvusOption =
+    if (milvusOption.options.contains(MilvusOption.BackupMetaJson)) {
+      milvusOption.copy(
+        options = milvusOption.options - MilvusOption.BackupMetaJson
+      )
+    } else {
+      milvusOption
+    }
 
   // Get vector search configuration from MilvusOption
   private val vectorSearchConfig = milvusOption.vectorSearchConfig
@@ -2237,12 +2286,12 @@ class MilvusScan(
       .map(_.trim)
       .filter(_.nonEmpty)
       .map(bucket =>
-        milvusOption.copy(
-          options = milvusOption.options +
+        partitionMilvusOption.copy(
+          options = partitionMilvusOption.options +
             (Properties.FsConfig.FsBucketName -> bucket)
         )
       )
-      .getOrElse(milvusOption)
+      .getOrElse(partitionMilvusOption)
 
     val v3Partitions = manifestList.map { item =>
       val (basePath, parsedReadVersion) =

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2815,9 +2815,9 @@ class MilvusScan(
   /** Compute the shared partition-scoped L0 delete plans for a backup read from
     * the parsed meta, independent of partition planning. Falls back to a fresh
     * meta read when table init did not parse one (e.g. its read failed while
-    * the planner's succeeded), so a marker never silently resolves to an empty
-    * plan. Returns `Map.empty` when no deletes apply or the meta/schema cannot
-    * be resolved.
+    * the planner's succeeded), and fails loudly if that re-read also fails —
+    * otherwise a partition-scoped marker would silently resolve to an empty
+    * plan and deleted rows would come back as live.
     */
   private def computeBackupInheritedDeletePlans()
       : Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
@@ -2832,7 +2832,12 @@ class MilvusScan(
         MilvusScan.backupMaxJsonBytes(options)
       ) match {
         case Right(m) => m
-        case Left(_)  => return Map.empty
+        case Left(err) =>
+          throw new IllegalStateException(
+            s"Failed to re-read backup meta at ${BackupMetaReader
+                .metaPath(backupDir)} to resolve inherited delete plans: ${err.getMessage}",
+            err
+          )
       }
     }
     val coll = MilvusScan
@@ -2850,13 +2855,13 @@ class MilvusScan(
       .fields
       .find(_.isPrimaryKey)
       .getOrElse { return Map.empty }
-    val l0Segments =
-      BackupMetaReader.l0DeleteSegments(meta, coll.collectionId, backupDir)
-    if (l0Segments.isEmpty) {
+    val deleteOnlySegments =
+      BackupMetaReader.deleteOnlySegments(meta, coll.collectionId, backupDir)
+    if (deleteOnlySegments.isEmpty) {
       Map.empty
     } else {
       MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
-        l0Segments,
+        deleteOnlySegments,
         pkField,
         MilvusScan.snapshotBucket(backupDir).getOrElse(""),
         hadoopConf

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -182,9 +182,10 @@ case class MilvusTable(
     with Logging {
   var milvusCollection: MilvusCollectionInfo = _
   var partitionID: Long = 0L
-  // Serialized full_meta.json parsed during initFromBackup; threaded to the
-  // scan planner via the BackupMetaJson option so the meta is read/parsed once.
-  private var backupMetaJson: Option[String] = None
+  // full_meta.json parsed during initFromBackup, threaded directly to the scan
+  // planner (never through options, so it is neither re-serialized nor shipped
+  // to executors).
+  private var parsedBackupMeta: Option[BackupMetaReader.BackupInfo] = None
   initInfo()
   var fieldIDs =
     if (milvusOption.fieldIDs.nonEmpty) {
@@ -293,9 +294,7 @@ case class MilvusTable(
             }
         }
       }
-    backupMetaJson = parsedMeta.map { case (meta, _) =>
-      BackupMetaReader.serialize(meta)
-    }
+    parsedBackupMeta = parsedMeta.map(_._1)
 
     val parsedCollection = parsedMeta.map(_._2)
     val collectionId = parsedCollection.map(_.collectionId).getOrElse(0L)
@@ -472,12 +471,9 @@ case class MilvusTable(
         partitionID.toString
       )
     }
-    backupMetaJson.foreach { json =>
-      mergedOptions.put(MilvusOption.BackupMetaJson, json)
-    }
 
     val allOptions = new CaseInsensitiveStringMap(mergedOptions)
-    new MilvusScanBuilder(schema(), allOptions)
+    new MilvusScanBuilder(schema(), allOptions, parsedBackupMeta)
   }
 
   override def name(): String = milvusOption.collectionName
@@ -684,7 +680,8 @@ case class MilvusTable(
 
 class MilvusScanBuilder(
     schema: StructType,
-    options: CaseInsensitiveStringMap
+    options: CaseInsensitiveStringMap,
+    preParsedBackupMeta: Option[BackupMetaReader.BackupInfo] = None
 ) extends ScanBuilder
     with SupportsPushDownFilters
     with SupportsPushDownRequiredColumns
@@ -891,7 +888,12 @@ class MilvusScanBuilder(
   }
 
   override def build(): Scan = {
-    new MilvusScan(currentSchema, currentOptions, pushedFilterArray)
+    new MilvusScan(
+      currentSchema,
+      currentOptions,
+      pushedFilterArray,
+      preParsedBackupMeta
+    )
   }
 }
 
@@ -1674,23 +1676,21 @@ object MilvusScan extends Logging {
 class MilvusScan(
     schema: StructType,
     options: CaseInsensitiveStringMap,
-    pushedFilters: Array[Filter] = Array.empty[Filter]
+    pushedFilters: Array[Filter] = Array.empty[Filter],
+    // Backup meta already parsed at table init (threaded directly, never via
+    // options, so it does not ride along on InputPartitions to executors).
+    preParsedBackupMeta: Option[BackupMetaReader.BackupInfo] = None
 ) extends Scan
     with Batch
     with Logging {
   private val milvusOption = MilvusOption(options)
 
-  // The threaded backup meta (if any) is consumed on the driver only; it must
-  // not ride along on every InputPartition to the executors (it can be tens of
-  // MB and has no executor-side consumer).
-  private val partitionMilvusOption: MilvusOption =
-    if (milvusOption.options.contains(MilvusOption.BackupMetaJson)) {
-      milvusOption.copy(
-        options = milvusOption.options - MilvusOption.BackupMetaJson
-      )
-    } else {
-      milvusOption
-    }
+  // Partition-scoped L0 delete plans computed during backup planning; the
+  // reader factory resolves the shared plan from this single map (partitions
+  // carry only a marker), so a delete-heavy backup is not duplicated per
+  // segment. Driver-side only; never serialized to executors directly.
+  private var backupInheritedDeletePlans
+      : Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = Map.empty
 
   // Get vector search configuration from MilvusOption
   private val vectorSearchConfig = milvusOption.vectorSearchConfig
@@ -2290,12 +2290,12 @@ class MilvusScan(
       .map(_.trim)
       .filter(_.nonEmpty)
       .map(bucket =>
-        partitionMilvusOption.copy(
-          options = partitionMilvusOption.options +
+        milvusOption.copy(
+          options = milvusOption.options +
             (Properties.FsConfig.FsBucketName -> bucket)
         )
       )
-      .getOrElse(partitionMilvusOption)
+      .getOrElse(milvusOption)
 
     val v3Partitions = manifestList.map { item =>
       val (basePath, parsedReadVersion) =
@@ -2596,36 +2596,24 @@ class MilvusScan(
     )
 
     val hadoopConf = buildSnapshotHadoopConf(backupDir)
-    // Prefer the meta already parsed during table init (threaded via the
-    // BackupMetaJson option) so full_meta.json is read/parsed once per read;
-    // fall back to a fresh read otherwise (e.g. direct scan without table init).
-    val meta = Option(options.get(MilvusOption.BackupMetaJson))
-      .filter(_.nonEmpty)
-      .map { json =>
-        BackupMetaReader.parse(json) match {
-          case Right(m) => m
-          case Left(err) =>
-            throw new IllegalArgumentException(
-              s"Failed to parse threaded backup meta for '$backupDir': ${err.getMessage}",
-              err
-            )
-        }
+    // Prefer the meta already parsed at table init (threaded directly, so it is
+    // neither re-serialized nor shipped to executors); fall back to a fresh
+    // read otherwise (e.g. a direct scan without table init).
+    val meta = preParsedBackupMeta.getOrElse {
+      BackupMetaReader.readMeta(
+        hadoopConf,
+        backupDir,
+        MilvusScan.backupMaxJsonBytes(options)
+      ) match {
+        case Right(m) => m
+        case Left(err) =>
+          throw new IllegalArgumentException(
+            s"Failed to parse backup meta at ${BackupMetaReader
+                .metaPath(backupDir)}: ${err.getMessage}",
+            err
+          )
       }
-      .getOrElse {
-        BackupMetaReader.readMeta(
-          hadoopConf,
-          backupDir,
-          MilvusScan.backupMaxJsonBytes(options)
-        ) match {
-          case Right(m) => m
-          case Left(err) =>
-            throw new IllegalArgumentException(
-              s"Failed to parse backup meta at ${BackupMetaReader
-                  .metaPath(backupDir)}: ${err.getMessage}",
-              err
-            )
-        }
-      }
+    }
     if (meta.isSnapshotFormat) {
       throw new IllegalArgumentException(
         s"Backup '${meta.name}' is in snapshot format; only binlog-format " +
@@ -2742,7 +2730,12 @@ class MilvusScan(
             )
         }
       }
+    backupInheritedDeletePlans = inheritedDeletePlansByPartition
 
+    // inlineInheritedDeletePlans=false: partitions carry a partition-scoped
+    // marker instead of a copy of the L0 delete plan, and the reader factory
+    // resolves the shared plan from a single map — otherwise a delete-heavy
+    // backup materializes the L0 delete map once per segment (O(S×D)).
     buildSnapshotPartitions(
       manifestList = Seq.empty,
       defaultPartitionId = "0",
@@ -2750,16 +2743,13 @@ class MilvusScan(
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition,
-      inlineInheritedDeletePlans = true,
+      inlineInheritedDeletePlans = false,
       forceCanonicalBucket = canonicalBucket
     )
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {
-    // The threaded backup meta is consumed on the driver only; strip it before
-    // this map is serialized into the task binary and deserialized on every
-    // executor, where nothing reads it.
-    val optionsMap = options.asScala.toMap - MilvusOption.BackupMetaJson
+    val optionsMap = options.asScala.toMap
     val inheritedPlansByPartition =
       if (
         MilvusOption
@@ -2811,6 +2801,15 @@ class MilvusScan(
               )
           }
         }
+      } else if (
+        MilvusOption
+          .isBackupMode(options) && MilvusOption.readApplyDeletes(options)
+      ) {
+        // Backup partitions carry a partition-scoped marker (inline=false), so
+        // the shared L0 delete plan must be supplied here. Reuse the map the
+        // planner already computed — it is built once on the driver and
+        // serialized once with this factory, not per segment.
+        backupInheritedDeletePlans
       } else {
         Map.empty[Long, com.zilliz.spark.connector.read.MilvusDeletePlan]
       }

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2462,7 +2462,9 @@ class MilvusScan(
     val applyDeletes = MilvusOption.readApplyDeletes(options)
     // Object paths are reconstructed from `backupDir` plus segment IDs inside
     // BackupMetaReader; the meta's `log_path` values are source keys and are
-    // never opened. No separate bucket is needed for delete-plan resolution.
+    // never opened. The native packed reader receives bucket-relative keys, so
+    // its `fs.bucket_name` must be canonicalized to the backup URI's bucket.
+    val canonicalBucket = MilvusScan.snapshotBucket(backupDir)
     val v2Segments = BackupMetaReader.toV2Segments(
       meta,
       hadoopConf,
@@ -2485,7 +2487,7 @@ class MilvusScan(
     val v2DeletePlans = loadV2DeletePlans(
       v2Segments,
       schemaBytes,
-      snapshotBucket = None,
+      snapshotBucket = canonicalBucket,
       hadoopConf,
       errorContext = "backup"
     )
@@ -2500,7 +2502,7 @@ class MilvusScan(
         MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
           inheritedDeleteSegments,
           pkField,
-          bucket = "",
+          canonicalBucket.getOrElse(""),
           hadoopConf
         ) match {
           case Right(plans) => plans
@@ -2519,7 +2521,8 @@ class MilvusScan(
       v2Segments = v2Segments,
       v2DeletePlans = v2DeletePlans,
       inheritedDeletePlansByPartition = inheritedDeletePlansByPartition,
-      inlineInheritedDeletePlans = true
+      inlineInheritedDeletePlans = true,
+      forceCanonicalBucket = canonicalBucket
     )
   }
 

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -229,34 +229,31 @@ case class MilvusTable(
     * connection). The collection schema is materialized from the backup's
     * `full_meta.json` so downstream metadata rehydration (e.g. Milvus data type
     * / vector dimension on Spark fields) works identically to snapshot mode.
-    * Best-effort: if the meta cannot be read or parsed, we fall back to an
-    * empty schema and rely on the caller-supplied Spark schema.
+    * The collection is selected by `milvus.collection.name`, and its id is read
+    * from the meta. Best-effort only for I/O: if the meta cannot be read we
+    * fall back to an empty schema, but a meta-level contract violation (e.g. a
+    * dynamic collection without a `$meta` record) surfaces loudly.
     */
   private def initFromBackup(): Unit = {
-    val collectionId = milvusOption.options
-      .get(MilvusOption.SnapshotCollectionId)
-      .map(_.toLong)
-      .getOrElse(0L)
     partitionID = 0L
 
-    val schemaFromMeta =
+    val parsedCollection =
       MilvusOption.backupDir(milvusOption.options).flatMap { dir =>
         val conf =
           MilvusScan.buildHadoopConfForOptions(milvusOption.options, dir)
-        BackupMetaReader
-          .readMeta(conf, dir)
-          .toOption
-          .flatMap(_.collectionBackups.headOption.flatMap(_.schema))
-          .flatMap(s =>
-            scala.util
-              .Try(
-                CollectionSchema.parseFrom(
-                  BackupMetaReader.toProtobufSchemaBytes(s)
-                )
-              )
-              .toOption
-          )
+        BackupMetaReader.readMeta(conf, dir).toOption.flatMap { meta =>
+          MilvusScan
+            .resolveBackupCollection(meta, milvusOption.collectionName)
+            .toOption
+        }
       }
+
+    val collectionId = parsedCollection.map(_.collectionId).getOrElse(0L)
+
+    val schemaFromMeta = parsedCollection.flatMap(_.schema).map { s =>
+      BackupMetaReader.validateDynamicFieldSchema(s)
+      CollectionSchema.parseFrom(BackupMetaReader.toProtobufSchemaBytes(s))
+    }
 
     schemaFromMeta match {
       case Some(schema) =>
@@ -1441,6 +1438,38 @@ object MilvusScan extends Logging {
     metadata
   }
 
+  /** Resolve the collection to read from a backup meta, matching on
+    * `milvus.collection.name`. Returns `Left(message)` when no collection
+    * matches, or when the name is unset and the backup holds multiple
+    * collections (so callers never silently read the wrong `.head`).
+    */
+  private[sources] def resolveBackupCollection(
+      meta: BackupMetaReader.BackupInfo,
+      collectionName: String
+  ): Either[String, BackupMetaReader.CollectionBackup] = {
+    if (collectionName.nonEmpty) {
+      meta.collectionBackups.find(_.collectionName == collectionName) match {
+        case Some(coll) => Right(coll)
+        case None =>
+          Left(
+            s"Backup '${meta.name}' does not contain collection " +
+              s"'$collectionName'; available: " +
+              meta.collectionBackups.map(_.collectionName).mkString(",")
+          )
+      }
+    } else {
+      meta.collectionBackups match {
+        case Seq(single) => Right(single)
+        case _ =>
+          Left(
+            s"Backup '${meta.name}' contains " +
+              s"${meta.collectionBackups.size} collection(s); set " +
+              s"${MilvusOption.MilvusCollectionName} to select one"
+          )
+      }
+    }
+  }
+
   /** Build a Hadoop `Configuration` for reading objects referenced by a
     * snapshot/backup path, applying the connector's `fs.*` options plus any
     * per-bucket S3A configuration. Extracted as a companion method so both the
@@ -2434,13 +2463,26 @@ class MilvusScan(
           "backups can be read as a datasource"
       )
     }
-    if (meta.collectionBackups.size != 1) {
+    val coll = MilvusScan.resolveBackupCollection(
+      meta,
+      milvusOption.collectionName
+    ) match {
+      case Right(c) => c
+      case Left(msg) =>
+        throw new IllegalArgumentException(msg)
+    }
+    if (
+      milvusOption.partitionName.nonEmpty || milvusOption.partitionID.nonEmpty ||
+      milvusOption.segmentID.nonEmpty
+    ) {
       throw new IllegalArgumentException(
-        s"Backup '${meta.name}' must contain exactly one collection for a " +
-          s"datasource read, got ${meta.collectionBackups.size}"
+        s"Backup datasource does not support " +
+          s"'${MilvusOption.MilvusPartitionName}' / " +
+          s"'${MilvusOption.MilvusPartitionID}' / " +
+          s"'${MilvusOption.MilvusSegmentID}' selectors yet; read the whole " +
+          "backup and filter in Spark"
       )
     }
-    val coll = meta.collectionBackups.head
     val schemaBytes = coll.schema
       .map(BackupMetaReader.toProtobufSchemaBytes)
       .getOrElse {

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2575,7 +2575,8 @@ class MilvusScan(
       meta,
       hadoopConf,
       backupDir,
-      applyDeletes
+      applyDeletes,
+      coll.collectionId
     ) match {
       case Right(segs) => segs
       case Left(err) =>
@@ -2584,11 +2585,17 @@ class MilvusScan(
           err
         )
     }
-    MilvusScan.ensureClientSnapshotHasPackedSegments(
-      Seq.empty,
-      v2Segments,
-      coll.collectionName
-    )
+    // L0 delete-only segments alone must not satisfy the guard: they carry no
+    // column groups and would be filtered out at partition planning, so a
+    // delete-only backup would silently read zero rows.
+    if (!v2Segments.exists(_.columnGroups.nonEmpty)) {
+      throw new IllegalArgumentException(
+        s"Backup '${meta.name}' collection '${coll.collectionName}' has no " +
+          "packed-parquet (StorageV2) data segments to read (only delete-only " +
+          "segments). This connector requires Milvus 2.6+ with Storage V2; " +
+          "ensure the collection has been flushed and contains data."
+      )
+    }
 
     val v2DeletePlans = loadV2DeletePlans(
       v2Segments,

--- a/src/main/scala/sources/MilvusDataSource.scala
+++ b/src/main/scala/sources/MilvusDataSource.scala
@@ -2813,17 +2813,27 @@ class MilvusScan(
   }
 
   /** Compute the shared partition-scoped L0 delete plans for a backup read from
-    * the parsed meta, independent of partition planning. Returns `Map.empty`
-    * when no deletes apply or the meta/schema cannot be resolved (the planner
-    * would already have failed loudly for those cases).
+    * the parsed meta, independent of partition planning. Falls back to a fresh
+    * meta read when table init did not parse one (e.g. its read failed while
+    * the planner's succeeded), so a marker never silently resolves to an empty
+    * plan. Returns `Map.empty` when no deletes apply or the meta/schema cannot
+    * be resolved.
     */
   private def computeBackupInheritedDeletePlans()
       : Map[Long, com.zilliz.spark.connector.read.MilvusDeletePlan] = {
     val backupDir = MilvusOption.backupDir(options).getOrElse {
       return Map.empty
     }
+    val hadoopConf = buildSnapshotHadoopConf(backupDir)
     val meta = preParsedBackupMeta.getOrElse {
-      return Map.empty
+      BackupMetaReader.readMeta(
+        hadoopConf,
+        backupDir,
+        MilvusScan.backupMaxJsonBytes(options)
+      ) match {
+        case Right(m) => m
+        case Left(_)  => return Map.empty
+      }
     }
     val coll = MilvusScan
       .resolveBackupCollection(
@@ -2845,7 +2855,6 @@ class MilvusScan(
     if (l0Segments.isEmpty) {
       Map.empty
     } else {
-      val hadoopConf = buildSnapshotHadoopConf(backupDir)
       MilvusDeltaLogReader.loadPartitionScopedDeletePlans(
         l0Segments,
         pkField,

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -461,4 +461,31 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     conf.get("fs.s3a.threads.max") shouldBe "16"
     conf.get("fs.s3a.impl") shouldBe "org.apache.hadoop.fs.s3a.S3AFileSystem"
   }
+
+  test("isBackupMode is true only when milvus.backup.dir is set") {
+    MilvusOption.isBackupMode(Map.empty[String, String]) shouldBe false
+    MilvusOption.isBackupMode(
+      Map(MilvusOption.MilvusUri -> "http://localhost:19530")
+    ) shouldBe false
+    MilvusOption.isBackupMode(
+      Map(MilvusOption.BackupDir -> "s3a://bucket/backup/b1")
+    ) shouldBe true
+    MilvusOption.isBackupMode(
+      Map(MilvusOption.BackupDir -> "   ")
+    ) shouldBe false
+  }
+
+  test("validateBackupModeOptions rejects backup combined with snapshot mode") {
+    val both = Map(
+      MilvusOption.BackupDir -> "s3a://bucket/backup/b1",
+      MilvusOption.SnapshotV2Segments -> "[]"
+    )
+    intercept[IllegalArgumentException] {
+      MilvusOption.validateBackupModeOptions(both)
+    }
+    // Backup mode alone is fine.
+    MilvusOption.validateBackupModeOptions(
+      Map(MilvusOption.BackupDir -> "s3a://bucket/backup/b1")
+    )
+  }
 }

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -475,6 +475,18 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
     ) shouldBe false
   }
 
+  test("backupDir normalizes the s3:// alias to s3a://") {
+    MilvusOption.backupDir(
+      Map(MilvusOption.BackupDir -> "s3://bucket/backup/b1")
+    ) shouldBe Some("s3a://bucket/backup/b1")
+    MilvusOption.backupDir(
+      Map(MilvusOption.BackupDir -> "s3a://bucket/backup/b1")
+    ) shouldBe Some("s3a://bucket/backup/b1")
+    MilvusOption.backupDir(
+      Map(MilvusOption.BackupDir -> "/data/backup/b1")
+    ) shouldBe Some("/data/backup/b1")
+  }
+
   test("validateBackupModeOptions rejects backup combined with snapshot mode") {
     val both = Map(
       MilvusOption.BackupDir -> "s3a://bucket/backup/b1",

--- a/src/test/scala/MilvusOptionTest.scala
+++ b/src/test/scala/MilvusOptionTest.scala
@@ -500,4 +500,27 @@ class MilvusS3OptionTest extends AnyFunSuite with Matchers {
       Map(MilvusOption.BackupDir -> "s3a://bucket/backup/b1")
     )
   }
+
+  test("empty-valued snapshot hint keys do not enable snapshot mode") {
+    // Config templates keep optional keys with empty values; they must not trip
+    // the snapshot/backup mutual-exclusion check.
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotManifests -> "")
+    ) shouldBe false
+    MilvusOption.isSnapshotMode(
+      Map(MilvusOption.SnapshotV2Segments -> "   ")
+    ) shouldBe false
+    MilvusOption.validateBackupModeOptions(
+      Map(
+        MilvusOption.BackupDir -> "s3a://bucket/backup/b1",
+        MilvusOption.SnapshotManifests -> ""
+      )
+    )
+    MilvusOption.validateBackupModeOptions(
+      Map(
+        MilvusOption.BackupDir -> "s3a://bucket/backup/b1",
+        MilvusOption.SnapshotV2Segments -> ""
+      )
+    )
+  }
 }

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -234,6 +234,49 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       "/data/backups/b1/meta/full_meta.json"
   }
 
+  test(
+    "path builders split qualified URIs (Hadoop) from bucket-relative keys (native)"
+  ) {
+    val seg = BackupMetaReader.SegmentBackup(
+      segmentId = 777L,
+      collectionId = 444L,
+      partitionId = 555L,
+      groupId = 777L
+    )
+    BackupMetaReader.backupKeyBase(
+      "s3a://bucket/backup/b1"
+    ) shouldBe "backup/b1"
+    BackupMetaReader.backupKeyBase("/data/backup/b1") shouldBe "/data/backup/b1"
+
+    // Native reader gets bucket-relative keys; Hadoop reads get the qualified URI.
+    BackupMetaReader.nativeInsertLogPath(
+      "s3a://bucket/backup/b1",
+      seg,
+      103L,
+      1L
+    ) shouldBe "backup/b1/binlogs/insert_log/444/555/777/777/103/1"
+    BackupMetaReader.qualifiedInsertLogPath(
+      "s3a://bucket/backup/b1",
+      seg,
+      103L,
+      1L
+    ) shouldBe "s3a://bucket/backup/b1/binlogs/insert_log/444/555/777/777/103/1"
+
+    // Delta logs only feed the Hadoop delete-plan reader, so only qualified
+    // paths exist. groupID level present for part != -1, omitted for part == -1.
+    BackupMetaReader.qualifiedDeltaLogPath(
+      "s3a://bucket/backup/b1",
+      seg,
+      9L
+    ) shouldBe "s3a://bucket/backup/b1/binlogs/delta_log/444/555/777/777/9"
+    val l0 = seg.copy(partitionId = -1L, groupId = 0L)
+    BackupMetaReader.qualifiedDeltaLogPath(
+      "s3a://bucket/backup/b1",
+      l0,
+      9L
+    ) shouldBe "s3a://bucket/backup/b1/binlogs/delta_log/444/-1/777/9"
+  }
+
   test("readMeta parses a binlog-format backup full_meta.json") {
     val dir = Files.createTempDirectory("milvus-backup-meta-")
     try {

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -1,0 +1,381 @@
+package com.zilliz.spark.connector.read
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path => HPath}
+import org.apache.parquet.example.data.simple.SimpleGroupFactory
+import org.apache.parquet.example.data.Group
+import org.apache.parquet.hadoop.example.{
+  ExampleParquetWriter,
+  GroupWriteSupport
+}
+import org.apache.parquet.hadoop.metadata.CompressionCodecName
+import org.apache.parquet.schema.{MessageType, Types}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.milvus.grpc.schema.{CollectionSchema, DataType}
+
+/** Tests for [[BackupMetaReader]] — parses milvus-backup's `full_meta.json` and
+  * maps it to the packed-V2 read-path objects. Local parquet files written with
+  * parquet-mr's example writer carry `PARQUET:field_id` the same way
+  * milvus-storage does, so the field-id / row-count recovery can be exercised
+  * without minio.
+  */
+class BackupMetaReaderTest extends AnyFunSuite with Matchers {
+
+  private val groupASchema: MessageType = Types
+    .buildMessage()
+    .required(PrimitiveTypeName.INT64)
+    .id(100)
+    .named("pk")
+    .required(PrimitiveTypeName.INT64)
+    .id(0)
+    .named("row_id")
+    .required(PrimitiveTypeName.INT64)
+    .id(1)
+    .named("ts")
+    .named("milvus_group")
+
+  private val groupCSchema: MessageType = Types
+    .buildMessage()
+    .required(PrimitiveTypeName.BINARY)
+    .id(101)
+    .named("name")
+    .named("milvus_group")
+
+  /** Write a local parquet with the given rows (one `Group` per row) and return
+    * its `file://` URI.
+    */
+  private def writeParquet(
+      schema: MessageType,
+      rows: List[SimpleGroupFactory => Group]
+  ): String = {
+    val tmp = Files.createTempFile("milvus-backup-test-", ".parquet")
+    Files.delete(tmp)
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(tmp.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      rows.foreach(build => writer.write(build(factory)))
+    } finally {
+      writer.close()
+    }
+    tmp.toUri.toString
+  }
+
+  private def parquetA: String =
+    writeParquet(
+      groupASchema,
+      List(
+        f =>
+          f.newGroup()
+            .append("pk", 1L)
+            .append("row_id", 10L)
+            .append("ts", 100L),
+        f =>
+          f.newGroup().append("pk", 2L).append("row_id", 11L).append("ts", 101L)
+      )
+    )
+
+  private def parquetB: String =
+    writeParquet(
+      groupASchema,
+      List(f =>
+        f.newGroup().append("pk", 3L).append("row_id", 12L).append("ts", 102L)
+      )
+    )
+
+  private def parquetC: String =
+    writeParquet(
+      groupCSchema,
+      List(
+        f => f.newGroup().append("name", "a"),
+        f => f.newGroup().append("name", "b"),
+        f => f.newGroup().append("name", "c")
+      )
+    )
+
+  private def backupFixture(
+      format: String = "",
+      groupAPath: String,
+      groupBPath: String,
+      groupCPath: String,
+      deltaPath: String
+  ): String = {
+    s"""{
+       |  "id": "task-1",
+       |  "name": "b1",
+       |  "format": "$format",
+       |  "milvus_version": "v2.6.0",
+       |  "collection_backups": [
+       |    {
+       |      "collection_id": 444,
+       |      "collection_name": "demo",
+       |      "db_name": "default",
+       |      "schema": {
+       |        "name": "demo",
+       |        "description": "",
+       |        "autoID": false,
+       |        "enable_dynamic_field": false,
+       |        "fields": [
+       |          {"fieldID": 100, "name": "id", "is_primary_key": true, "description": "", "autoID": false, "data_type": 5, "type_params": [], "index_params": [], "state": 0, "element_type": 0, "is_dynamic": false, "is_partition_key": false, "nullable": false, "is_function_output": false},
+       |          {"fieldID": 101, "name": "name", "is_primary_key": false, "description": "", "autoID": false, "data_type": 21, "type_params": [{"key": "max_length", "value": "64"}], "index_params": [], "state": 0, "element_type": 0, "is_dynamic": false, "is_partition_key": false, "nullable": false, "is_function_output": false},
+       |          {"fieldID": 102, "name": "vector", "is_primary_key": false, "description": "", "autoID": false, "data_type": 101, "type_params": [{"key": "dim", "value": "8"}], "index_params": [], "state": 0, "element_type": 0, "is_dynamic": false, "is_partition_key": false, "nullable": false, "is_function_output": false}
+       |        ]
+       |      },
+       |      "shards_num": 1,
+       |      "consistency_level": 2,
+       |      "partition_backups": [
+       |        {
+       |          "partition_id": 555,
+       |          "partition_name": "_default",
+       |          "collection_id": 444,
+       |          "segment_backups": [
+       |            {
+       |              "segment_id": 777,
+       |              "collection_id": 444,
+       |              "partition_id": 555,
+       |              "num_of_rows": 3,
+       |              "binlogs": [
+       |                {"fieldID": 103, "binlogs": [
+       |                  {"log_path": "$groupAPath", "log_size": 100, "log_id": 1},
+       |                  {"log_path": "$groupBPath", "log_size": 100, "log_id": 2}
+       |                ]},
+       |                {"fieldID": 101, "binlogs": [
+       |                  {"log_path": "$groupCPath", "log_size": 100, "log_id": 1}
+       |                ]}
+       |              ],
+       |              "deltalogs": [],
+       |              "size": 300,
+       |              "group_id": 777,
+       |              "is_l0": false,
+       |              "v_channel": "by-dev-rootcoord-dml-0",
+       |              "storage_version": 2
+       |            }
+       |          ],
+       |          "size": 300
+       |        }
+       |      ],
+       |      "size": 300,
+       |      "has_index": false,
+       |      "index_infos": [],
+       |      "load_state": "Loaded",
+       |      "l0_segments": [
+       |        {
+       |          "segment_id": 888,
+       |          "collection_id": 444,
+       |          "partition_id": -1,
+       |          "num_of_rows": 0,
+       |          "binlogs": [],
+       |          "deltalogs": [
+       |            {"fieldID": 0, "binlogs": [{"log_path": "$deltaPath", "log_size": 10, "log_id": 1}]}
+       |          ],
+       |          "size": 10,
+       |          "group_id": 0,
+       |          "is_l0": true,
+       |          "v_channel": "by-dev-rootcoord-dml-0",
+       |          "storage_version": 2
+       |        }
+       |      ]
+       |    }
+       |  ],
+       |  "size": 310,
+       |  "milvus_version": "v2.6.0"
+       |}""".stripMargin
+  }
+
+  test("metaPath joins the backup dir with meta/full_meta.json") {
+    BackupMetaReader.metaPath("s3a://bucket/backup/b1") shouldBe
+      "s3a://bucket/backup/b1/meta/full_meta.json"
+    BackupMetaReader.metaPath("s3a://bucket/backup/b1/") shouldBe
+      "s3a://bucket/backup/b1/meta/full_meta.json"
+    BackupMetaReader.metaPath("/data/backups/b1") shouldBe
+      "/data/backups/b1/meta/full_meta.json"
+  }
+
+  test("readMeta parses a binlog-format backup full_meta.json") {
+    val dir = Files.createTempDirectory("milvus-backup-meta-")
+    try {
+      val metaDir = Paths.get(dir.toString, "meta")
+      Files.createDirectories(metaDir)
+      val json =
+        backupFixture(
+          groupAPath = "backup/b1/binlogs/insert_log/444/555/777/103/1",
+          groupBPath = "backup/b1/binlogs/insert_log/444/555/777/103/2",
+          groupCPath = "backup/b1/binlogs/insert_log/444/555/777/101/1",
+          deltaPath = "backup/b1/binlogs/delta_log/444/-1/888/1"
+        )
+      Files.write(
+        Paths.get(metaDir.toString, "full_meta.json"),
+        json.getBytes("UTF-8")
+      )
+
+      val meta = BackupMetaReader
+        .readMeta(new Configuration(), dir.toString)
+        .getOrElse(fail("expected Right"))
+      meta.name shouldBe "b1"
+      meta.isSnapshotFormat shouldBe false
+      meta.collectionBackups should have size 1
+
+      val coll = meta.collectionBackups.head
+      coll.collectionId shouldBe 444L
+      coll.collectionName shouldBe "demo"
+      coll.schema.isDefined shouldBe true
+      coll.schema.get.fields should have size 3
+      coll.schema.get.fields.head.fieldId shouldBe 100L
+      coll.allSegments should have size 2 // 777 (L1) + 888 (L0)
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test("toProtobufSchemaBytes round-trips the backup collection schema") {
+    val json =
+      backupFixture(
+        groupAPath = "x",
+        groupBPath = "y",
+        groupCPath = "z",
+        deltaPath = "d"
+      )
+    val meta = BackupMetaReader.parse(json).getOrElse(fail("expected Right"))
+    val schema = meta.collectionBackups.head.schema.get
+
+    val parsed = CollectionSchema.parseFrom(
+      BackupMetaReader.toProtobufSchemaBytes(schema)
+    )
+    parsed.name shouldBe "demo"
+    parsed.fields should have size 3
+
+    val byId = parsed.fields.map(f => f.fieldID -> f).toMap
+    byId(100L).isPrimaryKey shouldBe true
+    byId(100L).dataType shouldBe DataType.Int64
+    byId(101L).dataType shouldBe DataType.VarChar
+    byId(101L).typeParams.find(_.key == "max_length").get.value shouldBe "64"
+    byId(102L).dataType shouldBe DataType.FloatVector
+    byId(102L).typeParams.find(_.key == "dim").get.value shouldBe "8"
+  }
+
+  test("toV2Segments recovers column groups, field ids and row counts") {
+    val a = parquetA
+    val b = parquetB
+    val c = parquetC
+    val meta = BackupMetaReader
+      .parse(
+        backupFixture(
+          groupAPath = a,
+          groupBPath = b,
+          groupCPath = c,
+          deltaPath = "dummy/delta.log"
+        )
+      )
+      .getOrElse(fail("expected Right"))
+
+    val segments = BackupMetaReader
+      .toV2Segments(meta, new Configuration(), bucket = "")
+      .getOrElse(fail("expected Right"))
+
+    segments should have size 2
+    val seg = segments.find(_.segmentId == 777L).get
+    seg.partitionId shouldBe 555L
+    seg.numOfRows shouldBe 3L
+    seg.storageVersion shouldBe 2L
+    seg.columnGroups should have size 2
+
+    val slot103 = seg.columnGroups.find(_.slotFieldId == 103L).get
+    slot103.fieldIds shouldBe Seq(100L, 0L, 1L)
+    slot103.filePaths shouldBe Seq(a, b)
+    slot103.fileRowCounts shouldBe Seq(2L, 1L)
+
+    val slot101 = seg.columnGroups.find(_.slotFieldId == 101L).get
+    slot101.fieldIds shouldBe Seq(101L)
+    slot101.filePaths shouldBe Seq(c)
+    slot101.fileRowCounts shouldBe Seq(3L)
+
+    val l0 = segments.find(_.segmentId == 888L).get
+    l0.columnGroups shouldBe empty
+    l0.deltaLogs should have size 1
+    l0.deltaLogs.head.logPath shouldBe "dummy/delta.log"
+  }
+
+  test("toV2Segments skips L0 segments when applyDeletes is false") {
+    val meta = BackupMetaReader
+      .parse(
+        backupFixture(
+          groupAPath = parquetA,
+          groupBPath = parquetB,
+          groupCPath = parquetC,
+          deltaPath = "dummy/delta.log"
+        )
+      )
+      .getOrElse(fail("expected Right"))
+    val segments = BackupMetaReader
+      .toV2Segments(
+        meta,
+        new Configuration(),
+        bucket = "",
+        applyDeletes = false
+      )
+      .getOrElse(fail("expected Right"))
+    segments.map(_.segmentId) shouldBe Seq(777L)
+  }
+
+  test("buildV2Segment rejects StorageV3+ and skips StorageV1") {
+    val v3 = BackupMetaReader.SegmentBackup(
+      segmentId = 1L,
+      storageVersion = 3L
+    )
+    BackupMetaReader
+      .buildV2Segment(v3, new Configuration(), "", applyDeletes = true)
+      .left
+      .toOption
+      .get
+      .getMessage should include("StorageV3")
+
+    val v1 = BackupMetaReader.SegmentBackup(
+      segmentId = 2L,
+      storageVersion = 0L
+    )
+    BackupMetaReader
+      .buildV2Segment(v1, new Configuration(), "", applyDeletes = true) shouldBe
+      Right(None)
+  }
+
+  test("toV2Segments rejects snapshot-format backups") {
+    val meta = BackupMetaReader
+      .parse(
+        backupFixture(
+          format = "snapshot",
+          groupAPath = parquetA,
+          groupBPath = parquetB,
+          groupCPath = parquetC,
+          deltaPath = "dummy/delta.log"
+        )
+      )
+      .getOrElse(fail("expected Right"))
+    val result =
+      BackupMetaReader.toV2Segments(meta, new Configuration(), bucket = "")
+    result.isLeft shouldBe true
+    result.left.toOption.get.getMessage should include("snapshot format")
+  }
+
+  private def deleteRecursively(dir: java.nio.file.Path): Unit = {
+    import scala.jdk.CollectionConverters._
+    if (Files.exists(dir)) {
+      Files.list(dir).iterator().asScala.foreach { p =>
+        if (Files.isDirectory(p)) deleteRecursively(p)
+        else Files.deleteIfExists(p)
+      }
+      Files.deleteIfExists(dir)
+    }
+  }
+}

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -362,6 +362,23 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("serialize/parse round-trips the parsed backup meta") {
+    val json = backupFixture(
+      groupAPath = SourceKeys._1,
+      groupBPath = SourceKeys._2,
+      groupCPath = SourceKeys._3,
+      deltaPath = SourceKeys._4
+    )
+    val meta = BackupMetaReader.parse(json).getOrElse(fail("expected Right"))
+    val roundTripped =
+      BackupMetaReader
+        .parse(BackupMetaReader.serialize(meta))
+        .getOrElse(
+          fail("expected Right")
+        )
+    roundTripped shouldBe meta
+  }
+
   test("toProtobufSchemaBytes round-trips the backup collection schema") {
     val json = backupFixture(
       groupAPath = SourceKeys._1,

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -1,7 +1,6 @@
 package com.zilliz.spark.connector.read
 
-import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path => HPath}
@@ -20,10 +19,13 @@ import org.scalatest.matchers.should.Matchers
 import io.milvus.grpc.schema.{CollectionSchema, DataType}
 
 /** Tests for [[BackupMetaReader]] — parses milvus-backup's `full_meta.json` and
-  * maps it to the packed-V2 read-path objects. Local parquet files written with
-  * parquet-mr's example writer carry `PARQUET:field_id` the same way
-  * milvus-storage does, so the field-id / row-count recovery can be exercised
-  * without minio.
+  * maps it to the packed-V2 read-path objects.
+  *
+  * The meta fixtures carry **Milvus source keys** for `log_path` (e.g.
+  * `files/insert_log/...`) exactly like a real export — milvus-backup records
+  * the source key and copies the data under a separate `DestKey`. The tests
+  * materialize that `DestKey` layout on local disk and assert that the reader
+  * reconstructs those backup paths (never the source keys).
   */
 class BackupMetaReaderTest extends AnyFunSuite with Matchers {
 
@@ -47,19 +49,19 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     .named("name")
     .named("milvus_group")
 
-  /** Write a local parquet with the given rows (one `Group` per row) and return
-    * its `file://` URI.
+  /** Write a parquet file at `target` (creating parent dirs) with one `Group`
+    * per row.
     */
-  private def writeParquet(
+  private def writeParquetAt(
+      target: java.nio.file.Path,
       schema: MessageType,
       rows: List[SimpleGroupFactory => Group]
-  ): String = {
-    val tmp = Files.createTempFile("milvus-backup-test-", ".parquet")
-    Files.delete(tmp)
+  ): Unit = {
+    Files.createDirectories(target.getParent)
     val conf = new Configuration()
     GroupWriteSupport.setSchema(schema, conf)
     val writer = ExampleParquetWriter
-      .builder(new HPath(tmp.toUri))
+      .builder(new HPath(target.toUri))
       .withType(schema)
       .withConf(conf)
       .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
@@ -70,11 +72,31 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     } finally {
       writer.close()
     }
-    tmp.toUri.toString
   }
 
-  private def parquetA: String =
-    writeParquet(
+  /** Materialize the backup object layout milvus-backup's `DestKey` produces
+    * under `root` for the fixture segments:
+    *
+    * {{{
+    *   binlogs/insert_log/444/555/777/777/103/{1,2}   (2 rows, 1 row)
+    *   binlogs/insert_log/444/555/777/777/101/1        (3 rows)
+    * }}}
+    *
+    * Returns the backup dir path string.
+    */
+  private def materializeBackup(root: java.nio.file.Path): String = {
+    val seg =
+      Paths.get(
+        root.toString,
+        "binlogs",
+        "insert_log",
+        "444",
+        "555",
+        "777",
+        "777"
+      )
+    writeParquetAt(
+      Paths.get(seg.toString, "103", "1"),
       groupASchema,
       List(
         f =>
@@ -86,17 +108,15 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
           f.newGroup().append("pk", 2L).append("row_id", 11L).append("ts", 101L)
       )
     )
-
-  private def parquetB: String =
-    writeParquet(
+    writeParquetAt(
+      Paths.get(seg.toString, "103", "2"),
       groupASchema,
       List(f =>
         f.newGroup().append("pk", 3L).append("row_id", 12L).append("ts", 102L)
       )
     )
-
-  private def parquetC: String =
-    writeParquet(
+    writeParquetAt(
+      Paths.get(seg.toString, "101", "1"),
       groupCSchema,
       List(
         f => f.newGroup().append("name", "a"),
@@ -104,6 +124,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
         f => f.newGroup().append("name", "c")
       )
     )
+    root.toString
+  }
 
   private def backupFixture(
       format: String = "",
@@ -194,6 +216,15 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
        |}""".stripMargin
   }
 
+  // Milvus source keys, as a real full_meta.json records them.
+  private val SourceKeys =
+    (
+      "files/insert_log/444/555/777/103/1",
+      "files/insert_log/444/555/777/103/2",
+      "files/insert_log/444/555/777/101/1",
+      "files/delta_log/444/-1/888/1"
+    )
+
   test("metaPath joins the backup dir with meta/full_meta.json") {
     BackupMetaReader.metaPath("s3a://bucket/backup/b1") shouldBe
       "s3a://bucket/backup/b1/meta/full_meta.json"
@@ -208,13 +239,12 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     try {
       val metaDir = Paths.get(dir.toString, "meta")
       Files.createDirectories(metaDir)
-      val json =
-        backupFixture(
-          groupAPath = "backup/b1/binlogs/insert_log/444/555/777/103/1",
-          groupBPath = "backup/b1/binlogs/insert_log/444/555/777/103/2",
-          groupCPath = "backup/b1/binlogs/insert_log/444/555/777/101/1",
-          deltaPath = "backup/b1/binlogs/delta_log/444/-1/888/1"
-        )
+      val json = backupFixture(
+        groupAPath = SourceKeys._1,
+        groupBPath = SourceKeys._2,
+        groupCPath = SourceKeys._3,
+        deltaPath = SourceKeys._4
+      )
       Files.write(
         Paths.get(metaDir.toString, "full_meta.json"),
         json.getBytes("UTF-8")
@@ -240,13 +270,12 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
   }
 
   test("toProtobufSchemaBytes round-trips the backup collection schema") {
-    val json =
-      backupFixture(
-        groupAPath = "x",
-        groupBPath = "y",
-        groupCPath = "z",
-        deltaPath = "d"
-      )
+    val json = backupFixture(
+      groupAPath = SourceKeys._1,
+      groupBPath = SourceKeys._2,
+      groupCPath = SourceKeys._3,
+      deltaPath = SourceKeys._4
+    )
     val meta = BackupMetaReader.parse(json).getOrElse(fail("expected Right"))
     val schema = meta.collectionBackups.head.schema.get
 
@@ -265,89 +294,152 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     byId(102L).typeParams.find(_.key == "dim").get.value shouldBe "8"
   }
 
-  test("toV2Segments recovers column groups, field ids and row counts") {
-    val a = parquetA
-    val b = parquetB
-    val c = parquetC
-    val meta = BackupMetaReader
-      .parse(
-        backupFixture(
-          groupAPath = a,
-          groupBPath = b,
-          groupCPath = c,
-          deltaPath = "dummy/delta.log"
+  test(
+    "toV2Segments reconstructs backup paths and recovers column groups, field ids and row counts"
+  ) {
+    val dir = Files.createTempDirectory("milvus-backup-b1-")
+    try {
+      val backupDir = materializeBackup(dir)
+      val meta = BackupMetaReader
+        .parse(
+          backupFixture(
+            groupAPath = SourceKeys._1,
+            groupBPath = SourceKeys._2,
+            groupCPath = SourceKeys._3,
+            deltaPath = SourceKeys._4
+          )
         )
+        .getOrElse(fail("expected Right"))
+
+      val segments = BackupMetaReader
+        .toV2Segments(meta, new Configuration(), backupDir)
+        .getOrElse(fail("expected Right"))
+
+      segments should have size 2
+      val seg = segments.find(_.segmentId == 777L).get
+      seg.partitionId shouldBe 555L
+      seg.numOfRows shouldBe 3L
+      seg.storageVersion shouldBe 2L
+      seg.columnGroups should have size 2
+
+      // Reconstructed backup paths (groupId=777 level present for insert_log),
+      // not the source keys carried in the meta.
+      val slot103 = seg.columnGroups.find(_.slotFieldId == 103L).get
+      slot103.fieldIds shouldBe Seq(100L, 0L, 1L)
+      slot103.filePaths shouldBe Seq(
+        s"$backupDir/binlogs/insert_log/444/555/777/777/103/1",
+        s"$backupDir/binlogs/insert_log/444/555/777/777/103/2"
       )
-      .getOrElse(fail("expected Right"))
+      slot103.fileRowCounts shouldBe Seq(2L, 1L)
 
-    val segments = BackupMetaReader
-      .toV2Segments(meta, new Configuration(), bucket = "")
-      .getOrElse(fail("expected Right"))
+      val slot101 = seg.columnGroups.find(_.slotFieldId == 101L).get
+      slot101.fieldIds shouldBe Seq(101L)
+      slot101.filePaths shouldBe Seq(
+        s"$backupDir/binlogs/insert_log/444/555/777/777/101/1"
+      )
+      slot101.fileRowCounts shouldBe Seq(3L)
 
-    segments should have size 2
-    val seg = segments.find(_.segmentId == 777L).get
-    seg.partitionId shouldBe 555L
-    seg.numOfRows shouldBe 3L
-    seg.storageVersion shouldBe 2L
-    seg.columnGroups should have size 2
-
-    val slot103 = seg.columnGroups.find(_.slotFieldId == 103L).get
-    slot103.fieldIds shouldBe Seq(100L, 0L, 1L)
-    slot103.filePaths shouldBe Seq(a, b)
-    slot103.fileRowCounts shouldBe Seq(2L, 1L)
-
-    val slot101 = seg.columnGroups.find(_.slotFieldId == 101L).get
-    slot101.fieldIds shouldBe Seq(101L)
-    slot101.filePaths shouldBe Seq(c)
-    slot101.fileRowCounts shouldBe Seq(3L)
-
-    val l0 = segments.find(_.segmentId == 888L).get
-    l0.columnGroups shouldBe empty
-    l0.deltaLogs should have size 1
-    l0.deltaLogs.head.logPath shouldBe "dummy/delta.log"
+      // L0 delta logs reconstruct without the groupID level (partition == -1).
+      val l0 = segments.find(_.segmentId == 888L).get
+      l0.columnGroups shouldBe empty
+      l0.deltaLogs should have size 1
+      l0.deltaLogs.head.logPath shouldBe
+        s"$backupDir/binlogs/delta_log/444/-1/888/1"
+    } finally {
+      deleteRecursively(dir)
+    }
   }
 
   test("toV2Segments skips L0 segments when applyDeletes is false") {
-    val meta = BackupMetaReader
-      .parse(
-        backupFixture(
-          groupAPath = parquetA,
-          groupBPath = parquetB,
-          groupCPath = parquetC,
-          deltaPath = "dummy/delta.log"
+    val dir = Files.createTempDirectory("milvus-backup-b1-")
+    try {
+      val backupDir = materializeBackup(dir)
+      val meta = BackupMetaReader
+        .parse(
+          backupFixture(
+            groupAPath = SourceKeys._1,
+            groupBPath = SourceKeys._2,
+            groupCPath = SourceKeys._3,
+            deltaPath = SourceKeys._4
+          )
         )
-      )
-      .getOrElse(fail("expected Right"))
-    val segments = BackupMetaReader
-      .toV2Segments(
-        meta,
-        new Configuration(),
-        bucket = "",
-        applyDeletes = false
-      )
-      .getOrElse(fail("expected Right"))
-    segments.map(_.segmentId) shouldBe Seq(777L)
+        .getOrElse(fail("expected Right"))
+      val segments = BackupMetaReader
+        .toV2Segments(
+          meta,
+          new Configuration(),
+          backupDir,
+          applyDeletes = false
+        )
+        .getOrElse(fail("expected Right"))
+      segments.map(_.segmentId) shouldBe Seq(777L)
+    } finally {
+      deleteRecursively(dir)
+    }
   }
 
-  test("buildV2Segment rejects StorageV3+ and skips StorageV1") {
-    val v3 = BackupMetaReader.SegmentBackup(
-      segmentId = 1L,
-      storageVersion = 3L
-    )
+  test(
+    "buildV2Segment fails hard for non-L0 non-StorageV2 and keeps L0 without a storage version"
+  ) {
+    val conf = new Configuration()
+
+    // StorageV3 data segment -> Left.
+    val v3 = BackupMetaReader.SegmentBackup(segmentId = 1L, storageVersion = 3L)
     BackupMetaReader
-      .buildV2Segment(v3, new Configuration(), "", applyDeletes = true)
+      .buildV2Segment(v3, conf, "/tmp/backup", applyDeletes = true)
       .left
       .toOption
       .get
-      .getMessage should include("StorageV3")
+      .getMessage should include("storage_version")
 
-    val v1 = BackupMetaReader.SegmentBackup(
-      segmentId = 2L,
-      storageVersion = 0L
-    )
+    // StorageV1 data segment -> fails hard too (partial dataset is worse than
+    // an error).
+    val v1 = BackupMetaReader.SegmentBackup(segmentId = 2L, storageVersion = 0L)
     BackupMetaReader
-      .buildV2Segment(v1, new Configuration(), "", applyDeletes = true) shouldBe
-      Right(None)
+      .buildV2Segment(v1, conf, "/tmp/backup", applyDeletes = true)
+      .isLeft shouldBe true
+
+    // L0 delete-only segment with storage_version 0/omitted (how Milvus 2.6
+    // creates them) must NOT fall into the StorageV1 skip path.
+    val l0NoVersion = BackupMetaReader.SegmentBackup(
+      segmentId = 3L,
+      collectionId = 444L,
+      partitionId = -1L,
+      isL0 = true,
+      storageVersion = 0L,
+      deltalogs = Seq(
+        BackupMetaReader.FieldBinlog(
+          fieldId = 0L,
+          binlogs = Seq(
+            BackupMetaReader.Binlog(
+              logId = 1L,
+              logPath = "files/delta_log/444/-1/3/1",
+              logSize = 10L
+            )
+          )
+        )
+      )
+    )
+    BackupMetaReader.buildV2Segment(
+      l0NoVersion,
+      conf,
+      "/tmp/backup",
+      applyDeletes = true
+    ) match {
+      case Right(Some(seg)) =>
+        seg.columnGroups shouldBe empty
+        seg.deltaLogs.map(_.logPath) shouldBe Seq(
+          "/tmp/backup/binlogs/delta_log/444/-1/3/1"
+        )
+      case other => fail(s"expected Right(Some), got $other")
+    }
+    // With applyDeletes=false the L0 segment is skipped entirely.
+    BackupMetaReader.buildV2Segment(
+      l0NoVersion,
+      conf,
+      "/tmp/backup",
+      applyDeletes = false
+    ) shouldBe Right(None)
   }
 
   test("toV2Segments rejects snapshot-format backups") {
@@ -355,15 +447,18 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       .parse(
         backupFixture(
           format = "snapshot",
-          groupAPath = parquetA,
-          groupBPath = parquetB,
-          groupCPath = parquetC,
-          deltaPath = "dummy/delta.log"
+          groupAPath = SourceKeys._1,
+          groupBPath = SourceKeys._2,
+          groupCPath = SourceKeys._3,
+          deltaPath = SourceKeys._4
         )
       )
       .getOrElse(fail("expected Right"))
-    val result =
-      BackupMetaReader.toV2Segments(meta, new Configuration(), bucket = "")
+    val result = BackupMetaReader.toV2Segments(
+      meta,
+      new Configuration(),
+      "s3a://bucket/backup/b1"
+    )
     result.isLeft shouldBe true
     result.left.toOption.get.getMessage should include("snapshot format")
   }

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -681,6 +681,80 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("L1 segment delta logs reconstruct with the groupID level") {
+    val dir = Files.createTempDirectory("milvus-backup-l1-")
+    try {
+      // L1 (partition != -1) delta logs carry the groupID level; a regression
+      // here (empty deltaLogs or a mis-ordered delta path) would silently let
+      // deleted rows come back because loadV2DeletePlans filters on
+      // columnGroups.nonEmpty && deltaLogs.nonEmpty.
+      val segDir =
+        Paths.get(
+          dir.toString,
+          "binlogs",
+          "insert_log",
+          "444",
+          "555",
+          "999",
+          "777"
+        )
+      writeParquetAt(
+        Paths.get(segDir.toString, "103", "1"),
+        groupASchema,
+        List(f =>
+          f.newGroup().append("pk", 1L).append("row_id", 10L).append("ts", 100L)
+        )
+      )
+      val seg = BackupMetaReader.SegmentBackup(
+        segmentId = 777L,
+        collectionId = 444L,
+        partitionId = 555L,
+        groupId = 999L,
+        numOfRows = 1L,
+        storageVersion = 2L,
+        binlogs = Seq(
+          BackupMetaReader.FieldBinlog(
+            fieldId = 103L,
+            binlogs = Seq(
+              BackupMetaReader.Binlog(
+                logId = 1L,
+                logPath = "files/insert_log/444/555/777/103/1",
+                logSize = 10L
+              )
+            )
+          )
+        ),
+        deltalogs = Seq(
+          BackupMetaReader.FieldBinlog(
+            fieldId = 0L,
+            binlogs = Seq(
+              BackupMetaReader.Binlog(
+                logId = 5L,
+                logPath = "files/delta_log/444/555/777/5",
+                logSize = 10L
+              )
+            )
+          )
+        )
+      )
+      BackupMetaReader.buildV2Segment(
+        seg,
+        new Configuration(),
+        dir.toString,
+        applyDeletes = true
+      ) match {
+        case Right(Some(v2)) =>
+          v2.deltaLogs.map(_.logId) shouldBe Seq(5L)
+          v2.deltaLogs.map(_.logPath) shouldBe Seq(
+            s"${dir.toString}/binlogs/delta_log/444/555/999/777/5"
+          )
+        case other => fail(s"expected Right(Some), got $other")
+      }
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
   private def deleteRecursively(dir: java.nio.file.Path): Unit = {
     import scala.jdk.CollectionConverters._
     if (Files.exists(dir)) {

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -506,6 +506,67 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     result.left.toOption.get.getMessage should include("snapshot format")
   }
 
+  test(
+    "toProtobufSchemaBytes rejects dynamic collections without a $meta record"
+  ) {
+    import com.fasterxml.jackson.databind.node.IntNode
+    val base = BackupMetaReader.BackupCollectionSchema(
+      name = "demo",
+      enableDynamicField = true,
+      fields = Seq(
+        BackupMetaReader.BackupFieldSchema(
+          fieldId = 100L,
+          name = "id",
+          rawDataType = Some(IntNode.valueOf(5))
+        )
+      )
+    )
+    val err = intercept[IllegalArgumentException] {
+      BackupMetaReader.toProtobufSchemaBytes(base)
+    }
+    err.getMessage should include("--backup_index_extra")
+
+    // With the $meta field recorded, conversion succeeds.
+    val withMeta = base.copy(
+      fields = base.fields :+ BackupMetaReader.BackupFieldSchema(
+        fieldId = 101L,
+        name = "$meta",
+        rawDataType = Some(IntNode.valueOf(23))
+      )
+    )
+    BackupMetaReader.toProtobufSchemaBytes(withMeta).nonEmpty shouldBe true
+  }
+
+  test(
+    "buildV2Segment fails hard when a non-empty StorageV2 segment has no binlogs"
+  ) {
+    val conf = new Configuration()
+    val seg = BackupMetaReader.SegmentBackup(
+      segmentId = 9L,
+      storageVersion = 2L,
+      numOfRows = 50000L,
+      binlogs = Seq.empty
+    )
+    val err = BackupMetaReader
+      .buildV2Segment(seg, conf, "/tmp/backup", applyDeletes = true)
+      .left
+      .toOption
+      .get
+    err.getMessage should include("refusing to silently drop rows")
+
+    // A genuinely empty segment (no rows, no binlogs) stays a soft empty.
+    val zeroRowSeg = seg.copy(numOfRows = 0L)
+    BackupMetaReader.buildV2Segment(
+      zeroRowSeg,
+      conf,
+      "/tmp/backup",
+      applyDeletes = true
+    ) match {
+      case Right(Some(v2)) => v2.columnGroups shouldBe Seq.empty
+      case other           => fail(s"expected Right(Some), got $other")
+    }
+  }
+
   private def deleteRecursively(dir: java.nio.file.Path): Unit = {
     import scala.jdk.CollectionConverters._
     if (Files.exists(dir)) {

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -237,11 +237,13 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
   test(
     "path builders split qualified URIs (Hadoop) from bucket-relative keys (native)"
   ) {
+    // A groupId distinct from segmentId pins the {group}/{seg} level order —
+    // groupId == segmentId would not discriminate the two.
     val seg = BackupMetaReader.SegmentBackup(
       segmentId = 777L,
       collectionId = 444L,
       partitionId = 555L,
-      groupId = 777L
+      groupId = 999L
     )
     BackupMetaReader.backupKeyBase(
       "s3a://bucket/backup/b1"
@@ -257,13 +259,13 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       seg,
       103L,
       1L
-    ) shouldBe "backup/b1/binlogs/insert_log/444/555/777/777/103/1"
+    ) shouldBe "backup/b1/binlogs/insert_log/444/555/999/777/103/1"
     BackupMetaReader.qualifiedInsertLogPath(
       "s3a://bucket/backup/b1",
       seg,
       103L,
       1L
-    ) shouldBe "s3a://bucket/backup/b1/binlogs/insert_log/444/555/777/777/103/1"
+    ) shouldBe "s3a://bucket/backup/b1/binlogs/insert_log/444/555/999/777/103/1"
 
     // Delta logs only feed the Hadoop delete-plan reader, so only qualified
     // paths exist. groupID level present for part != -1, omitted for part == -1.
@@ -271,7 +273,7 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       "s3a://bucket/backup/b1",
       seg,
       9L
-    ) shouldBe "s3a://bucket/backup/b1/binlogs/delta_log/444/555/777/777/9"
+    ) shouldBe "s3a://bucket/backup/b1/binlogs/delta_log/444/555/999/777/9"
     val l0 = seg.copy(partitionId = -1L, groupId = 0L)
     BackupMetaReader.qualifiedDeltaLogPath(
       "s3a://bucket/backup/b1",

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -769,6 +769,35 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
   }
 
   test(
+    "toProtobufSchemaBytes rejects collections with struct-array fields"
+  ) {
+    import com.fasterxml.jackson.databind.node.IntNode
+    val arrayNode = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance
+      .arrayNode()
+    arrayNode.addObject()
+    val schema = BackupMetaReader.BackupCollectionSchema(
+      name = "demo",
+      fields = Seq(
+        BackupMetaReader.BackupFieldSchema(
+          fieldId = 100L,
+          name = "id",
+          rawDataType = Some(IntNode.valueOf(5))
+        )
+      ),
+      structArrayFields = Some(arrayNode)
+    )
+    val err = intercept[IllegalArgumentException] {
+      BackupMetaReader.toProtobufSchemaBytes(schema)
+    }
+    err.getMessage should include("struct-array")
+
+    // Empty / absent struct_array_fields are fine.
+    BackupMetaReader
+      .toProtobufSchemaBytes(schema.copy(structArrayFields = None))
+      .nonEmpty shouldBe true
+  }
+
+  test(
     "buildV2Segment fails hard when a non-empty StorageV2 segment has no binlogs"
   ) {
     val conf = new Configuration()
@@ -879,6 +908,73 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
         .toOption
         .get
       err.getMessage should include("inconsistent row totals")
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
+  test(
+    "buildV2Segment rejects when footer rows disagree with num_of_rows"
+  ) {
+    val dir = Files.createTempDirectory("milvus-backup-rowmismatch-")
+    try {
+      val base =
+        Paths.get(
+          dir.toString,
+          "binlogs",
+          "insert_log",
+          "444",
+          "555",
+          "999",
+          "777"
+        )
+      writeParquetAt(
+        Paths.get(base.toString, "103", "1"),
+        groupASchema,
+        List(
+          f =>
+            f.newGroup()
+              .append("pk", 1L)
+              .append("row_id", 10L)
+              .append("ts", 100L),
+          f =>
+            f.newGroup()
+              .append("pk", 2L)
+              .append("row_id", 11L)
+              .append("ts", 101L)
+        )
+      )
+      val seg = BackupMetaReader.SegmentBackup(
+        segmentId = 777L,
+        collectionId = 444L,
+        partitionId = 555L,
+        groupId = 999L,
+        numOfRows = 3L, // meta claims 3, footer has 2
+        storageVersion = 2L,
+        binlogs = Seq(
+          BackupMetaReader.FieldBinlog(
+            fieldId = 103L,
+            binlogs = Seq(
+              BackupMetaReader.Binlog(
+                logId = 1L,
+                logPath = "files/insert_log/444/555/777/103/1",
+                logSize = 10L
+              )
+            )
+          )
+        )
+      )
+      val err = BackupMetaReader
+        .buildV2Segment(
+          seg,
+          new Configuration(),
+          dir.toString,
+          applyDeletes = true
+        )
+        .left
+        .toOption
+        .get
+      err.getMessage should include("meta and data disagree")
     } finally {
       deleteRecursively(dir)
     }

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -403,7 +403,7 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
         .getOrElse(fail("expected Right"))
 
       val segments = BackupMetaReader
-        .toV2Segments(meta, new Configuration(), backupDir)
+        .toV2Segments(meta, new Configuration(), backupDir, collectionId = 444L)
         .getOrElse(fail("expected Right"))
 
       segments should have size 2
@@ -441,6 +441,51 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("toV2Segments materializes only the requested collection") {
+    val dir = Files.createTempDirectory("milvus-backup-b1-")
+    try {
+      val backupDir = materializeBackup(dir)
+      val base = BackupMetaReader
+        .parse(
+          backupFixture(
+            groupAPath = SourceKeys._1,
+            groupBPath = SourceKeys._2,
+            groupCPath = SourceKeys._3,
+            deltaPath = SourceKeys._4
+          )
+        )
+        .getOrElse(fail("expected Right"))
+      // A second collection with no segments must never leak into the read.
+      val twoColl = base.copy(
+        collectionBackups = base.collectionBackups :+
+          BackupMetaReader.CollectionBackup(
+            collectionId = 555L,
+            collectionName = "other"
+          )
+      )
+      val segments = BackupMetaReader
+        .toV2Segments(
+          twoColl,
+          new Configuration(),
+          backupDir,
+          collectionId = 444L
+        )
+        .getOrElse(fail("expected Right"))
+      segments.map(_.segmentId) shouldBe Seq(777L, 888L)
+
+      BackupMetaReader
+        .toV2Segments(
+          twoColl,
+          new Configuration(),
+          backupDir,
+          collectionId = 555L
+        )
+        .getOrElse(fail("expected Right")) shouldBe Seq.empty
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
   test("toV2Segments skips L0 segments when applyDeletes is false") {
     val dir = Files.createTempDirectory("milvus-backup-b1-")
     try {
@@ -460,7 +505,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
           meta,
           new Configuration(),
           backupDir,
-          applyDeletes = false
+          applyDeletes = false,
+          collectionId = 444L
         )
         .getOrElse(fail("expected Right"))
       segments.map(_.segmentId) shouldBe Seq(777L)
@@ -548,7 +594,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     val result = BackupMetaReader.toV2Segments(
       meta,
       new Configuration(),
-      "s3a://bucket/backup/b1"
+      "s3a://bucket/backup/b1",
+      collectionId = 444L
     )
     result.isLeft shouldBe true
     result.left.toOption.get.getMessage should include("snapshot format")

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -252,6 +252,12 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     // Empty-authority URIs keep the leading slash, matching the bare form.
     BackupMetaReader.backupKeyBase("file:///data/backup/b1") shouldBe
       "/data/backup/b1"
+    // Backup at the bucket root: empty bucket-relative prefix, and trailing
+    // double-slashes must collapse to a single location.
+    BackupMetaReader.backupKeyBase("s3a://bucket") shouldBe ""
+    BackupMetaReader.backupKeyBase("s3a://b/backup/b1//") shouldBe "backup/b1"
+    BackupMetaReader.metaPath("s3a://b/backup/b1//") shouldBe
+      "s3a://b/backup/b1/meta/full_meta.json"
 
     // Native reader gets bucket-relative keys; Hadoop reads get the qualified URI.
     BackupMetaReader.nativeInsertLogPath(
@@ -266,6 +272,15 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       103L,
       1L
     ) shouldBe "s3a://bucket/backup/b1/binlogs/insert_log/444/555/999/777/103/1"
+    // Bucket-root backup: native key has NO leading slash (a different S3 key).
+    BackupMetaReader.nativeInsertLogPath("s3a://bucket", seg, 103L, 1L) shouldBe
+      "binlogs/insert_log/444/555/999/777/103/1"
+    BackupMetaReader.qualifiedInsertLogPath(
+      "s3a://bucket",
+      seg,
+      103L,
+      1L
+    ) shouldBe "s3a://bucket/binlogs/insert_log/444/555/999/777/103/1"
 
     // Delta logs only feed the Hadoop delete-plan reader, so only qualified
     // paths exist. groupID level present for part != -1, omitted for part == -1.

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -696,6 +696,92 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test(
+    "buildV2Segment rejects column groups with inconsistent row totals"
+  ) {
+    val dir = Files.createTempDirectory("milvus-backup-inconsistent-")
+    try {
+      val base =
+        Paths.get(
+          dir.toString,
+          "binlogs",
+          "insert_log",
+          "444",
+          "555",
+          "999",
+          "777"
+        )
+      writeParquetAt(
+        Paths.get(base.toString, "103", "1"),
+        groupASchema,
+        List(
+          f =>
+            f.newGroup()
+              .append("pk", 1L)
+              .append("row_id", 10L)
+              .append("ts", 100L),
+          f =>
+            f.newGroup()
+              .append("pk", 2L)
+              .append("row_id", 11L)
+              .append("ts", 101L)
+        )
+      )
+      writeParquetAt(
+        Paths.get(base.toString, "101", "1"),
+        groupCSchema,
+        List(
+          f => f.newGroup().append("name", "a"),
+          f => f.newGroup().append("name", "b"),
+          f => f.newGroup().append("name", "c")
+        )
+      )
+      val seg = BackupMetaReader.SegmentBackup(
+        segmentId = 777L,
+        collectionId = 444L,
+        partitionId = 555L,
+        groupId = 999L,
+        numOfRows = 5L,
+        storageVersion = 2L,
+        binlogs = Seq(
+          BackupMetaReader.FieldBinlog(
+            fieldId = 103L,
+            binlogs = Seq(
+              BackupMetaReader.Binlog(
+                logId = 1L,
+                logPath = "files/insert_log/444/555/777/103/1",
+                logSize = 10L
+              )
+            )
+          ),
+          BackupMetaReader.FieldBinlog(
+            fieldId = 101L,
+            binlogs = Seq(
+              BackupMetaReader.Binlog(
+                logId = 1L,
+                logPath = "files/insert_log/444/555/777/101/1",
+                logSize = 10L
+              )
+            )
+          )
+        )
+      )
+      val err = BackupMetaReader
+        .buildV2Segment(
+          seg,
+          new Configuration(),
+          dir.toString,
+          applyDeletes = true
+        )
+        .left
+        .toOption
+        .get
+      err.getMessage should include("inconsistent row totals")
+    } finally {
+      deleteRecursively(dir)
+    }
+  }
+
   test("L1 segment delta logs reconstruct with the groupID level") {
     val dir = Files.createTempDirectory("milvus-backup-l1-")
     try {

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -345,7 +345,9 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     ).dedupColumnGroupsBySlot.columnGroups shouldBe Seq(unknown)
   }
 
-  test("l0DeleteSegments returns L0-only segments with qualified delta paths") {
+  test(
+    "deleteOnlySegments returns delete-only segments with qualified delta paths"
+  ) {
     val meta = BackupMetaReader
       .parse(
         backupFixture(
@@ -356,7 +358,7 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
         )
       )
       .getOrElse(fail("expected Right"))
-    val l0 = BackupMetaReader.l0DeleteSegments(
+    val l0 = BackupMetaReader.deleteOnlySegments(
       meta,
       444L,
       "s3a://bucket/backup/b1"
@@ -365,6 +367,53 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     l0.head.columnGroups shouldBe Seq.empty
     l0.head.deltaLogs.map(_.logPath) shouldBe Seq(
       "s3a://bucket/backup/b1/binlogs/delta_log/444/-1/888/1"
+    )
+
+    // A non-L0 StorageV2 segment with no binlogs, zero rows and non-empty
+    // deltalogs is also delete-only — it must match the planner's inherited
+    // predicate so its partition marker has a matching plan entry.
+    val nonL0Empty = BackupMetaReader.SegmentBackup(
+      segmentId = 999L,
+      collectionId = 444L,
+      partitionId = 555L,
+      groupId = 999L,
+      numOfRows = 0L,
+      storageVersion = 2L,
+      binlogs = Seq.empty,
+      deltalogs = Seq(
+        BackupMetaReader.FieldBinlog(
+          fieldId = 0L,
+          binlogs = Seq(
+            BackupMetaReader.Binlog(
+              logId = 7L,
+              logPath = "files/delta_log/444/555/999/7",
+              logSize = 10L
+            )
+          )
+        )
+      )
+    )
+    val meta2 = BackupMetaReader.BackupInfo(
+      name = "b2",
+      collectionBackups = Seq(
+        BackupMetaReader.CollectionBackup(
+          collectionId = 444L,
+          collectionName = "demo",
+          partitionBackups = Seq(
+            BackupMetaReader.PartitionBackup(
+              partitionId = 555L,
+              segmentBackups = Seq(nonL0Empty)
+            )
+          )
+        )
+      )
+    )
+    val segs =
+      BackupMetaReader.deleteOnlySegments(meta2, 444L, "s3a://bucket/backup/b2")
+    segs.map(_.segmentId) shouldBe Seq(999L)
+    segs.head.columnGroups shouldBe Seq.empty
+    segs.head.deltaLogs.map(_.logPath) shouldBe Seq(
+      "s3a://bucket/backup/b2/binlogs/delta_log/444/555/999/999/7"
     )
   }
 

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -342,6 +342,29 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     ).dedupColumnGroupsBySlot.columnGroups shouldBe Seq(unknown)
   }
 
+  test("l0DeleteSegments returns L0-only segments with qualified delta paths") {
+    val meta = BackupMetaReader
+      .parse(
+        backupFixture(
+          groupAPath = SourceKeys._1,
+          groupBPath = SourceKeys._2,
+          groupCPath = SourceKeys._3,
+          deltaPath = SourceKeys._4
+        )
+      )
+      .getOrElse(fail("expected Right"))
+    val l0 = BackupMetaReader.l0DeleteSegments(
+      meta,
+      444L,
+      "s3a://bucket/backup/b1"
+    )
+    l0.map(_.segmentId) shouldBe Seq(888L)
+    l0.head.columnGroups shouldBe Seq.empty
+    l0.head.deltaLogs.map(_.logPath) shouldBe Seq(
+      "s3a://bucket/backup/b1/binlogs/delta_log/444/-1/888/1"
+    )
+  }
+
   test("readMeta parses a binlog-format backup full_meta.json") {
     val dir = Files.createTempDirectory("milvus-backup-meta-")
     try {

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -105,14 +105,12 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
             .append("row_id", 10L)
             .append("ts", 100L),
         f =>
-          f.newGroup().append("pk", 2L).append("row_id", 11L).append("ts", 101L)
-      )
-    )
-    writeParquetAt(
-      Paths.get(seg.toString, "103", "2"),
-      groupASchema,
-      List(f =>
-        f.newGroup().append("pk", 3L).append("row_id", 12L).append("ts", 102L)
+          f.newGroup()
+            .append("pk", 2L)
+            .append("row_id", 11L)
+            .append("ts", 101L),
+        f =>
+          f.newGroup().append("pk", 3L).append("row_id", 12L).append("ts", 102L)
       )
     )
     writeParquetAt(
@@ -132,8 +130,14 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       groupAPath: String,
       groupBPath: String,
       groupCPath: String,
-      deltaPath: String
+      deltaPath: String,
+      multiFile: Boolean = true
   ): String = {
+    val groupBBinlog =
+      if (multiFile)
+        """,
+          |                  {"log_path": "$groupBPath", "log_size": 100, "log_id": 2}""".stripMargin
+      else ""
     s"""{
        |  "id": "task-1",
        |  "name": "b1",
@@ -169,13 +173,12 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
        |              "partition_id": 555,
        |              "num_of_rows": 3,
        |              "binlogs": [
-       |                {"fieldID": 103, "binlogs": [
-       |                  {"log_path": "$groupAPath", "log_size": 100, "log_id": 1},
-       |                  {"log_path": "$groupBPath", "log_size": 100, "log_id": 2}
-       |                ]},
-       |                {"fieldID": 101, "binlogs": [
-       |                  {"log_path": "$groupCPath", "log_size": 100, "log_id": 1}
-       |                ]}
+        |                {"fieldID": 103, "binlogs": [
+        |                  {"log_path": "$groupAPath", "log_size": 100, "log_id": 1}$groupBBinlog
+        |                ]},
+        |                {"fieldID": 101, "binlogs": [
+        |                  {"log_path": "$groupCPath", "log_size": 100, "log_id": 1}
+        |                ]}
        |              ],
        |              "deltalogs": [],
        |              "size": 300,
@@ -454,7 +457,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
             groupAPath = SourceKeys._1,
             groupBPath = SourceKeys._2,
             groupCPath = SourceKeys._3,
-            deltaPath = SourceKeys._4
+            deltaPath = SourceKeys._4,
+            multiFile = false
           )
         )
         .getOrElse(fail("expected Right"))
@@ -475,10 +479,9 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       val slot103 = seg.columnGroups.find(_.slotFieldId == 103L).get
       slot103.fieldIds shouldBe Seq(100L, 0L, 1L)
       slot103.filePaths shouldBe Seq(
-        s"$backupDir/binlogs/insert_log/444/555/777/777/103/1",
-        s"$backupDir/binlogs/insert_log/444/555/777/777/103/2"
+        s"$backupDir/binlogs/insert_log/444/555/777/777/103/1"
       )
-      slot103.fileRowCounts shouldBe Seq(2L, 1L)
+      slot103.fileRowCounts shouldBe Seq(3L)
 
       val slot101 = seg.columnGroups.find(_.slotFieldId == 101L).get
       slot101.fieldIds shouldBe Seq(101L)
@@ -508,7 +511,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
             groupAPath = SourceKeys._1,
             groupBPath = SourceKeys._2,
             groupCPath = SourceKeys._3,
-            deltaPath = SourceKeys._4
+            deltaPath = SourceKeys._4,
+            multiFile = false
           )
         )
         .getOrElse(fail("expected Right"))
@@ -553,7 +557,8 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
             groupAPath = SourceKeys._1,
             groupBPath = SourceKeys._2,
             groupCPath = SourceKeys._3,
-            deltaPath = SourceKeys._4
+            deltaPath = SourceKeys._4,
+            multiFile = false
           )
         )
         .getOrElse(fail("expected Right"))
@@ -570,6 +575,31 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     } finally {
       deleteRecursively(dir)
     }
+  }
+
+  test(
+    "toV2Segments rejects multi-file column groups (milvus-storage bug)"
+  ) {
+    val meta = BackupMetaReader
+      .parse(
+        backupFixture(
+          groupAPath = SourceKeys._1,
+          groupBPath = SourceKeys._2,
+          groupCPath = SourceKeys._3,
+          deltaPath = SourceKeys._4
+        )
+      )
+      .getOrElse(fail("expected Right"))
+    val result = BackupMetaReader.toV2Segments(
+      meta,
+      new Configuration(),
+      "/tmp/backup",
+      collectionId = 444L
+    )
+    result.isLeft shouldBe true
+    result.left.toOption.get.getMessage should include(
+      "multi-file column groups"
+    )
   }
 
   test(

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -247,6 +247,9 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       "s3a://bucket/backup/b1"
     ) shouldBe "backup/b1"
     BackupMetaReader.backupKeyBase("/data/backup/b1") shouldBe "/data/backup/b1"
+    // Empty-authority URIs keep the leading slash, matching the bare form.
+    BackupMetaReader.backupKeyBase("file:///data/backup/b1") shouldBe
+      "/data/backup/b1"
 
     // Native reader gets bucket-relative keys; Hadoop reads get the qualified URI.
     BackupMetaReader.nativeInsertLogPath(
@@ -275,6 +278,51 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
       l0,
       9L
     ) shouldBe "s3a://bucket/backup/b1/binlogs/delta_log/444/-1/777/9"
+  }
+
+  test(
+    "V2SegmentInfo.dedupColumnGroupsBySlot keeps the newest slot per field"
+  ) {
+    val oldGroup = V2ColumnGroup(
+      fieldIds = Seq(100L, 0L, 1L),
+      filePaths = Seq("p1"),
+      fileRowCounts = Seq(2L),
+      slotFieldId = 3L
+    )
+    val newGroup = V2ColumnGroup(
+      fieldIds = Seq(100L),
+      filePaths = Seq("p2"),
+      fileRowCounts = Seq(1L),
+      slotFieldId = 100L
+    )
+    val seg = V2SegmentInfo(
+      segmentId = 1L,
+      partitionId = 1L,
+      numOfRows = 3L,
+      storageVersion = 2L,
+      columnGroups = Seq(oldGroup, newGroup)
+    )
+    val deduped = seg.dedupColumnGroupsBySlot
+    // The old group keeps its unique fields (0, 1); the shared field 100 is
+    // stripped from it and read from the newer slot (100).
+    deduped.columnGroups.map(_.slotFieldId) shouldBe Seq(3L, 100L)
+    deduped.columnGroups.head.fieldIds shouldBe Seq(0L, 1L)
+    deduped.columnGroups.last.fieldIds shouldBe Seq(100L)
+
+    // Unknown slot (-1) disables dedup entirely.
+    val unknown = V2ColumnGroup(
+      fieldIds = Seq(100L),
+      filePaths = Seq("p"),
+      fileRowCounts = Seq(1L),
+      slotFieldId = -1L
+    )
+    V2SegmentInfo(
+      segmentId = 2L,
+      partitionId = 1L,
+      numOfRows = 1L,
+      storageVersion = 2L,
+      columnGroups = Seq(unknown)
+    ).dedupColumnGroupsBySlot.columnGroups shouldBe Seq(unknown)
   }
 
   test("readMeta parses a binlog-format backup full_meta.json") {

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -214,7 +214,7 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
     }
   }
 
-  test("readRowCount sums row groups from the footer") {
+  test("readFieldIdsAndRowCount sums row groups across the footer") {
     val tmp = Files.createTempFile("milvus-rowcount-test-", ".parquet")
     Files.delete(tmp)
     val schema: MessageType = Types
@@ -233,7 +233,7 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
     // recordCount >= DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK (100), so with 3
     // rows a tiny rowGroupSize would never flush and the file would hold one
     // block. Write enough rows for the check to run and flush multiple groups,
-    // so readRowCount must genuinely sum across them.
+    // so the production footerInfo must genuinely sum across them.
     val totalRows = 150
     val writer = ExampleParquetWriter
       .builder(new HPath(tmp.toUri))
@@ -254,13 +254,16 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
     }
 
     try {
-      MilvusParquetFooterReader.readRowCount(
-        tmp.toUri.toString,
-        new Configuration()
-      ) shouldBe Right(totalRows.toLong)
+      // The production path (used by the backup planner) returns field IDs and
+      // the summed row count in a single open.
+      val info = MilvusParquetFooterReader
+        .readFieldIdsAndRowCount(tmp.toUri.toString, new Configuration())
+        .getOrElse(fail("expected Right"))
+      info.fieldIds shouldBe Seq(100L, 0L)
+      info.rowCount shouldBe totalRows.toLong
 
       // Prove the file actually has multiple row groups (a first-block-only
-      // readRowCount would not reach totalRows).
+      // sum would not reach totalRows).
       val parquet = org.apache.parquet.hadoop.ParquetFileReader.open(
         org.apache.parquet.hadoop.util.HadoopInputFile
           .fromPath(new HPath(tmp.toUri), new Configuration())

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -213,6 +213,46 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
       Files.deleteIfExists(tmp)
     }
   }
+
+  test("readRowCount sums row groups from the footer") {
+    val tmp = Files.createTempFile("milvus-rowcount-test-", ".parquet")
+    Files.delete(tmp)
+    val schema: MessageType = Types
+      .buildMessage()
+      .required(PrimitiveTypeName.INT64)
+      .id(100)
+      .named("pk")
+      .required(PrimitiveTypeName.INT64)
+      .id(0)
+      .named("row_id")
+      .named("milvus_group")
+
+    val conf = new Configuration()
+    GroupWriteSupport.setSchema(schema, conf)
+    val writer = ExampleParquetWriter
+      .builder(new HPath(tmp.toUri))
+      .withType(schema)
+      .withConf(conf)
+      .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      .build()
+    try {
+      val factory = new SimpleGroupFactory(schema)
+      writer.write(factory.newGroup().append("pk", 1L).append("row_id", 10L))
+      writer.write(factory.newGroup().append("pk", 2L).append("row_id", 11L))
+      writer.write(factory.newGroup().append("pk", 3L).append("row_id", 12L))
+    } finally {
+      writer.close()
+    }
+
+    try {
+      MilvusParquetFooterReader.readRowCount(
+        tmp.toUri.toString,
+        new Configuration()
+      ) shouldBe Right(3L)
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
+  }
 }
 
 class FatalFooterFileSystem extends FileSystem {

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -229,21 +229,26 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
 
     val conf = new Configuration()
     GroupWriteSupport.setSchema(schema, conf)
+    // parquet-mr only evaluates the row-group size once
+    // recordCount >= DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK (100), so with 3
+    // rows a tiny rowGroupSize would never flush and the file would hold one
+    // block. Write enough rows for the check to run and flush multiple groups,
+    // so readRowCount must genuinely sum across them.
+    val totalRows = 150
     val writer = ExampleParquetWriter
       .builder(new HPath(tmp.toUri))
       .withType(schema)
       .withConf(conf)
       .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
-      // Tiny row-group threshold forces one row group per row, so the test
-      // actually sums across multiple groups (returning only the first block's
-      // count would not yield 3).
       .withRowGroupSize(1)
       .build()
     try {
       val factory = new SimpleGroupFactory(schema)
-      writer.write(factory.newGroup().append("pk", 1L).append("row_id", 10L))
-      writer.write(factory.newGroup().append("pk", 2L).append("row_id", 11L))
-      writer.write(factory.newGroup().append("pk", 3L).append("row_id", 12L))
+      (1 to totalRows).foreach { i =>
+        writer.write(
+          factory.newGroup().append("pk", i.toLong).append("row_id", i.toLong)
+        )
+      }
     } finally {
       writer.close()
     }
@@ -252,7 +257,19 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
       MilvusParquetFooterReader.readRowCount(
         tmp.toUri.toString,
         new Configuration()
-      ) shouldBe Right(3L)
+      ) shouldBe Right(totalRows.toLong)
+
+      // Prove the file actually has multiple row groups (a first-block-only
+      // readRowCount would not reach totalRows).
+      val parquet = org.apache.parquet.hadoop.ParquetFileReader.open(
+        org.apache.parquet.hadoop.util.HadoopInputFile
+          .fromPath(new HPath(tmp.toUri), new Configuration())
+      )
+      try {
+        parquet.getFooter.getBlocks.size() should be >= 2
+      } finally {
+        parquet.close()
+      }
     } finally {
       Files.deleteIfExists(tmp)
     }

--- a/src/test/scala/read/MilvusParquetFooterReaderTest.scala
+++ b/src/test/scala/read/MilvusParquetFooterReaderTest.scala
@@ -234,6 +234,10 @@ class MilvusParquetFooterReaderTest extends AnyFunSuite with Matchers {
       .withType(schema)
       .withConf(conf)
       .withCompressionCodec(CompressionCodecName.UNCOMPRESSED)
+      // Tiny row-group threshold forces one row group per row, so the test
+      // actually sums across multiple groups (returning only the first block's
+      // count would not yield 3).
+      .withRowGroupSize(1)
       .build()
     try {
       val factory = new SimpleGroupFactory(schema)

--- a/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
+++ b/src/test/scala/read/MilvusSegmentManifestReaderTest.scala
@@ -169,12 +169,14 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
         V2ColumnGroup(
           fieldIds = Seq(100L, 0L, 1L),
           filePaths = Seq("files/insert_log/.../0/100"),
-          fileRowCounts = Seq(20480L)
+          fileRowCounts = Seq(20480L),
+          slotFieldId = 3L
         ),
         V2ColumnGroup(
           fieldIds = Seq(103L),
           filePaths = Seq("p/103"),
-          fileRowCounts = Seq(20480L)
+          fileRowCounts = Seq(20480L),
+          slotFieldId = 103L
         )
       ),
       deltaLogs = Seq(
@@ -198,6 +200,9 @@ class MilvusSegmentManifestReaderTest extends AnyFunSuite with Matchers {
     got.segmentId shouldBe seg.segmentId
     got.columnGroups(0).fieldIds shouldBe Seq(100L, 0L, 1L)
     got.columnGroups(0).fileRowCounts shouldBe Seq(20480L)
+    // slotFieldId round-trips so slot-based dedup is not a silent no-op for
+    // the milvus.snapshot.v2.segments option path.
+    got.columnGroups.map(_.slotFieldId) shouldBe Seq(3L, 103L)
     got.deltaLogs shouldBe seg.deltaLogs
     // Exercise the exact pattern that failed at runtime — mapping over the
     // rehydrated Seq[Long]. Must not throw ClassCastException.

--- a/src/test/scala/read/MilvusSnapshotReaderTest.scala
+++ b/src/test/scala/read/MilvusSnapshotReaderTest.scala
@@ -762,6 +762,18 @@ class MilvusSnapshotReaderTest extends AnyFunSuite with Matchers {
     roundTripped.head shouldBe segments.head
   }
 
+  test(
+    "deserializeV2Segments defaults legacy column-group JSON to unknown slot"
+  ) {
+    // JSON that predates slot_field_id: the group must decode to -1 so
+    // slot-based dedup stays off rather than reading stale data.
+    val json =
+      """[{"segment_id":1,"partition_id":1,"num_of_rows":1,"storage_version":2,""" +
+        """"column_groups":[{"field_ids":[100],"file_paths":["p"],"file_row_counts":[1]}]}]"""
+    val segs = MilvusSnapshotReader.deserializeV2Segments(json).toOption.get
+    segs.head.columnGroups.head.slotFieldId shouldBe -1L
+  }
+
   test("Parse data_type as string format (e.g., 'Int64' instead of 5)") {
     val jsonWithStringDataType = """
     {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -214,30 +214,55 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(MilvusScan.snapshotBucket("file:///data/backup/b1") == None)
   }
 
-  test("resolveBackupCollection matches by collection name, never .head") {
-    def coll(name: String, id: Long) =
+  test("backupMaxJsonBytes honors milvus.snapshot.max.json.bytes") {
+    val withLimit = new ju.HashMap[String, String]()
+    withLimit.put(MilvusOption.SnapshotMaxJsonBytes, "1048576")
+    assert(
+      MilvusScan.backupMaxJsonBytes(new CaseInsensitiveStringMap(withLimit)) ==
+        1048576L
+    )
+    assert(
+      MilvusScan.backupMaxJsonBytes(
+        new CaseInsensitiveStringMap(new ju.HashMap[String, String]())
+      ) ==
+        MilvusSnapshotReader.MaxSnapshotJsonBytes
+    )
+  }
+
+  test("resolveBackupCollection matches by name and database, never .head") {
+    def coll(name: String, id: Long, db: String = "") =
       BackupMetaReader.CollectionBackup(
         collectionName = name,
-        collectionId = id
+        collectionId = id,
+        dbName = db
       )
     val multi = BackupMetaReader.BackupInfo(
       name = "b1",
-      collectionBackups = Seq(coll("c1", 1L), coll("c2", 2L))
+      collectionBackups =
+        Seq(coll("orders", 1L, "db1"), coll("orders", 2L, "db2"))
     )
     assert(
-      MilvusScan.resolveBackupCollection(multi, "c2").map(_.collectionId) ==
+      MilvusScan
+        .resolveBackupCollection(multi, "db1", "orders")
+        .map(_.collectionId) ==
+        Right(1L)
+    )
+    assert(
+      MilvusScan
+        .resolveBackupCollection(multi, "db2", "orders")
+        .map(_.collectionId) ==
         Right(2L)
     )
-    assert(MilvusScan.resolveBackupCollection(multi, "nope").isLeft)
-    // No name given + multiple collections -> error, not .head.
-    assert(MilvusScan.resolveBackupCollection(multi, "").isLeft)
+    assert(MilvusScan.resolveBackupCollection(multi, "db1", "nope").isLeft)
+    assert(MilvusScan.resolveBackupCollection(multi, "", "orders").isLeft)
+    assert(MilvusScan.resolveBackupCollection(multi, "", "").isLeft)
 
     val single = BackupMetaReader.BackupInfo(
       name = "s",
       collectionBackups = Seq(coll("only", 3L))
     )
     assert(
-      MilvusScan.resolveBackupCollection(single, "").map(_.collectionId) ==
+      MilvusScan.resolveBackupCollection(single, "", "").map(_.collectionId) ==
         Right(3L)
     )
   }

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -270,6 +270,29 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test(
+    "backup createReaderFactory falls back to re-reading meta when init did not parse it"
+  ) {
+    // preParsedBackupMeta = None (table init failed but the planner would have
+    // re-read the meta and stamped markers). The factory must not silently hand
+    // an empty plan — it re-reads the meta, and a missing dir degrades to empty
+    // without throwing.
+    val options = new ju.HashMap[String, String]()
+    options.put(MilvusOption.BackupDir, "/tmp/nonexistent-backup-xyz")
+    options.put(MilvusOption.MilvusCollectionName, "demo")
+    val scan = new MilvusScan(
+      StructType(Seq(StructField("RowID", LongType, nullable = false))),
+      new CaseInsensitiveStringMap(options),
+      preParsedBackupMeta = None
+    )
+    val factory = scan.createReaderFactory()
+    assert(
+      factory.isInstanceOf[
+        com.zilliz.spark.connector.read.MilvusPartitionReaderFactory
+      ]
+    )
+  }
+
   test("resolveBackupCollection matches by name and database, never .head") {
     def coll(name: String, id: Long, db: String = "") =
       BackupMetaReader.CollectionBackup(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -204,11 +204,13 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
-  test("snapshotBucket rejects unsupported schemes") {
-    val err = intercept[IllegalArgumentException] {
-      MilvusScan.snapshotBucket("gs://a-bucket/files/snapshot.json")
-    }
-    assert(err.getMessage.contains("Unsupported snapshot s3_location scheme"))
+  test("snapshotBucket returns None for unsupported (non-S3) schemes") {
+    // Non-S3 locations carry no bucket to configure; explicit scheme
+    // validation lives in resolveClientSnapshotLocation.
+    assert(
+      MilvusScan.snapshotBucket("gs://a-bucket/files/snapshot.json") == None
+    )
+    assert(MilvusScan.snapshotBucket("file:///data/backup/b1") == None)
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -37,6 +37,7 @@ import org.scalatest.BeforeAndAfterEach
 import com.zilliz.spark.connector.{MilvusCollectionInfo, MilvusOption}
 import com.zilliz.spark.connector.loon.Properties
 import com.zilliz.spark.connector.read.{
+  BackupMetaReader,
   Collection,
   CollectionSchema,
   MilvusDeletePlan,
@@ -211,6 +212,34 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       MilvusScan.snapshotBucket("gs://a-bucket/files/snapshot.json") == None
     )
     assert(MilvusScan.snapshotBucket("file:///data/backup/b1") == None)
+  }
+
+  test("resolveBackupCollection matches by collection name, never .head") {
+    def coll(name: String, id: Long) =
+      BackupMetaReader.CollectionBackup(
+        collectionName = name,
+        collectionId = id
+      )
+    val multi = BackupMetaReader.BackupInfo(
+      name = "b1",
+      collectionBackups = Seq(coll("c1", 1L), coll("c2", 2L))
+    )
+    assert(
+      MilvusScan.resolveBackupCollection(multi, "c2").map(_.collectionId) ==
+        Right(2L)
+    )
+    assert(MilvusScan.resolveBackupCollection(multi, "nope").isLeft)
+    // No name given + multiple collections -> error, not .head.
+    assert(MilvusScan.resolveBackupCollection(multi, "").isLeft)
+
+    val single = BackupMetaReader.BackupInfo(
+      name = "s",
+      collectionBackups = Seq(coll("only", 3L))
+    )
+    assert(
+      MilvusScan.resolveBackupCollection(single, "").map(_.collectionId) ==
+        Right(3L)
+    )
   }
 
   test(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -1492,6 +1492,52 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(second.deletePlan.containsLongPk(7L, 50L))
     assert(!second.deletePlan.containsLongPk(8L, 100L))
   }
+
+  test("snapshot planner dedups V2 column groups by slot before planning") {
+    val scan = scanWithOptions(new ju.HashMap[String, String]())
+    // A segment that went through add-field + backfill: the old multi-field
+    // group (slot 3) still reports field 100 from its own schema, and the newer
+    // single-field group (slot 100) reports it too. buildSnapshotPartitions
+    // must strip the overlapping field from the older slot.
+    val partitions = scan.buildSnapshotPartitions(
+      manifestList = Seq.empty,
+      defaultPartitionId = "20",
+      schemaBytes = java.util.Base64.getDecoder.decode(emptySchemaBytes),
+      v2Segments = Seq(
+        V2SegmentInfo(
+          segmentId = 30L,
+          partitionId = 20L,
+          numOfRows = 2L,
+          storageVersion = 2L,
+          columnGroups = Seq(
+            V2ColumnGroup(
+              fieldIds = Seq(100L, 0L, 1L),
+              filePaths = Seq("files/insert_log/10/20/30/3/1.parquet"),
+              fileRowCounts = Seq(2L),
+              slotFieldId = 3L
+            ),
+            V2ColumnGroup(
+              fieldIds = Seq(100L),
+              filePaths = Seq("files/insert_log/10/20/30/100/1.parquet"),
+              fileRowCounts = Seq(2L),
+              slotFieldId = 100L
+            )
+          )
+        )
+      ),
+      v2DeletePlans = Map.empty,
+      inheritedDeletePlansByPartition = Map.empty,
+      inlineInheritedDeletePlans = true
+    )
+
+    val partition = partitions.head.asInstanceOf[MilvusPackedV2InputPartition]
+    val groups = partition.columnGroups
+    assert(groups.size == 2)
+    // Old slot keeps only its unique fields; the shared field 100 is read from
+    // the newest slot.
+    assert(groups.find(_.slotFieldId == 3L).get.fieldIds == Seq(0L, 1L))
+    assert(groups.find(_.slotFieldId == 100L).get.fieldIds == Seq(100L))
+  }
 }
 
 class CloseTrackingFileSystem extends FileSystem {

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -290,6 +290,34 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
         .map(_.collectionId) == Right(10L)
     )
 
+    // Explicit "default" selects the default-db candidate even when another
+    // database has a same-named collection (request side is not flattened).
+    val mixed = BackupMetaReader.BackupInfo(
+      name = "mixed",
+      collectionBackups = Seq(
+        BackupMetaReader.CollectionBackup(
+          collectionName = "orders",
+          collectionId = 11L,
+          dbName = "" // default
+        ),
+        BackupMetaReader.CollectionBackup(
+          collectionName = "orders",
+          collectionId = 12L,
+          dbName = "db2"
+        )
+      )
+    )
+    assert(
+      MilvusScan
+        .resolveBackupCollection(mixed, "default", "orders")
+        .map(_.collectionId) == Right(11L)
+    )
+    assert(
+      MilvusScan
+        .resolveBackupCollection(mixed, "db2", "orders")
+        .map(_.collectionId) == Right(12L)
+    )
+
     val single = BackupMetaReader.BackupInfo(
       name = "s",
       collectionBackups = Seq(coll("only", 3L))

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -229,6 +229,47 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     )
   }
 
+  test("backup createReaderFactory is self-contained without prior planning") {
+    import com.fasterxml.jackson.databind.node.IntNode
+    val schema = BackupMetaReader.BackupCollectionSchema(
+      name = "demo",
+      fields = Seq(
+        BackupMetaReader.BackupFieldSchema(
+          fieldId = 100L,
+          name = "id",
+          isPrimaryKey = true,
+          rawDataType = Some(IntNode.valueOf(5))
+        )
+      )
+    )
+    val meta = BackupMetaReader.BackupInfo(
+      name = "b1",
+      collectionBackups = Seq(
+        BackupMetaReader.CollectionBackup(
+          collectionName = "demo",
+          collectionId = 444L,
+          schema = Some(schema)
+        )
+      )
+    )
+    val options = new ju.HashMap[String, String]()
+    options.put(MilvusOption.BackupDir, "s3a://bucket/backup/b1")
+    options.put(MilvusOption.MilvusCollectionName, "demo")
+    val scan = new MilvusScan(
+      StructType(Seq(StructField("RowID", LongType, nullable = false))),
+      new CaseInsensitiveStringMap(options),
+      preParsedBackupMeta = Some(meta)
+    )
+    // No prior planInputPartitions call: the factory must compute its delete
+    // context on its own (no planning side effect).
+    val factory = scan.createReaderFactory()
+    assert(
+      factory.isInstanceOf[
+        com.zilliz.spark.connector.read.MilvusPartitionReaderFactory
+      ]
+    )
+  }
+
   test("resolveBackupCollection matches by name and database, never .head") {
     def coll(name: String, id: Long, db: String = "") =
       BackupMetaReader.CollectionBackup(

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -257,6 +257,39 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
     assert(MilvusScan.resolveBackupCollection(multi, "", "orders").isLeft)
     assert(MilvusScan.resolveBackupCollection(multi, "", "").isLeft)
 
+    // "default" database is equivalent to an empty db_name (older backups omit
+    // it), in both directions.
+    val defaultDb = BackupMetaReader.BackupInfo(
+      name = "d",
+      collectionBackups = Seq(
+        BackupMetaReader.CollectionBackup(
+          collectionName = "orders",
+          collectionId = 9L,
+          dbName = "" // omitted by milvus-backup
+        )
+      )
+    )
+    assert(
+      MilvusScan
+        .resolveBackupCollection(defaultDb, "default", "orders")
+        .map(_.collectionId) == Right(9L)
+    )
+    val namedDefault = BackupMetaReader.BackupInfo(
+      name = "d2",
+      collectionBackups = Seq(
+        BackupMetaReader.CollectionBackup(
+          collectionName = "orders",
+          collectionId = 10L,
+          dbName = "default"
+        )
+      )
+    )
+    assert(
+      MilvusScan
+        .resolveBackupCollection(namedDefault, "", "orders")
+        .map(_.collectionId) == Right(10L)
+    )
+
     val single = BackupMetaReader.BackupInfo(
       name = "s",
       collectionBackups = Seq(coll("only", 3L))

--- a/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
+++ b/src/test/scala/sources/MilvusScanClientSnapshotTest.scala
@@ -271,12 +271,12 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
   }
 
   test(
-    "backup createReaderFactory falls back to re-reading meta when init did not parse it"
+    "backup createReaderFactory fails loudly when the meta re-read fails"
   ) {
-    // preParsedBackupMeta = None (table init failed but the planner would have
-    // re-read the meta and stamped markers). The factory must not silently hand
-    // an empty plan — it re-reads the meta, and a missing dir degrades to empty
-    // without throwing.
+    // preParsedBackupMeta = None (table init failed) and the factory's fallback
+    // re-read also fails. The planner would have stamped inherited-delete
+    // markers, so the factory must NOT hand an empty plan — it must fail loudly
+    // rather than silently returning deleted rows.
     val options = new ju.HashMap[String, String]()
     options.put(MilvusOption.BackupDir, "/tmp/nonexistent-backup-xyz")
     options.put(MilvusOption.MilvusCollectionName, "demo")
@@ -285,12 +285,10 @@ class MilvusScanClientSnapshotTest extends AnyFunSuite with BeforeAndAfterEach {
       new CaseInsensitiveStringMap(options),
       preParsedBackupMeta = None
     )
-    val factory = scan.createReaderFactory()
-    assert(
-      factory.isInstanceOf[
-        com.zilliz.spark.connector.read.MilvusPartitionReaderFactory
-      ]
-    )
+    val err = intercept[IllegalStateException] {
+      scan.createReaderFactory()
+    }
+    assert(err.getMessage.contains("re-read backup meta"))
   }
 
   test("resolveBackupCollection matches by name and database, never .head") {


### PR DESCRIPTION
Introduce an offline, client-free read path that consumes binlog-format milvus-backup exports via the new
`milvus.backup.dir` option. The export's full_meta.json is translated into the same V2SegmentInfo objects the snapshot path uses, so the StorageV2 packed reader, delete planning, extra columns and vector projection are reused unchanged.

milvus-backup only records log_size per binlog, so per-file row counts are recovered from each parquet footer, and real field IDs are recovered from each file's own schema. L0 delete-only segments feed partition-scoped inherited delete plans; L1 segments keep their own delta logs. Snapshot and backup modes are mutually exclusive.

New BackupMetaReader and MilvusParquetFooterReader.readRowCount back the planner; add unit tests for both.