### PR TITLE
fix: report partitionId 0 for multi-partition backfill results

### DIFF
--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -70,6 +70,10 @@ case class BackfillResult(
     segmentResults: Map[Long, SegmentBackfillResult],
     executionTimeMs: Long,
     collectionId: Long,
+    /** Partition every processed segment belongs to, or 0 when the segments
+      * span several partitions. Milvus reads 0 as "no partition check"; any
+      * other value must match each segment's partition or the commit fails.
+      */
     partitionId: Long,
     schemaVersion: Int,
     newFieldNames: Seq[String],

--- a/src/main/scala/operations/backfill/BackfillResult.scala
+++ b/src/main/scala/operations/backfill/BackfillResult.scala
@@ -71,8 +71,9 @@ case class BackfillResult(
     executionTimeMs: Long,
     collectionId: Long,
     /** Partition every processed segment belongs to, or 0 when the segments
-      * span several partitions. Milvus reads 0 as "no partition check"; any
-      * other value must match each segment's partition or the commit fails.
+      * span several partitions. Milvus skips its partition check for 0 (and,
+      * since milvus-io/milvus#53330, for any non-positive value); a positive
+      * value must match each segment's partition or the commit fails.
       */
     partitionId: Long,
     schemaVersion: Int,

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -39,6 +39,20 @@ import io.milvus.grpc.schema.{DataType => MilvusDataType}
   */
 object MilvusBackfill {
 
+  /** Partition ID stamped on the top-level result JSON.
+    *
+    * Milvus DataCoord (`CommitBackfillResult`) treats a non-zero value as a
+    * partition-scoped commit and rejects every segment whose partition differs
+    * from it; `0` means "no partition restriction". A backfill that spans more
+    * than one partition must therefore report `0`. The previous `-1` sentinel
+    * made Milvus compare every segment against partition -1 and reject all of
+    * them ("no backfill segments passed pre-validation").
+    */
+  private[backfill] def resolveResultPartitionId(
+      partitionIDs: Set[Long]
+  ): Long =
+    if (partitionIDs.size == 1) partitionIDs.head else 0L
+
   private val logger = LoggerFactory.getLogger(getClass)
 
   private[backfill] final case class BackfillSource(
@@ -627,7 +641,7 @@ object MilvusBackfill {
         segmentResults = segmentResults,
         executionTimeMs = executionTime,
         collectionId = collectionID,
-        partitionId = if (partitionIDs.size == 1) partitionIDs.head else -1,
+        partitionId = resolveResultPartitionId(partitionIDs),
         schemaVersion = snapshotMetadataOpt
           .map(_.collection.schema.version)
           .getOrElse(0),

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -41,12 +41,13 @@ object MilvusBackfill {
 
   /** Partition ID stamped on the top-level result JSON.
     *
-    * Milvus DataCoord (`CommitBackfillResult`) treats a non-zero value as a
-    * partition-scoped commit and rejects every segment whose partition differs
-    * from it; `0` means "no partition restriction". A backfill that spans more
-    * than one partition must therefore report `0`. The previous `-1` sentinel
-    * made Milvus compare every segment against partition -1 and reject all of
-    * them ("no backfill segments passed pre-validation").
+    * Milvus DataCoord (`CommitBackfillResult`) validates every segment's
+    * partition against a positive value and skips the check otherwise. Builds
+    * before milvus-io/milvus#53330 skip the check only for `0`, so `0` is the
+    * one value that means "no partition restriction" on every build. A backfill
+    * that spans more than one partition must therefore report `0`. The previous
+    * `-1` sentinel was compared against partition -1 by those builds, which
+    * rejected every segment ("no backfill segments passed pre-validation").
     */
   private[backfill] def resolveResultPartitionId(
       partitionIDs: Set[Long]

--- a/src/test/scala/operations/backfill/BackfillPartitionIdTest.scala
+++ b/src/test/scala/operations/backfill/BackfillPartitionIdTest.scala
@@ -1,0 +1,48 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** The top-level `partitionId` is consumed by Milvus `CommitBackfillResult`,
+  * which only treats `0` as "no partition restriction". Any other value is
+  * compared against every segment's partition.
+  */
+class BackfillPartitionIdTest extends AnyFunSuite with Matchers {
+
+  test("single partition reports that partition ID") {
+    MilvusBackfill.resolveResultPartitionId(
+      Set(450000000002L)
+    ) shouldBe 450000000002L
+  }
+
+  test("segments spanning several partitions report 0, not -1") {
+    MilvusBackfill.resolveResultPartitionId(
+      Set(450000000002L, 450000000003L, 450000000004L)
+    ) shouldBe 0L
+  }
+
+  test("no partitions reports 0") {
+    MilvusBackfill.resolveResultPartitionId(Set.empty) shouldBe 0L
+  }
+
+  test("result JSON carries 0 for a multi-partition backfill") {
+    val segment = SegmentBackfillResult(
+      segmentId = 10L,
+      rowCount = 3L,
+      manifestPaths = Seq("s3a://bucket/manifest"),
+      executionTimeMs = 1L,
+      outputPath = "s3a://bucket/output"
+    )
+    val result = BackfillResult.success(
+      segmentResults = Map(10L -> segment),
+      executionTimeMs = 1L,
+      collectionId = 1L,
+      partitionId = MilvusBackfill.resolveResultPartitionId(Set(2L, 3L)),
+      schemaVersion = 1,
+      newFieldNames = Seq("f")
+    )
+    val json = new ObjectMapper().readTree(result.toJson)
+    json.get("partitionId").asLong() shouldBe 0L
+  }
+}


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
## Problem

Milvus DataCoord `CommitBackfillResult` (milvus-io/milvus#49265) skipped its partition check only when the result JSON's top-level `partitionId` was `0`. Every other value was compared against each segment's partition, and mismatches were rejected.

spark-milvus has written `-1` whenever the processed segments span more than one partition (since #59). Milvus therefore rejected every segment with `segment does not belong to the result's partition`, returned `no backfill segments passed pre-validation`, and the commit failed with HTTP 500. Any collection with more than one physical partition hits this, including every partition-key collection. The new-field binlogs were already written; only the commit was refused.

Milvus fixed its side in milvus-io/milvus#53330 (master, merged 2026-09-10) and the 3.0 cherry-pick milvus-io/milvus#53346 (pending): the check now runs only for a positive `partitionId`. Builds that predate it still accept only `0`, so `0` is the value that commits on every build. The two fixes are independent; either one alone resolves the failure, and both together keep the single-partition check intact.

## Change

- Report `0` when the processed segments span several partitions; a single partition still reports its real ID.
- Extract `resolveResultPartitionId` and add unit tests for single / multi / empty partition sets and the JSON output.
- Document the Milvus-side semantics on `BackfillResult.partitionId`.

Per-segment paths and files are unchanged; Milvus reads the top-level field only for this check.

## Tests

- `BackfillPartitionIdTest`, `BackfillResultTest`: 6 passed.
- Full unit suite: 569 passed. The 2 failures (`MilvusStorageFFITest`, `MilvusStorageMultiFileGroupTest`) need the Linux native `milvus-storage-jni` library and fail on macOS regardless of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PptsavR356QgWDfqQPMNNH


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Use 0 as multi-partition backfill partitionId sentinel

- Extract resolveResultPartitionId helper for partition resolution

- Add tests for single, multi, empty partition sets

- Document Milvus CommitBackfillResult partition check semantics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Partition IDs from processed segments"] --> B["resolveResultPartitionId"]
  B -- "size == 1: return ID" --> C["BackfillResult.partitionId"]
  B -- "size != 1: return 0" --> C
  C --> D["Result JSON consumed by Milvus"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MilvusBackfill.scala</strong><dd><code>Resolve backfill partition ID centrally</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/operations/backfill/MilvusBackfill.scala

<ul><li>Introduce <code>resolveResultPartitionId</code> to return a single partition ID or <br>0 for multi/empty sets.<br> <li> Replace inline <code>if</code> with helper when building final <code>BackfillResult</code>.<br> <li> Add scaladoc explaining Milvus partition check semantics.</ul>


</details>


  </td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/122/files#diff-9bc89e38c434b97e18d65ebc3bd3a4b8b6d88e37f42ad9232524110d2d60a4a9">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackfillResult.scala</strong><dd><code>Document partitionId sentinel semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/operations/backfill/BackfillResult.scala

<ul><li>Expand <code>partitionId</code> field scaladoc to explain 0 sentinel and Milvus <br>behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/122/files#diff-9a398df22a5ef189521a498c136faa08df5cd3a84ab1b0a0df9aae7caa0dfbd2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackfillPartitionIdTest.scala</strong><dd><code>Add backfill partition ID unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/scala/operations/backfill/BackfillPartitionIdTest.scala

<ul><li>Test single partition returns actual ID.<br> <li> Test multi-partition returns 0 not -1.<br> <li> Test empty set returns 0.<br> <li> Test JSON serialization carries 0 for multi-partition.</ul>


</details>


  </td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/122/files#diff-27301dfb2d5f93220e160763fec2cb52e172c65c1f8600f3891f930487bde8dd">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

