### PR TITLE
fix: Support multi-file column groups in backup reads

### DIFF
--- a/docs/backup-datasource-design.md
+++ b/docs/backup-datasource-design.md
@@ -89,9 +89,10 @@ Branch precedence: snapshot mode > backup mode > client mode.
 Two gaps versus a Milvus snapshot are closed in `BackupMetaReader`:
 
 1. **Per-file row counts** (`fileRowCounts`) — always recovered from the parquet
-   footers (the meta never carries `entries_num`); each column group is a single
-   file read once via `readFieldIdsAndRowCount` (multi-file column groups are
-   rejected, see §7).
+   footers (the meta never carries `entries_num`); the **head file** of each
+   column group is read once via `readFieldIdsAndRowCount` for both field IDs
+   and its row count, and any remaining files' row counts are read in parallel
+   via `readRowCount` (multi-file column groups are supported, see §7).
 2. **Slot → real field ID mapping** — the AVRO segment-info is not copied by
    the backup, so real field IDs are recovered from the **head file** of each
    column group via `readFieldIdsAndRowCount` (all files in a group share the
@@ -265,18 +266,15 @@ Behavior:
   Seq.empty` and are skipped during partition planning. A StorageV2 data
   segment with rows but no binlogs fails hard rather than silently dropping
   rows.
-- **Known external bug — multi-file column groups rejected.** The connector
-  feeds per-file row counts to `MilvusStorageColumnGroups.createFromGroups`,
-  but milvus-storage's `BuildLoonColumnGroups` (`v2_column_groups_builder.cpp`)
-  writes them as group-cumulative `start_index`/`end_index` while
-  `ColumnGroupReaderImpl::open` intersects them against per-file row-group
-  offsets, so a column group spanning more than one binlog file would return
-  fewer rows (file `i > 0` truncated, zero when earlier files are at least as
-  large). Rather than silently read short, the backup planner **rejects any
-  column group with more than one file** (`buildV2SegmentWithFs`); the fix
-  belongs in milvus-storage (per-file, not cumulative, indices) plus a
-  submodule bump, after which the guard can be removed. The snapshot/backfill
-  path shares `createFromGroups` and is affected by the same bug.
+- **Multi-file column groups are supported.** A column group may span several
+  binlog files (multiple flushes). Per-file row counts are recovered from each
+  file's parquet footer (head file via `readFieldIdsAndRowCount`, the rest in
+  parallel via `readRowCount`) and fed to
+  `MilvusStorageColumnGroups.createFromGroups`. The earlier rejection guard was
+  removed after milvus-storage fixed `BuildLoonColumnGroups`
+  (`v2_column_groups_builder.cpp`, milvus-storage#657) to write per-file
+  `[0, rc_i)` indices instead of group-cumulative ranges; the submodule pin was
+  bumped to that fix (`cb22dfa`).
 - Dynamic collections: a default backup (no etcd access) does not record the
   `$meta` field, so reading it would return null `$meta` rows; such backups are
   rejected with a pointer to `--backup_index_extra` (requires milvus-backup
@@ -318,8 +316,11 @@ Behavior:
   double-slashes are handled: the native key never gains a leading slash and
   all trailing slashes are stripped (both would be different S3 keys).
 - Column-group footer reads run on a single bounded pool (`SegmentReadPool`,
-  segment-level parallelism). Multi-file column groups are rejected (see §7),
-  so there are no nested per-file tail reads and therefore no worker-blocks-on-its-own-pool deadlock risk.
+  segment-level parallelism). Per-file tail row-count reads for multi-file
+  column groups run on their own pool (`FooterReadPool`), kept separate so a
+  segment worker blocked on `Future.get()` for its tail reads can never starve
+  those reads of threads (a single shared pool would deadlock when every worker
+  waits on tasks queued behind it).
 - A dynamic collection whose `$meta` field is present is not duplicated by the
   computed schema.
 - Local paths (`/data/backup/...` or `file:///...`) are exercised by the

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -163,11 +163,11 @@ The Spark read schema must be provided via `.schema()` or is derived from the
 backup meta; without `.schema()` the read fails loudly if the meta cannot be
 read. Reading a dynamic collection (`enable_dynamic_field=true`) requires the
 backup meta to record the `$meta` field — captured only with milvus-backup
-etcd access (`--backup_index_extra`) and **v0.5.13+**. Two backup shapes abort
-the read at planning time: a column group spanning more than one binlog file
-(an unfixed milvus-storage bug — see the design doc) and a collection with
-struct-array fields (`struct_array_fields`). S3 credentials use the existing
-`fs.*` options (`fs.address`,
+etcd access (`--backup_index_extra`) and **v0.5.13+**. A column group spanning
+multiple binlog files is supported (milvus-storage#657 fixed the per-file row
+range encoding; see the design doc). One backup shape still aborts the read at
+planning time: a collection with struct-array fields (`struct_array_fields`).
+S3 credentials use the existing `fs.*` options (`fs.address`,
 `fs.access_key_id`, `fs.access_key_value`, ...); the bucket comes from the
 `milvus.backup.dir` URI.
 

--- a/src/main/scala/read/BackupMetaReader.scala
+++ b/src/main/scala/read/BackupMetaReader.scala
@@ -50,20 +50,22 @@ import io.milvus.grpc.schema.{
   * separate `DestKey` under the backup dir and records only the source key in
   * the meta — so object paths are always reconstructed from `backupDir` plus
   * the collection/partition/group/segment/field/log IDs, never taken from
-  * `log_path`. Three gaps vs. a Milvus snapshot are closed here:
-  *   1. milvus-backup persists only `log_size` per binlog, not `entries_num`.
-  *      The per-file row count is recovered by reading each (single) parquet
-  *      footer's row count
-  *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]). 2. The AVRO
-  *      segment-info (and hence the slot -> real field ID mapping) is not
-  *      copied by the backup; the real field IDs are recovered from the **head
-  *      file** of each column group via that file's own parquet schema
-  *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]) — matching
-  *      V2SegmentLoader, which assumes all files in a group share the schema.
-  *      3. L0 delete-only segments are created by Milvus without a
-  *      `StorageVersion` (0/omitted), so they are handled before any
-  *      storage-version filtering.
-  *
+   * `log_path`. Three gaps vs. a Milvus snapshot are closed here:
+   *   1. milvus-backup persists only `log_size` per binlog, not `entries_num`.
+   *      Per-file row counts are recovered by reading each binlog's parquet
+   *      footer ([MilvusParquetFooterReader.readRowCount], with the head file's
+   *      footer read once for both field IDs and its row count via
+   *      [MilvusParquetFooterReader.readFieldIdsAndRowCount]).
+   *   2. The AVRO
+   *      segment-info (and hence the slot -> real field ID mapping) is not
+   *      copied by the backup; the real field IDs are recovered from the **head
+   *      file** of each column group via that file's own parquet schema
+   *      ([MilvusParquetFooterReader.readFieldIdsAndRowCount]) — matching
+   *      V2SegmentLoader, which assumes all files in a group share the schema.
+   *   3. L0 delete-only segments are created by Milvus without a
+   *      `StorageVersion` (0/omitted), so they are handled before any
+   *      storage-version filtering.
+   *
   * Only StorageV2 (packed parquet, `storage_version == 2`) data segments are
   * supported; anything else fails hard rather than returning a partial dataset.
   */
