### PR TITLE
fix: use durable Avro source for native builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,16 @@ RUN git config --global --add safe.directory /workspace && \
     git config --global --add safe.directory /workspace/milvus-storage && \
     git submodule update --init --recursive
 
+# Apache removes superseded releases from dlcdn; keep the pinned recipe and
+# checksum, but use the durable archive endpoint for its Avro source.
+RUN set -eux; \
+    avro_ref='libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d'; \
+    conan download "${avro_ref}" -r default-conan-local2 --only-recipe; \
+    avro_recipe="$(conan cache path "${avro_ref}")"; \
+    sed -i 's#https://dlcdn.apache.org/avro/#https://archive.apache.org/dist/avro/#' \
+        "${avro_recipe}/conandata.yml"; \
+    grep -Fq 'https://archive.apache.org/dist/avro/' "${avro_recipe}/conandata.yml"
+
 # Build milvus-storage native libraries using its Conan 2 Makefile.
 RUN cd milvus-storage/cpp && make java-lib
 


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## What changed

- Download the pinned `libavrocpp` Conan recipe before the native build.
- Replace the retired Apache `dlcdn` source URL with the durable Apache Archive endpoint.
- Fail fast unless the corrected URL is present.

## Why

The pinned recipe downloads `avro-src-1.12.1.tar.gz` from `dlcdn.apache.org`, which now returns HTTP 404. This makes both AMD64 and ARM64 native builds fail before Spark-Milvus compilation.

The dependency version, recipe revision, and source SHA256 remain unchanged. The newer upstream recipe contains the same URL-only correction, so this avoids pulling unrelated `milvus-storage` changes.

## Verification

- Replayed the Dockerfile commands with Conan 2.25.1 against `default-conan-local2`; recipe download, cache lookup, replacement, and validation succeeded.
- Confirmed the Apache Archive URL returns HTTP 200.
- Confirmed the old and fixed recipes differ only in the source URL.
- `git diff --check` passed.

A full image build was not run locally because the Docker daemon is unavailable; CI should execute the complete native build.


___

### **PR Type**
Bug fix


___

### **Description**
- Download pinned `libavrocpp` Conan recipe before native build.

- Replace retired `dlcdn.apache.org` source URL with durable archive endpoint.

- Validate corrected URL to fail fast if missing.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile native build"] --> B["conan download libavrocpp recipe"]
  B --> C["sed replace dlcdn URL with archive.apache.org URL"]
  C --> D["grep verify archive URL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Avro source URL in Conan recipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Download pinned <br><code>libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d</code> recipe <br>using <code>conan download</code><br> <li> Update <code>conandata.yml</code> to replace <code>https://dlcdn.apache.org/avro/</code> with <br><code>https://archive.apache.org/dist/avro/</code><br> <li> Add <code>grep -Fq</code> validation so the build fails if the archive URL is not <br>present</ul>


</details>


  </td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/121/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

