### PR TITLE
ci: add PR-Agent review and CI status labels for pull requests

### DIFF
--- a/.github/workflows/ci-labels.yml
+++ b/.github/workflows/ci-labels.yml
@@ -1,0 +1,70 @@
+name: CI Labels
+
+# Mirrors the ci-passed / ci-not-pass labels that Jenkins applies on
+# zilliztech/zilliz-cloud.
+#
+# ci.yml runs untrusted PR code, so it only gets a read-only token and cannot
+# label fork PRs. This workflow reacts to ci.yml via workflow_run, which always
+# runs from main with a write token and never checks out PR code.
+#
+#   CI requested            -> remove ci-passed, add ci-not-pass
+#   CI succeeded            -> remove ci-not-pass, add ci-passed
+#   CI failed / timed out   -> remove ci-passed, add ci-not-pass
+#   CI cancelled / skipped  -> no change (a newer run already reset the labels)
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [requested, completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            // workflow_run.pull_requests is empty for fork PRs, so resolve the
+            // PR from the head commit instead and double-check the SHA.
+            const { data: associated } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: run.head_sha,
+            });
+            const prs = associated.filter(pr => pr.state === 'open' && pr.head.sha === run.head_sha);
+            if (prs.length === 0) {
+              core.info(`No open PR at ${run.head_sha}; nothing to label (run may be stale).`);
+              return;
+            }
+
+            const PASSED = 'ci-passed';
+            const NOT_PASSED = 'ci-not-pass';
+            let add, remove;
+            if (context.payload.action === 'requested') {
+              add = NOT_PASSED; remove = PASSED;
+            } else if (run.conclusion === 'success') {
+              add = PASSED; remove = NOT_PASSED;
+            } else if (run.conclusion === 'failure' || run.conclusion === 'timed_out') {
+              add = NOT_PASSED; remove = PASSED;
+            } else {
+              core.info(`CI conclusion '${run.conclusion}', leaving labels untouched.`);
+              return;
+            }
+
+            for (const pr of prs) {
+              const issue_number = pr.number;
+              const current = pr.labels.map(l => l.name);
+              if (current.includes(remove)) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: remove })
+                  .catch(e => { if (e.status !== 404) throw e; });
+              }
+              if (!current.includes(add)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [add] });
+              }
+              core.info(`PR #${issue_number}: -${remove} +${add}`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Builds the connector and runs the unit tests on every PR. The native
+# milvus-storage libraries are not built here (that needs Conan 2 + Rust and
+# takes a long time, see Dockerfile); the JNI Scala wrapper compiles fine
+# without them, so only the two suites that load the .so are excluded.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Build milvus-storage JNI wrapper (Scala only, no native libs)
+        working-directory: milvus-storage/java
+        run: sbt package
+
+      - name: Compile main, test and integration-test sources
+        run: sbt 'compile; Test/compile; IntegrationTest/compile'
+
+      - name: Unit tests (suites that need the native .so are excluded)
+        run: >-
+          sbt
+          'set Test / testOptions += Tests.Filter(n => !Set("com.zilliz.spark.connector.loon.MilvusStorageFFITest", "com.zilliz.spark.connector.loon.MilvusStorageMultiFileGroupTest").contains(n))'
+          test

--- a/.github/workflows/pr-agent-review.yml
+++ b/.github/workflows/pr-agent-review.yml
@@ -1,0 +1,50 @@
+name: "PR-Agent Review"
+
+# Mirrors zilliztech/zilliz-cloud's pr-agent-review.yml. It produces the
+# "Bug fix" / "Tests" / "enhancement" / "documentation" / "Review effort N/5"
+# labels (see .pr_agent.toml, publish_labels = true) plus the auto description,
+# review and code suggestions.
+#
+# spark-milvus is public and most PRs come from forks. The plain `pull_request`
+# event runs fork PRs without repository secrets, so PR-Agent could never reach
+# the model gateway. `pull_request_target` runs in the base-repo context with
+# secrets. PR-Agent works purely through the GitHub API, so we deliberately do
+# NOT check out the PR code here (that is the unsafe part of pull_request_target).
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# One run at a time per PR, cancel stale reviews on new push.
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  pr-agent-review:
+    if: >-
+      vars.ENABLE_PR_AGENT_REVIEW == 'true'
+      && github.event.sender.type != 'Bot'
+      && !contains(github.event.pull_request.title, '[skip cr]')
+    name: "PR-Agent Review"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: PR-Agent Review
+        uses: The-PR-Agent/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_BASE_URL: "${{ secrets.ANTHROPIC_BASE_URL }}/v1"
+          config.model: "openai/gpt-5.4"
+          config.model_turbo: "openai/gpt-5.4"
+          config.fallback_models: '["openai/claude-sonnet-4-6"]'
+          config.custom_model_max_tokens: "1000000"
+          LITELLM_DROP_PARAMS: "true"
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"
+          github_action_config.pr_actions: '["opened", "reopened", "ready_for_review", "synchronize"]'

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,25 @@
+[pr_reviewer]
+extra_instructions = """\
+This is spark-milvus, the Apache Spark connector for Milvus (Scala 2.13, Spark 4.x, sbt).
+It reads Milvus binlog/segment data and the milvus-storage (Loon) format through a JNI bridge,
+and ships ETL operations such as backfill, backup reads and Milvus writes.
+
+Review focus areas:
+- Data correctness: schema mapping, null handling and Spark<->Milvus type conversions must round-trip exactly
+- Scale: no driver-side collect(), unbounded caching or per-row RPCs on large collections
+- Storage access: S3/OSS/MinIO/GCS path and credential handling must not leak secrets in logs or break existing URI schemes
+- JNI/native boundary: resource lifecycle (close/free), thread safety and error propagation from milvus-storage
+- CLI/config changes must keep backward-compatible defaults and be documented in the operation's README
+- New behaviour needs unit tests under src/test; tests that need Milvus/MinIO belong in src/it
+"""
+num_code_suggestions = 5
+inline_code_comments = true
+
+[pr_description]
+publish_labels = true
+publish_description_as_comment = false
+add_original_user_description = true
+generate_ai_title = false
+
+[pr_code_suggestions]
+num_code_suggestions = 5


### PR DESCRIPTION
## What

Bring spark-milvus in line with how `zilliztech/zilliz-cloud` labels its PRs.

| File | Purpose |
|---|---|
| `.github/workflows/pr-agent-review.yml` + `.pr_agent.toml` | PR-Agent auto describe / review / code suggestions. `publish_labels = true` yields the `Bug fix`, `Tests`, `enhancement`, `documentation`, `Review effort N/5` labels. Copied from zilliz-cloud; switched to `pull_request_target` because our PRs come from forks (the plain `pull_request` event has no secrets there). No `actions/checkout` step, so PR code is never executed in the privileged context. |
| `.github/workflows/ci.yml` | First PR CI for this repo: build the milvus-storage JNI wrapper (Scala only), `compile; Test/compile; IntegrationTest/compile`, then `sbt test` with the two native-backed suites (`MilvusStorageFFITest`, `MilvusStorageMultiFileGroupTest`) filtered out. Runs with a read-only token. |
| `.github/workflows/ci-labels.yml` | `workflow_run` companion that applies `ci-passed` / `ci-not-pass` (the labels Jenkins applies on zilliz-cloud). Resolves fork PRs via the head SHA since `workflow_run.pull_requests` is empty for forks. |

## Labels

Created on the repo with zilliz-cloud's colours: `ci-passed`, `ci-not-pass`, `Bug fix`, `Tests`, `Configuration changes`, `Possible security concern`, `Other`, `Review effort 1/5`…`5/5`. `enhancement` / `documentation` / `bug` already existed.

## Before the PR-Agent job runs

```
gh secret set ANTHROPIC_API_KEY  --repo zilliztech/spark-milvus
gh secret set ANTHROPIC_BASE_URL --repo zilliztech/spark-milvus
gh variable set ENABLE_PR_AGENT_REVIEW --repo zilliztech/spark-milvus --body true
```

Until the variable is set the job is skipped, so merging this is safe on its own.

## Notes

- Workflows using `pull_request_target` / `workflow_run` only take effect once they are on `main`, so they cannot be exercised from this PR itself. `ci.yml` does run here.
- `scalafmtCheck` is intentionally not part of CI: `BackupMetaReader*.scala` and `MilvusStorageMultiFileGroupTest.scala` on `main` are already unformatted and would fail every PR.
- The test filter was verified locally: `sbt 'set Test / testOptions += Tests.Filter(...)' 'Test/testOnly com.zilliz.spark.connector.loon.*'` ran `PropertiesTest` and `MilvusLoonWriterTest` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)