@@ -409,11 +411,25 @@ object BackupMetaReader extends Logging {
     math.max(2, math.min(cores, 8))
   }
 
+  /** Bounded, daemon thread pool for per-file parquet footer reads on the
+    * driver (a HEAD + one tail range GET each). Footer reads are I/O-bound, so
+    * fanning them out avoids a serialized round trip per binlog before any
+    * Spark task is scheduled.
+    *
+    * The inner tail-file reads run on their own pool, separate from
+    * [[SegmentReadPool]], so a segment worker blocked on `Future.get()` for its
+    * tail reads can never starve those reads of threads (a single shared pool
+    * would deadlock when every worker waits on tasks that are queued behind
+    * it).
+    */
+  private val FooterReadPool: ExecutorService = Executors.newFixedThreadPool(
+    FooterReadThreadCount,
+    daemonThreadFactory("backup-footer-read")
+  )
+
   /** Bounded, daemon thread pool for segment-level conversion (each segment's
-    * footer reads are independent). Only column groups with a single binlog
-    * file are supported, so each segment does one footer read per column group
-    * and cross-segment parallelism is what keeps a large backup from stalling
-    * the driver.
+    * footer reads are independent). See [[FooterReadPool]] for the deadlock
+    * rationale for keeping this separate from the per-file pool.
     */
   private val SegmentReadPool: ExecutorService = Executors.newFixedThreadPool(
     FooterReadThreadCount,
@@ -596,22 +612,6 @@ object BackupMetaReader extends Logging {
             )
           }
           val sorted = fieldBinlog.binlogs.sortBy(_.logId)
