### PR TITLE
enhance: Add input format dispatch to backfill reads

### DIFF
--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -13,7 +13,12 @@ import com.zilliz.spark.connector.MilvusOption
   * --s3-secret-key <secret> \ [--s3-root-path <path>] [--s3-region <region>]
   * [--s3-cloud-provider aws|aliyun|gcp|azure|tencent|huawei] [--s3-use-ssl] \
   * [--batch-size <n>] [--output-result <path>] \ [--mode
-  * replace|coalesce|overwrite]
+  * replace|coalesce|overwrite] [--input-format parquet|iceberg|lance]
+  *
+  * --input-path <path> is a format-neutral alias for --parquet (mutually
+  * exclusive with it). --input-format selects the input reader; only
+  * "parquet" is implemented, iceberg/lance are validated but rejected until
+  * their readers land.
   *
   * --mode:
   *   - replace: parquet is absolute source of truth; unmatched source rows get
@@ -28,10 +33,9 @@ object BackfillApp {
   def main(args: Array[String]): Unit = {
     val parsed = parseArgs(args)
 
-    val parquetPath = parsed.getOrElse(
-      "parquet",
-      throw new IllegalArgumentException("--parquet is required")
-    )
+    val parquetPath = resolveInputPath(parsed)
+    val inputFormat =
+      parsed.getOrElse("input-format", BackfillConfig.DefaultInputFormat)
     val snapshotPath = parsed.getOrElse(
       "snapshot",
       throw new IllegalArgumentException("--snapshot is required")
@@ -85,6 +89,7 @@ object BackfillApp {
       sourceS3Region = parsed.get("source-s3-region"),
       batchSize = parsed.getOrElse("batch-size", "1024").toInt,
       columnMapping = parsed.get("column-mapping").map(parseColumnMapping),
+      inputFormat = inputFormat,
       mode = parsed.getOrElse("mode", MilvusOption.BackfillModeCoalesce)
     )
 
@@ -147,6 +152,8 @@ object BackfillApp {
   // later inside the AWS default provider chain.
   private[backfill] val KvFlags: Set[String] = Set(
     "parquet",
+    "input-path",
+    "input-format",
     "snapshot",
     "s3-endpoint",
     "s3-bucket",
@@ -166,6 +173,26 @@ object BackfillApp {
   )
 
   private[backfill] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
+
+  /** Resolve the input data path from `--parquet` (legacy) or `--input-path`
+    * (format-neutral alias). Supplying both is a config mistake, not an
+    * override, so it fails fast instead of silently picking one.
+    */
+  private[backfill] def resolveInputPath(parsed: Map[String, String]): String = {
+    if (parsed.contains("parquet") && parsed.contains("input-path")) {
+      throw new IllegalArgumentException(
+        "--parquet and --input-path are mutually exclusive; use --input-path"
+      )
+    }
+    parsed
+      .get("parquet")
+      .orElse(parsed.get("input-path"))
+      .getOrElse(
+        throw new IllegalArgumentException(
+          "--parquet (or --input-path) is required"
+        )
+      )
+  }
 
   // Parse `src1:tgt1,src2:tgt2,...` into a map. Empty segments and malformed
   // entries raise a clear error rather than silently dropping bindings.

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -34,8 +34,10 @@ object BackfillApp {
     val parsed = parseArgs(args)
 
     val parquetPath = resolveInputPath(parsed)
-    val inputFormat =
-      parsed.getOrElse("input-format", BackfillConfig.DefaultInputFormat)
+    val inputFormat = parsed
+      .get("input-format")
+      .filter(_.trim.nonEmpty)
+      .getOrElse(BackfillConfig.DefaultInputFormat)
     val snapshotPath = parsed.getOrElse(
       "snapshot",
       throw new IllegalArgumentException("--snapshot is required")
@@ -177,16 +179,22 @@ object BackfillApp {
   /** Resolve the input data path from `--parquet` (legacy) or `--input-path`
     * (format-neutral alias). Supplying both is a config mistake, not an
     * override, so it fails fast instead of silently picking one.
+    *
+    * Template-driven spark-submit wrappers often keep optional keys with
+    * empty values (e.g. `--parquet "$LEGACY"` while migrating to
+    * `--input-path`); empty values are treated as absent, mirroring
+    * `MilvusOption.nonEmptyOption`.
     */
   private[backfill] def resolveInputPath(parsed: Map[String, String]): String = {
-    if (parsed.contains("parquet") && parsed.contains("input-path")) {
+    val parquetPath = parsed.get("parquet").filter(_.trim.nonEmpty)
+    val inputPath = parsed.get("input-path").filter(_.trim.nonEmpty)
+    if (parquetPath.nonEmpty && inputPath.nonEmpty) {
       throw new IllegalArgumentException(
         "--parquet and --input-path are mutually exclusive; use --input-path"
       )
     }
-    parsed
-      .get("parquet")
-      .orElse(parsed.get("input-path"))
+    parquetPath
+      .orElse(inputPath)
       .getOrElse(
         throw new IllegalArgumentException(
           "--parquet (or --input-path) is required"

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -72,9 +72,8 @@ case class BackfillConfig(
     sourceS3Region: Option[String] = None,
 
     // Input data source format. "parquet" is the only implemented reader;
-    // "iceberg" and "lance" are recognized by validation so configs can be
-    // authored ahead of their readers, but readBackfillData rejects them
-    // until the corresponding reader lands.
+    // "iceberg" and "lance" are recognized as valid format names but have no
+    // reader yet, so validate() rejects them until a reader lands.
     inputFormat: String = BackfillConfig.DefaultInputFormat,
 
     // Writer configuration
@@ -430,9 +429,9 @@ object BackfillConfig {
   private[backfill] val AllowedInputFormats =
     Set("parquet", "iceberg", "lance")
   // Subset of AllowedInputFormats with a working reader. validate() rejects
-  // recognized-but-unimplemented formats here, fail-fast at config time,
-  // instead of letting the job burn snapshot/S3 work before readBackfillData
-  // rejects the format. Each new reader extends this set.
+  // recognized-but-unimplemented formats here (fail-fast at config time), and
+  // readBackfillData guards its per-format dispatch on the same set so the two
+  // cannot drift. Each new reader extends this set and adds a dispatch arm.
   private[backfill] val ImplementedInputFormats = Set("parquet")
 
   private[backfill] val HadoopS3CredentialsProvider =

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -71,6 +71,12 @@ case class BackfillConfig(
     sourceS3UseIam: Option[Boolean] = None,
     sourceS3Region: Option[String] = None,
 
+    // Input data source format. "parquet" is the only implemented reader;
+    // "iceberg" and "lance" are recognized by validation so configs can be
+    // authored ahead of their readers, but readBackfillData rejects them
+    // until the corresponding reader lands.
+    inputFormat: String = BackfillConfig.DefaultInputFormat,
+
     // Writer configuration
     batchSize: Int = 1024,
     customOutputPath: Option[String] = None,
@@ -168,6 +174,11 @@ case class BackfillConfig(
       )
     } else if (normalizedRoleArn.isEmpty && hasRoleDetails) {
       Left("s3RoleSessionName and s3ExternalId require s3RoleArn")
+    } else if (!BackfillConfig.AllowedInputFormats.contains(inputFormat.trim)) {
+      Left(
+        s"inputFormat must be one of ${BackfillConfig.AllowedInputFormats
+            .mkString("[", ", ", "]")} (got '$inputFormat')"
+      )
     } else {
       // Same invariant for the source (input parquet) bucket. Any field
       // left as None falls back to the main credentials, which we already
@@ -406,6 +417,10 @@ object BackfillConfig {
   private[backfill] val AllowedCloudProviders =
     Set("aws", "gcp", "aliyun", "azure", "tencent", "huawei")
   private[backfill] val NativeAssumeRoleCloudProviders = Set("aws", "aliyun")
+
+  private[backfill] val DefaultInputFormat = "parquet"
+  private[backfill] val AllowedInputFormats =
+    Set("parquet", "iceberg", "lance")
 
   private[backfill] val HadoopS3CredentialsProvider =
     "fs.s3a.aws.credentials.provider"

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -179,6 +179,14 @@ case class BackfillConfig(
         s"inputFormat must be one of ${BackfillConfig.AllowedInputFormats
             .mkString("[", ", ", "]")} (got '$inputFormat')"
       )
+    } else if (
+      !BackfillConfig.ImplementedInputFormats.contains(inputFormat.trim)
+    ) {
+      Left(
+        s"inputFormat '$inputFormat' is recognized but not yet implemented; " +
+          s"only ${BackfillConfig.ImplementedInputFormats.mkString("[", ", ", "]")} " +
+          "have a reader"
+      )
     } else {
       // Same invariant for the source (input parquet) bucket. Any field
       // left as None falls back to the main credentials, which we already
@@ -421,6 +429,11 @@ object BackfillConfig {
   private[backfill] val DefaultInputFormat = "parquet"
   private[backfill] val AllowedInputFormats =
     Set("parquet", "iceberg", "lance")
+  // Subset of AllowedInputFormats with a working reader. validate() rejects
+  // recognized-but-unimplemented formats here, fail-fast at config time,
+  // instead of letting the job burn snapshot/S3 work before readBackfillData
+  // rejects the format. Each new reader extends this set.
+  private[backfill] val ImplementedInputFormats = Set("parquet")
 
   private[backfill] val HadoopS3CredentialsProvider =
     "fs.s3a.aws.credentials.provider"

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -475,9 +475,31 @@ object MilvusBackfill {
     }
   }
 
-  /** Read backfill data from Parquet file
+  /** Read the backfill input by dispatching on `config.inputFormat`.
+    *
+    * Only "parquet" has a reader today; "iceberg" and "lance" pass config
+    * validation but are rejected here with an explicit unsupported-format
+    * error until their readers land.
     */
   private def readBackfillData(
+      spark: SparkSession,
+      rawPath: String,
+      config: BackfillConfig
+  ): Either[BackfillError, BackfillSource] =
+    config.inputFormat.trim match {
+      case BackfillConfig.DefaultInputFormat =>
+        readParquet(spark, rawPath, config)
+      case other =>
+        Left(
+          DataReadError(
+            path = rawPath,
+            message = s"Input format '$other' is not supported yet; only " +
+              s"'${BackfillConfig.DefaultInputFormat}' is currently available"
+          )
+        )
+    }
+
+  private def readParquet(
       spark: SparkSession,
       rawPath: String,
       config: BackfillConfig

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -477,9 +477,10 @@ object MilvusBackfill {
 
   /** Read the backfill input by dispatching on `config.inputFormat`.
     *
-    * Only "parquet" has a reader today; "iceberg" and "lance" pass config
-    * validation but are rejected here with an explicit unsupported-format
-    * error until their readers land.
+    * `BackfillConfig.validate()` already rejects recognized-but-unimplemented
+    * formats (iceberg, lance) before any snapshot/segment work; this branch
+    * remains as a defensive safety net for embedded callers that bypass
+    * validate().
     */
   private def readBackfillData(
       spark: SparkSession,

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -477,28 +477,32 @@ object MilvusBackfill {
 
   /** Read the backfill input by dispatching on `config.inputFormat`.
     *
-    * `BackfillConfig.validate()` already rejects recognized-but-unimplemented
-    * formats (iceberg, lance) before any snapshot/segment work; this branch
-    * remains as a defensive safety net for embedded callers that bypass
-    * validate().
+    * The guard is keyed to the same `ImplementedInputFormats` set that
+    * `BackfillConfig.validate()` uses, so the two cannot drift: a format with
+    * a reader is dispatched here, anything else fails with the same
+    * not-implemented contract. `run()` rejects unimplemented formats earlier,
+    * at validate() before any snapshot/S3 work.
     */
   private def readBackfillData(
       spark: SparkSession,
       rawPath: String,
       config: BackfillConfig
-  ): Either[BackfillError, BackfillSource] =
-    config.inputFormat.trim match {
-      case BackfillConfig.DefaultInputFormat =>
-        readParquet(spark, rawPath, config)
-      case other =>
-        Left(
-          DataReadError(
-            path = rawPath,
-            message = s"Input format '$other' is not supported yet; only " +
-              s"'${BackfillConfig.DefaultInputFormat}' is currently available"
-          )
+  ): Either[BackfillError, BackfillSource] = {
+    val format = config.inputFormat.trim
+    if (!BackfillConfig.ImplementedInputFormats.contains(format)) {
+      return Left(
+        DataReadError(
+          path = rawPath,
+          message = s"Input format '$format' is not implemented; only " +
+            s"${BackfillConfig.ImplementedInputFormats.mkString("[", ", ", "]")} " +
+            "have a reader"
         )
+      )
     }
+    format match {
+      case "parquet" => readParquet(spark, rawPath, config)
+    }
+  }
 
   private def readParquet(
       spark: SparkSession,

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -30,7 +30,7 @@ class for running backfill as a Spark application:
 spark-submit \
   --class com.zilliz.spark.connector.operations.backfill.BackfillApp \
   spark-connector-assembly-<branch>-amd64-SNAPSHOT.jar \
-  --parquet      s3a://source-bucket/new_fields.parquet \
+  --input-path   s3a://source-bucket/new_fields.parquet \
   --snapshot     s3a://milvus-bucket/snapshots/foo.json \
   --s3-endpoint  s3.us-west-2.amazonaws.com \
   --s3-bucket    milvus-bucket \
@@ -46,8 +46,12 @@ spark-submit \
   [--source-s3-region us-east-1] \
   [--batch-size 1024] \
   [--output-result s3a://milvus-bucket/backfill/result.json] \
-  [--mode replace|coalesce|overwrite]
+  [--mode replace|coalesce|overwrite] \
+  [--input-format parquet]
 ```
+
+`--parquet <path>` is still accepted as a legacy alias for `--input-path`;
+passing both is an error.
 
 ### Authentication and dual-bucket credentials
 
@@ -81,7 +85,7 @@ spark-submit \
 
 | Flag           | Description                                       |
 |----------------|---------------------------------------------------|
-| `--parquet`    | Path to the new-field parquet (`pk, field1, ...`) |
+| `--input-path` | Path to the new-field input data (`pk, field1, ...`). `--parquet` is a legacy alias; the two are mutually exclusive. |
 | `--snapshot`   | Path to the Milvus snapshot manifest JSON          |
 | `--s3-endpoint`| S3 endpoint for the Milvus storage bucket          |
 | `--s3-bucket`  | Milvus storage bucket name                         |
@@ -90,6 +94,7 @@ spark-submit \
 
 | Flag              | Default     | Description                                                                  |
 |-------------------|-------------|------------------------------------------------------------------------------|
+| `--input-format`  | `parquet`   | Input reader. `parquet` is the only implemented format; `iceberg` and `lance` are recognized but rejected at config validation until their readers land. |
 | `--mode`          | `coalesce`  | Merge semantics: `replace`, `coalesce` (fill-if-null), or `overwrite`. See "Merge modes" below. |
 | `--batch-size`    | `1024`      | Rows per Arrow batch flushed to the writer.                                  |
 | `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -82,6 +82,41 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     parsed("source-use-iam") shouldBe "true"
   }
 
+  test("parseArgs accepts --input-path and --input-format") {
+    val parsed = BackfillApp.parseArgs(
+      Array("--input-path", "s3://bucket/backfill.lance", "--input-format", "lance")
+    )
+    parsed("input-path") shouldBe "s3://bucket/backfill.lance"
+    parsed("input-format") shouldBe "lance"
+  }
+
+  test("resolveInputPath keeps --parquet as the legacy alias") {
+    BackfillApp.resolveInputPath(
+      Map("parquet" -> "/tmp/data.parquet")
+    ) shouldBe "/tmp/data.parquet"
+  }
+
+  test("resolveInputPath accepts --input-path as the format-neutral alias") {
+    BackfillApp.resolveInputPath(
+      Map("input-path" -> "s3://bucket/backfill.lance")
+    ) shouldBe "s3://bucket/backfill.lance"
+  }
+
+  test("resolveInputPath rejects both --parquet and --input-path") {
+    val ex = intercept[IllegalArgumentException] {
+      BackfillApp.resolveInputPath(
+        Map("parquet" -> "/tmp/a.parquet", "input-path" -> "/tmp/b.lance")
+      )
+    }
+    ex.getMessage should include("mutually exclusive")
+  }
+
+  test("resolveInputPath requires an input path") {
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.resolveInputPath(Map.empty)
+    }
+  }
+
   test("parseArgs throws on missing value for non-flag") {
     an[IllegalArgumentException] should be thrownBy {
       BackfillApp.parseArgs(Array("--parquet"))

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -111,6 +111,27 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     ex.getMessage should include("mutually exclusive")
   }
 
+  test("resolveInputPath treats empty flag values as absent") {
+    // Template wrappers keep optional keys with empty values; an empty
+    // --parquet must not trip the mutual-exclusion check nor shadow a
+    // populated --input-path.
+    BackfillApp.resolveInputPath(
+      Map("parquet" -> "", "input-path" -> "s3://bucket/backfill.lance")
+    ) shouldBe "s3://bucket/backfill.lance"
+    BackfillApp.resolveInputPath(
+      Map("parquet" -> " ", "input-path" -> "/tmp/a.parquet")
+    ) shouldBe "/tmp/a.parquet"
+  }
+
+  test("resolveInputPath treats a sole empty path as missing") {
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.resolveInputPath(Map("parquet" -> ""))
+    }
+    an[IllegalArgumentException] should be thrownBy {
+      BackfillApp.resolveInputPath(Map("input-path" -> ""))
+    }
+  }
+
   test("resolveInputPath requires an input path") {
     an[IllegalArgumentException] should be thrownBy {
       BackfillApp.resolveInputPath(Map.empty)

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -793,6 +793,32 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     }
   }
 
+  test(
+    "MilvusBackfill.run rejects unimplemented inputFormat at config validation"
+  ) {
+    BackfillConfig.AllowedInputFormats
+      .diff(BackfillConfig.ImplementedInputFormats)
+      .foreach { format =>
+        val cfg = BackfillConfig(
+          s3Endpoint = "localhost:9000",
+          s3BucketName = "b",
+          s3AccessKey = "minioadmin",
+          s3SecretKey = "minioadmin",
+          inputFormat = format
+        )
+        // An empty snapshotPath would otherwise be read; failing at
+        // config.validate() proves the error short-circuits before any
+        // snapshot/S3 work.
+        MilvusBackfill.run(spark, "file:///unused.input", "", cfg) match {
+          case Left(error) =>
+            error.message should include("Invalid configuration")
+            error.message should include(format)
+          case Right(_) =>
+            fail(s"expected unimplemented inputFormat '$format' to fail")
+        }
+      }
+  }
+
   test("getMilvusReadOptions includes AK/SK when s3UseIam=false") {
     val cfg = BackfillConfig(
       s3Endpoint = "minio:9000",

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -22,6 +22,37 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     )
 
     config.validate() shouldBe Right(())
+    config.inputFormat shouldBe BackfillConfig.DefaultInputFormat
+  }
+
+  test("validate accepts parquet/iceberg/lance as inputFormat") {
+    BackfillConfig.AllowedInputFormats.foreach { format =>
+      val config = BackfillConfig(
+        s3Endpoint = "localhost:9000",
+        s3BucketName = "test-bucket",
+        s3AccessKey = "minioadmin",
+        s3SecretKey = "minioadmin",
+        inputFormat = format
+      )
+      config.validate() shouldBe Right(())
+    }
+  }
+
+  test("validate rejects unknown inputFormat") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "avro"
+    )
+    config.validate() match {
+      case Right(_) =>
+        fail("expected validation error for unknown inputFormat")
+      case Left(message) =>
+        message should include("inputFormat must be one of")
+        message should include("(got 'avro')")
+    }
   }
 
   test(

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -25,8 +25,8 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.inputFormat shouldBe BackfillConfig.DefaultInputFormat
   }
 
-  test("validate accepts parquet/iceberg/lance as inputFormat") {
-    BackfillConfig.AllowedInputFormats.foreach { format =>
+  test("validate accepts implemented inputFormat (parquet)") {
+    BackfillConfig.ImplementedInputFormats.foreach { format =>
       val config = BackfillConfig(
         s3Endpoint = "localhost:9000",
         s3BucketName = "test-bucket",
@@ -35,6 +35,27 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
         inputFormat = format
       )
       config.validate() shouldBe Right(())
+    }
+  }
+
+  test("validate rejects recognized-but-unimplemented inputFormats") {
+    val unimplemented =
+      BackfillConfig.AllowedInputFormats -- BackfillConfig.ImplementedInputFormats
+    unimplemented should not be empty
+    unimplemented.foreach { format =>
+      val config = BackfillConfig(
+        s3Endpoint = "localhost:9000",
+        s3BucketName = "test-bucket",
+        s3AccessKey = "minioadmin",
+        s3SecretKey = "minioadmin",
+        inputFormat = format
+      )
+      config.validate() match {
+        case Right(_) =>
+          fail(s"expected validation error for unimplemented inputFormat '$format'")
+        case Left(message) =>
+          message should include("recognized but not yet implemented")
+      }
     }
   }
 


### PR DESCRIPTION
Backfill input reads are hardcoded to spark.read.parquet inside readBackfillData, so the CLI and config expose no way to select a different input source.

Introduce an inputFormat field on BackfillConfig, dispatch readBackfillData by format, and extract the existing parquet logic into readParquet. Iceberg and lance pass config validation but are rejected with an explicit unsupported-format error until their readers land.

The CLI gains --input-format and --input-path; --parquet remains the legacy alias. Supplying both paths fails fast instead of silently picking one.