-          // Guard: a column group spanning multiple binlog files is rejected.
-          // milvus-storage's BuildLoonColumnGroups encodes per-file row counts
-          // as group-cumulative ranges, which the packed reader intersects
-          // against each file's own zero-based row-group offsets, so file i > 0
-          // is silently truncated (zero rows when earlier files are at least as
-          // large). Refuse loudly rather than return a short DataFrame; the fix
-          // belongs in milvus-storage (per-file, not cumulative, indices).
-          if (sorted.size > 1) {
-            throw new IllegalStateException(
-              s"backup segment ${seg.segmentId} has a column group (slot " +
-                s"${fieldBinlog.fieldId}) spanning ${sorted.size} binlog files; " +
-                "multi-file column groups are unsupported until " +
-                "milvus-storage BuildLoonColumnGroups is fixed (per-file, not " +
-                "group-cumulative, row ranges)"
-            )
-          }
           // Hadoop-qualified paths for the footer reads; the native reader
           // gets bucket-relative keys in `filePaths`.
           val hadoopPaths = sorted.map(b =>
@@ -620,9 +620,9 @@ object BackupMetaReader extends Logging {
           val nativePaths = sorted.map(b =>
             nativeInsertLogPath(backupDir, seg, fieldBinlog.fieldId, b.logId)
           )
-          // The (single) file's footer is read once for both the real field IDs
+          // The head file's footer is read once for both the real field IDs
           // (which live in the parquet schema, not the backup meta) and its row
-          // count.
+          // count; the remaining files' row counts are read in parallel.
           val headInfo = MilvusParquetFooterReader.readFieldIdsAndRowCount(
             fs,
             hadoopPaths.head
@@ -636,10 +636,25 @@ object BackupMetaReader extends Logging {
                 err
               )
           }
+          val tailRowCounts = if (hadoopPaths.size > 1) {
+            readRowCountsInParallel(
+              fs,
+              hadoopPaths.tail,
+              seg.segmentId,
+              fieldBinlog.fieldId
+            ) match {
+              case Right(counts) => counts
+              case Left(err)     => throw err
+            }
+          } else Seq.empty
           V2ColumnGroup(
             fieldIds = headInfo.fieldIds,
             filePaths = nativePaths,
-            fileRowCounts = Seq(headInfo.rowCount),
+            // Per-file row counts (the packed reader derives per-file [0, rc_i)
+            // ranges); the BuildLoonColumnGroups fix (milvus-storage#657) made
+            // multi-file column groups safe, so a group may span several binlog
+            // files.
+            fileRowCounts = headInfo.rowCount +: tailRowCounts,
             slotFieldId = fieldBinlog.fieldId
           )
         }
@@ -763,6 +778,38 @@ object BackupMetaReader extends Logging {
       seg.binlogs.isEmpty || seg.binlogs.forall(_.binlogs.isEmpty)
     hasDeltas && (seg.isL0 ||
       (seg.storageVersion == 2L && binlogsEmpty && seg.numOfRows == 0L))
+  }
+
+  /** Read the row count of every path concurrently, preserving input order. All
+    * reads share the caller-supplied `FileSystem` (thread-safe for concurrent
+    * opens), so no per-file S3A client is constructed.
+    */
+  private def readRowCountsInParallel(
+      fs: FileSystem,
+      paths: Seq[String],
+      segmentId: Long,
+      slotFieldId: Long
+  ): Either[Throwable, Seq[Long]] = {
+    try {
+      val futures = paths.map { p =>
+        FooterReadPool.submit(new Callable[Long] {
+          override def call(): Long =
+            MilvusParquetFooterReader.readRowCount(fs, p) match {
+              case Right(n) => n
+              case Left(err) =>
+                throw new RuntimeException(
+                  s"failed to read row count from parquet $p " +
+                    s"(backup segment $segmentId, slot $slotFieldId): " +
+                    s"${err.getMessage}",
+                  err
+                )
+            }
+        })
+      }
+      Right(futures.map(_.get()))
+    } catch {
+      case NonFatal(e) => Left(e)
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/scala/read/MilvusPackedV2PartitionReader.scala
+++ b/src/main/scala/read/MilvusPackedV2PartitionReader.scala
@@ -282,6 +282,29 @@ class MilvusPackedV2PartitionReader(
       throw e
   }
 
+  /** Total rows the packed reader must deliver, recovered from the per-file row
+    * counts fed to `MilvusStorageColumnGroups.createFromGroups`. All column
+    * groups of a segment carry the same row total, so the head group's sum is
+    * the segment-wide expectation.
+    *
+    * This is the "not silently short" guard: a pre-fix milvus-storage library
+    * (before milvus-storage#657) drops every file after the first in a
+    * multi-file column group, and the native cross-group row check cannot catch
+    * it when all groups share the same file split. Without a delivered-row
+    * comparison the scan would end on the first null batch and return a short
+    * DataFrame with no error and no log.
+    */
+  private val expectedTotalRows: Long =
+    columnGroups.headOption.map(_.fileRowCounts.sum).getOrElse(0L)
+
+  /** Physical rows observed so far (regardless of delete filtering): the sum of
+    * every batch's row count as batches are exhausted. Delete filtering skips
+    * rows in [[next]] but never removes them from a batch, so this counter
+    * reaches the native reader's full delivered row count at EOF.
+    */
+  private var observedPhysicalRows: Long = 0L
+  private var rowCountVerified: Boolean = false
+
   private var currentBatch: VectorSchemaRoot = null
   private var currentRowIndex: Int = 0
   private var currentBatchStartRowOffset: Long = 0L
@@ -330,6 +353,7 @@ class MilvusPackedV2PartitionReader(
         val exhausted = currentBatch
         currentBatch = null
         currentBatchStartRowOffset += exhausted.getRowCount.toLong
+        observedPhysicalRows += exhausted.getRowCount.toLong
         try exhausted.close()
         catch {
           case e: Throwable => logWarning("close exhausted batch failed", e)
@@ -339,6 +363,7 @@ class MilvusPackedV2PartitionReader(
       }
 
       if (currentBatch == null) {
+        verifyRowCount()
         return false
       }
 
@@ -367,6 +392,32 @@ class MilvusPackedV2PartitionReader(
   }
 
   override def close(): Unit = releaseAll()
+
+  /** Guard the no-partial-read contract at EOF: the packed reader must have
+    * delivered exactly `expectedTotalRows` physical rows. A short scan is
+    * refused loudly instead of silently returning fewer rows than the column
+    * groups declare — the failure mode of a pre-fix milvus-storage library
+    * (milvus-storage#657) on multi-file column groups.
+    *
+    * Runs once: Spark calls `next()` to exhaustion for a full scan; a `close()`
+    * before EOF (e.g. a caller that stops early) deliberately skips the check.
+    */
+  private def verifyRowCount(): Unit = {
+    if (rowCountVerified) return
+    rowCountVerified = true
+    if (observedPhysicalRows != expectedTotalRows) {
+      throw new IllegalStateException(
+        s"Packed V2 reader delivered $observedPhysicalRows rows for segment " +
+          s"with ${columnGroups.size} column group(s) spanning " +
+          s"${columnGroups.map(_.filePaths.size).sum} file(s), expected " +
+          s"$expectedTotalRows (sum of per-file row counts). This usually means " +
+          "the native milvus-storage library predates the BuildLoonColumnGroups " +
+          "per-file range fix (milvus-storage#657) and silently dropped rows " +
+          "after the first file of a column group; refusing to return a short " +
+          "DataFrame"
+      )
+    }
+  }
 
   private def isDeleted(rowIndex: Int): Boolean = {
     val pkVector = currentBatch.getVector(pkColumnName)

--- a/src/main/scala/read/MilvusParquetFooterReader.scala
+++ b/src/main/scala/read/MilvusParquetFooterReader.scala
@@ -204,6 +204,48 @@ object MilvusParquetFooterReader extends Logging {
       rowCount: Long
   )
 
+  /** Read the total number of rows a parquet file contains by summing its row
+    * groups' row counts from the footer.
+    *
+    * Used by the backup datasource to recover per-file row counts that
+    * milvus-backup's meta does not persist (only `log_size` is recorded), which
+    * the packed V2 reader requires to build valid per-file `[0, rc)` ranges.
+    * Like the other footer reads this issues a `HEAD` + a single range `GET`
+    * for the last few KB of the file.
+    *
+    * @return
+    *   `Right(rowCount)` on success. `Left(throwable)` on I/O or parse failure.
+    */
+  def readRowCount(
+      path: String,
+      hadoopConf: Configuration
+  ): Either[Throwable, Long] = {
+    readWithFileSystem(path, hadoopConf) { inputFile =>
+      sumRowGroups(inputFile)
+    }
+  }
+
+  /** [[readRowCount]] with a caller-supplied `FileSystem` (reused across many
+    * files, e.g. all binlogs of a backup read).
+    */
+  def readRowCount(
+      fs: FileSystem,
+      path: String
+  ): Either[Throwable, Long] = {
+    readWithFileSystem(fs, path) { inputFile =>
+      sumRowGroups(inputFile)
+    }
+  }
+
+  private def sumRowGroups(inputFile: InputFile): Long = {
+    val parquet = ParquetFileReader.open(inputFile)
+    try {
+      parquet.getFooter.getBlocks.asScala.map(_.getRowCount).sum
+    } finally {
+      parquet.close()
+    }
+  }
+
   /** Read a parquet file's own field IDs and total row count with a single
     * footer open — the production path the backup datasource uses to recover
     * both the column-group field IDs and the per-file row count.

--- a/src/test/scala/loon/MilvusStorageMultiFileGroupTest.scala
+++ b/src/test/scala/loon/MilvusStorageMultiFileGroupTest.scala
@@ -1,0 +1,284 @@
+package com.zilliz.spark.connector.loon
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters._
+
+import org.apache.arrow.c.{ArrowArray, ArrowSchema => CArrowSchema, Data}
+import org.apache.arrow.vector._
+import org.apache.arrow.vector.types.FloatingPointPrecision
+import org.apache.arrow.vector.types.pojo.{
+  ArrowType,
+  Field => ArrowField,
+  FieldType,
+  Schema => ArrowSchema
+}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import io.milvus.storage._
+
+/** Regression test for the multi-file column-group row-range bug
+  * (milvus-storage#657): `BuildLoonColumnGroups` used to write group-cumulative
+  * `start_index`/`end_index`, which the packed reader intersects against each
+  * file's own zero-based row groups, silently dropping every file after the
+  * first. The connector feeds per-file row counts via
+  * [[MilvusStorageColumnGroups.createFromGroups]] on the snapshot/backfill/
+  * backup read paths, so all three were affected.
+  *
+  * This pins the fixed behavior through the native reader exactly as the C++
+  * `TestMultiFileGroupBuildLoonReadsAllRows` does: build one column group
+  * spanning TWO parquet files with per-file row counts and assert the packed
+  * reader returns total rows == sum of per-file rows (regression: file 2+ used
+  * to disappear silently).
+  */
+class MilvusStorageMultiFileGroupTest extends AnyFunSuite with Matchers {
+
+  private def localProperties: MilvusStorageProperties = {
+    val properties = new MilvusStorageProperties()
+    val props = new java.util.HashMap[String, String]()
+    props.put("fs.storage_type", "local")
+    props.put("fs.root_path", "/")
+    properties.create(props)
+    properties.isValid shouldBe true
+    properties
+  }
+
+  private def testArrowSchema(): ArrowSchema = {
+    val metadataId = Map("PARQUET:field_id" -> "100").asJava
+    val metadataVec = Map("PARQUET:field_id" -> "103").asJava
+    val fields = List(
+      new ArrowField(
+        "id",
+        new FieldType(false, new ArrowType.Int(64, true), null, metadataId),
+        null
+      ),
+      new ArrowField(
+        "vector",
+        new FieldType(false, new ArrowType.List(), null, metadataVec),
+        List(
+          new ArrowField(
+            "element",
+            new FieldType(
+              false,
+              new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+              null
+            ),
+            null
+          )
+        ).asJava
+      )
+    ).asJava
+    new ArrowSchema(fields)
+  }
+
+  /** Export an ArrowSchema and return the wrapped C object + its address. */
+  private def exportSchema(
+      allocator: org.apache.arrow.memory.BufferAllocator,
+      schema: ArrowSchema
+  ): (CArrowSchema, Long) = {
+    val cSchema = CArrowSchema.allocateNew(allocator)
+    Data.exportSchema(allocator, schema, null, cSchema)
+    (cSchema, cSchema.memoryAddress())
+  }
+
+  /** Write `numRows` rows via the native writer into `dir/_data` and return the
+    * absolute path of the single parquet file produced.
+    */
+  private def writeSingleFile(
+      dir: Path,
+      numRows: Int
+  ): (String, Int) = {
+    val allocator = ArrowUtils.getAllocator
+    val properties = localProperties
+    val writer = new MilvusStorageWriter()
+
+    val (schema, schemaPtr) = exportSchema(allocator, testArrowSchema())
+    try {
+      writer.create(dir.toAbsolutePath.toString, schemaPtr, properties)
+
+      val root = VectorSchemaRoot.create(testArrowSchema(), allocator)
+      val idVector = root.getVector("id").asInstanceOf[BigIntVector]
+      val vectorList =
+        root.getVector("vector").asInstanceOf[org.apache.arrow.vector.complex.ListVector]
+
+      idVector.allocateNew(numRows)
+      vectorList.allocateNew()
+      val listWriter = vectorList.getWriter
+      var i = 0
+      while (i < numRows) {
+        idVector.set(i, i.toLong)
+        listWriter.setPosition(i)
+        listWriter.startList()
+        listWriter.float4().writeFloat4(i * 0.1f)
+        listWriter.endList()
+        i += 1
+      }
+      root.setRowCount(numRows)
+
+      val arrowArray = ArrowArray.allocateNew(allocator)
+      var closedPtr = 0L
+      try {
+        Data.exportVectorSchemaRoot(allocator, root, null, arrowArray)
+        writer.write(arrowArray.memoryAddress())
+        writer.flush()
+        closedPtr = writer.close()
+      } finally {
+        arrowArray.close()
+        root.close()
+        MilvusStorageColumnGroups.destroy(closedPtr)
+      }
+
+      // The writer lays out one parquet per column group under `_data/`.
+      val dataDir = dir.resolve("_data").toFile
+      dataDir.listFiles().filter(_.getName.endsWith(".parquet")).toList match {
+        case single :: Nil => (single.getAbsolutePath, numRows)
+        case files =>
+          fail(s"expected exactly one parquet under $dataDir, got $files")
+      }
+    } finally {
+      writer.destroy()
+      properties.free()
+      schema.close()
+    }
+  }
+
+  test(
+    "multi-file column group via native reader returns total rows == sum of per-file rows"
+  ) {
+    NativeLibraryLoader.loadLibrary()
+
+    val dirA = Files.createTempDirectory("milvus-multifile-a-")
+    val dirB = Files.createTempDirectory("milvus-multifile-b-")
+    try {
+      // Two files of different sizes: file 2 must NOT be dropped.
+      val (pathA, rowsA) = writeSingleFile(dirA, 100)
+      val (pathB, rowsB) = writeSingleFile(dirB, 50)
+
+      // Move file B into the same directory as file A so both live under one
+      // base path (mirrors the C++ regression test, which uses one base_path).
+      val pathBEff = {
+        val moved = new java.io.File(pathA).getParentFile.toPath.resolve(
+          new java.io.File(pathB).getName
+        )
+        Files.move(
+          java.nio.file.Paths.get(pathB),
+          moved,
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING
+        )
+        moved.toString
+      }
+
+      // Sanity: a single-file group for file B alone must read its own rows.
+      val singleB = MilvusStorageColumnGroups.createFromGroups(
+        Array(Array("id", "vector")),
+        Array(Array(pathBEff)),
+        Array(Array(rowsB.toLong))
+      )
+      try {
+        val alloc0 = ArrowUtils.getAllocator
+        val props0 = localProperties
+        val r0 = new MilvusStorageReader()
+        val (s0, s0p) = exportSchema(alloc0, testArrowSchema())
+        try {
+          r0.create(singleB, s0p, Array("id"), props0)
+          val h = r0.openRecordBatchReaderScala()
+          try {
+            var rows = 0L
+            var done = false
+            while (!done) {
+              val ba = ArrowArray.allocateNew(alloc0)
+              val bs = CArrowSchema.allocateNew(alloc0)
+              try {
+                if (r0.readNextBatchScala(h, ba.memoryAddress(), bs.memoryAddress())) {
+                  val rr = Data.importVectorSchemaRoot(alloc0, ba, bs, null)
+                  try rows += rr.getRowCount finally rr.close()
+                } else done = true
+              } finally {
+                ba.close()
+                bs.close()
+              }
+            }
+            rows shouldBe rowsB.toLong
+          } finally r0.destroyRecordBatchReaderScala(h)
+        } finally {
+          r0.destroy()
+          s0.close()
+          props0.free()
+        }
+      } finally MilvusStorageColumnGroups.destroy(singleB)
+
+      // Build one column group spanning BOTH files, exactly as the connector's
+      // MilvusStorageColumnGroups.createFromGroups path does (per-file row
+      // counts, one group).
+      val cols = Array(Array("id", "vector"))
+      val files = Array(Array(pathA, pathBEff))
+      val rcs = Array(Array(rowsA.toLong, rowsB.toLong))
+      val columnGroupsPtr =
+        MilvusStorageColumnGroups.createFromGroups(cols, files, rcs)
+      columnGroupsPtr should not be 0L
+
+      val allocator = ArrowUtils.getAllocator
+      val properties = localProperties
+      val reader = new MilvusStorageReader()
+      val (schema, schemaPtr) = exportSchema(allocator, testArrowSchema())
+      try {
+        reader.create(columnGroupsPtr, schemaPtr, Array("id"), properties)
+        reader.isValid shouldBe true
+
+        val rbrHandle = reader.openRecordBatchReaderScala()
+        try {
+          var totalRows = 0L
+          var done = false
+          while (!done) {
+            val batchArray = ArrowArray.allocateNew(allocator)
+            val batchSchema = CArrowSchema.allocateNew(allocator)
+            try {
+              val hasBatch = reader.readNextBatchScala(
+                rbrHandle,
+                batchArray.memoryAddress(),
+                batchSchema.memoryAddress()
+              )
+              if (!hasBatch) {
+                done = true
+              } else {
+                val readRoot = Data.importVectorSchemaRoot(
+                  allocator,
+                  batchArray,
+                  batchSchema,
+                  null
+                )
+                try {
+                  totalRows += readRoot.getRowCount
+                } finally {
+                  readRoot.close()
+                }
+              }
+            } finally {
+              batchArray.close()
+              batchSchema.close()
+            }
+          }
+          // Regression: file 2+ used to be silently truncated.
+          totalRows shouldBe (rowsA + rowsB).toLong
+        } finally {
+          reader.destroyRecordBatchReaderScala(rbrHandle)
+        }
+      } finally {
+        reader.destroy()
+        schema.close()
+        MilvusStorageColumnGroups.destroy(columnGroupsPtr)
+        properties.free()
+      }
+    } finally {
+      deleteRecursively(dirA.toFile)
+      deleteRecursively(dirB.toFile)
+    }
+  }
+
+  private def deleteRecursively(dir: java.io.File): Unit = {
+    if (dir.exists()) {
+      if (dir.isDirectory) dir.listFiles().foreach(deleteRecursively)
+      dir.delete()
+    }
+  }
+}

--- a/src/test/scala/read/BackupMetaReaderTest.scala
+++ b/src/test/scala/read/BackupMetaReaderTest.scala
@@ -125,6 +125,57 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
     root.toString
   }
 
+  /** Materialize a backup whose slot 103 column group spans **two** binlog
+    * files (mirrors the `multiFile = true` fixture: `103/1` + `103/2`), with
+    * the same total rows as the single-file [[materializeBackup]] shape.
+    */
+  private def materializeMultiFileBackup(root: java.nio.file.Path): String = {
+    val seg =
+      Paths.get(
+        root.toString,
+        "binlogs",
+        "insert_log",
+        "444",
+        "555",
+        "777",
+        "777"
+      )
+    writeParquetAt(
+      Paths.get(seg.toString, "103", "1"),
+      groupASchema,
+      List(
+        f =>
+          f.newGroup()
+            .append("pk", 1L)
+            .append("row_id", 10L)
+            .append("ts", 100L),
+        f =>
+          f.newGroup()
+            .append("pk", 2L)
+            .append("row_id", 11L)
+            .append("ts", 101L)
+      )
+    )
+    writeParquetAt(
+      Paths.get(seg.toString, "103", "2"),
+      groupASchema,
+      List(
+        f =>
+          f.newGroup().append("pk", 3L).append("row_id", 12L).append("ts", 102L)
+      )
+    )
+    writeParquetAt(
+      Paths.get(seg.toString, "101", "1"),
+      groupCSchema,
+      List(
+        f => f.newGroup().append("name", "a"),
+        f => f.newGroup().append("name", "b"),
+        f => f.newGroup().append("name", "c")
+      )
+    )
+    root.toString
+  }
+
   private def backupFixture(
       format: String = "",
       groupAPath: String,
@@ -627,28 +678,47 @@ class BackupMetaReaderTest extends AnyFunSuite with Matchers {
   }
 
   test(
-    "toV2Segments rejects multi-file column groups (milvus-storage bug)"
+    "toV2Segments recovers per-file row counts for multi-file column groups"
   ) {
-    val meta = BackupMetaReader
-      .parse(
-        backupFixture(
-          groupAPath = SourceKeys._1,
-          groupBPath = SourceKeys._2,
-          groupCPath = SourceKeys._3,
-          deltaPath = SourceKeys._4
+    val dir = Files.createTempDirectory("milvus-backup-multi-")
+    try {
+      val backupDir = materializeMultiFileBackup(dir)
+      val meta = BackupMetaReader
+        .parse(
+          backupFixture(
+            groupAPath = SourceKeys._1,
+            groupBPath = SourceKeys._2,
+            groupCPath = SourceKeys._3,
+            deltaPath = SourceKeys._4,
+            multiFile = true
+          )
         )
+        .getOrElse(fail("expected Right"))
+
+      val segments = BackupMetaReader
+        .toV2Segments(meta, new Configuration(), backupDir, collectionId = 444L)
+        .getOrElse(fail("expected Right"))
+
+      val seg = segments.find(_.segmentId == 777L).get
+      seg.numOfRows shouldBe 3L
+      // Slot 103 spans two binlog files; per-file row counts must be recovered
+      // (not group-cumulative), otherwise the packed reader silently truncates
+      // the second file.
+      val slot103 = seg.columnGroups.find(_.slotFieldId == 103L).get
+      slot103.filePaths shouldBe Seq(
+        s"$backupDir/binlogs/insert_log/444/555/777/777/103/1",
+        s"$backupDir/binlogs/insert_log/444/555/777/777/103/2"
       )
-      .getOrElse(fail("expected Right"))
-    val result = BackupMetaReader.toV2Segments(
-      meta,
-      new Configuration(),
-      "/tmp/backup",
-      collectionId = 444L
-    )
-    result.isLeft shouldBe true
-    result.left.toOption.get.getMessage should include(
-      "multi-file column groups"
-    )
+      slot103.fileRowCounts shouldBe Seq(2L, 1L)
+
+      val slot101 = seg.columnGroups.find(_.slotFieldId == 101L).get
+      slot101.filePaths shouldBe Seq(
+        s"$backupDir/binlogs/insert_log/444/555/777/777/101/1"
+      )
+      slot101.fileRowCounts shouldBe Seq(3L)
+    } finally {
+      deleteRecursively(dir)
+    }
   }
 
   test(


### PR DESCRIPTION
milvus-storage#657 fixed BuildLoonColumnGroups to write per-file [0, rc_i) ranges instead of group-cumulative offsets, which the packed reader intersects against each file's own zero-based row groups and was silently truncating every file after the first. Bump the submodule to cb22dfa and drop the temporary guard in BackupMetaReader that rejected a column group spanning multiple binlog files.

Restore per-file tail row-count reads on their own thread pool (FooterReadPool stays separate from SegmentReadPool so a segment worker blocked on Future.get() can never starve its own tail reads), re-add MilvusParquetFooterReader.readRowCount, and update BackupMetaReaderTest to expect per-file counts instead of rejection.

Add MilvusStorageMultiFileGroupTest, a native-reader integration test that builds one column group spanning two files via MilvusStorageColumnGroups.createFromGroups and pins total rows == sum of per-file rows. Update the design doc and reference docs accordingly.