### PR TITLE
enhance: Add Iceberg input reader to backfill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -198,6 +198,7 @@ lazy val root = (project in file("."))
       parquetHadoop,
       parquetAvro,
       avro,
+      icebergSparkRuntime,
       hadoopCommon,
       hadoopAws,
       hadoopAliyun,

--- a/docs/user-guide-snapshot-backfill.md
+++ b/docs/user-guide-snapshot-backfill.md
@@ -37,7 +37,7 @@ Use snapshot backfill when you need to:
 | Object storage             | S3 / MinIO / GCS with S3-compatible endpoint. Must be accessible from both Milvus and Spark.    |
 | Spark / Java               | Spark 4.0.x built for Scala 2.13, with Java 21. Cluster mode on YARN, Kubernetes, or standalone. |
 | Connector JARs             | `spark-connector-assembly-*.jar`. It bundles the native `milvus-storage` resources copied into `src/main/resources/native/`. |
-| Parquet of new-field data  | Must contain the resolved join-key column, plus one column per new field.                      |
+| New-field input data        | A Parquet file or an Iceberg table (`--input-format`), containing the resolved join-key column plus one column per new field. |
 | Network                    | Spark executors must reach the object store. Schema setup and snapshot creation use the Milvus SDK; result commit must reach the Proxy management HTTP endpoint. |
 
 ## 3. The flow at a glance
@@ -48,7 +48,7 @@ Use snapshot backfill when you need to:
 │ 2. CreateSnapshot(collection)         → snapshot.json on S3      │
 └──────────────────────────────────────────────────────────────────┘
                 │
-                ▼   snapshot.json + your parquet
+                ▼   snapshot.json + your input data (parquet / iceberg)
 ┌─── Spark job ────────────────────────────────────────────────────┐
 │ 3. Run BackfillApp                                               │
 │    → writes new binlogs to S3                                    │
@@ -66,12 +66,13 @@ Use snapshot backfill when you need to:
 Steps 1 and 2 use your Milvus SDK. Step 4 is a single request to the Proxy
 management HTTP endpoint, not a public SDK or gRPC method.
 
-## 4. Prepare your Parquet input
+## 4. Prepare your input data
 
-The Parquet file must contain:
+`--input-format` selects the input reader: `parquet` (default) or `iceberg`.
+The input must contain:
 
 - The **join-key** column. By default the job joins on the collection primary
-  key and expects a parquet column named `pk`; use `--column-mapping` if your
+  key and expects an input column named `pk`; use `--column-mapping` if your
   source has a different name.
 - One column per **new field** you want to backfill. Column names must
   match the Milvus field names (after any column mapping).
@@ -85,8 +86,18 @@ Example (new fields `category` and `score`, PK column in source is `doc_id`):
 
 At submit time: `--column-mapping doc_id:pk_field,category:category,score:score`.
 
+For an **Iceberg input**, pass `--input-format iceberg` and an
+`--input-path` of the form `catalog.db.table`. The catalog must be registered
+on the Spark session (`--conf spark.sql.catalog.<name>=org.apache.iceberg.spark.SparkCatalog`
+plus `type`/`warehouse`); the runtime jar is supplied with
+`--packages org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.2`.
+Iceberg *path* reads (`s3a://...`) are not supported — Iceberg 1.10 routes them
+through a hardcoded `type=hive` default catalog that needs a Hive metastore.
+`--iceberg-snapshot-id` time-travels the input table to a specific snapshot.
+Column mapping, join keys and merge modes are identical to the parquet input.
+
 To join on a different persisted snapshot field, pass
-`--join-key external_row_id`. With no mapping, the parquet must contain that
+`--join-key external_row_id`. With no mapping, the input must contain that
 exact column name. With a differently named input column:
 
 ```text
@@ -95,9 +106,9 @@ exact column name. With a differently named input column:
 ```
 
 The physical field must exist exactly (including case) in the snapshot schema
-and must be declared non-nullable. The parquet key must also be non-null and
+and must be declared non-nullable. The input key must also be non-null and
 unique so one source row cannot fan out into multiple output rows. Source
-values may repeat; the same parquet record is applied to every matching
+values may repeat; the same input record is applied to every matching
 physical source row. The join field is not a target field, so you cannot
 backfill it in the same operation. Supported physical-key Milvus types are
 Int8/16/32/64, String, and VarChar.
@@ -116,7 +127,7 @@ reserved for backfill metadata and cannot be used as join keys.
   explicitly in your ETL before running the job.
 
 Missing join keys in the Parquet: behaviour depends on `--mode` (see §6).
-Extra parquet keys not present in the collection are silently ignored.
+Extra input columns not present in the collection are silently ignored.
 
 ## 5. Step-by-step
 
@@ -333,13 +344,20 @@ your ETL before running backfill. Additional `coalesce` / `overwrite` caveats
 
 | Flag              | Description                                                             |
 | ----------------- | ----------------------------------------------------------------------- |
-| `--parquet`       | Path to user Parquet with join-key + new-field columns. `s3a://` or local. |
+| `--input-path`    | Input data location: path to a Parquet file (`s3a://` or local) or an Iceberg `catalog.db.table` identifier. `--parquet` is a legacy alias; the two are mutually exclusive. |
 | `--snapshot`      | Path to `snapshot.json` produced by Milvus `CreateSnapshot`.            |
 | `--s3-endpoint`   | S3 endpoint for Milvus storage (where segments live).                   |
 | `--s3-bucket`     | Bucket for Milvus storage.                                              |
 
 `BackfillApp` requires `--snapshot`; its CLI does not provide a client-only
 mode.
+
+### Input reader
+
+| Flag                 | Default     | Description                                                                 |
+| -------------------- | ----------- | --------------------------------------------------------------------------- |
+| `--input-format`     | `parquet`   | Input reader: `parquet` (implemented), `iceberg` (implemented), `lance` (recognized, rejected until its reader lands). |
+| `--iceberg-snapshot-id` | *(none)* | Iceberg snapshot to read the input table at (time travel); requires `--input-format iceberg`. |
 
 ### S3 auth (Milvus storage)
 
@@ -352,12 +370,14 @@ mode.
 | `--s3-root-path`   | Milvus `rootPath` (default: `files`).                                |
 | `--s3-region`      | Default: `us-east-1`.                                                |
 
-### Source bucket override (user Parquet in a different account / region)
+### Source bucket override (input in a different account / region)
 
 All of the above, prefixed with `--source-`: `--source-s3-endpoint`,
 `--source-s3-access-key`, `--source-s3-secret-key`, `--source-use-iam`,
 `--source-s3-use-ssl`, `--source-s3-region`. If none are given, the
-primary S3 config is reused for the input read.
+primary S3 config is reused for the input read. Applies to the Parquet input
+path and, for an Iceberg `hadoop`-catalog input, to the warehouse bucket that
+the identifier resolves to.
 
 ### Writer
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,6 +77,15 @@ object Dependencies {
   lazy val jacksonDatabind =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
 
+  // Iceberg input reader for backfill (inputFormat = "iceberg"). Spark 4.0 does
+  // NOT ship Iceberg, so this is marked provided: it stays out of the assembly
+  // and operators inject the runtime jar at submit time via --packages/--jars.
+  // test scope makes it available to integration tests that build real
+  // hadoop-catalog tables.
+  lazy val icebergVersion = "1.10.2"
+  lazy val icebergSparkRuntime =
+    "org.apache.iceberg" % "iceberg-spark-runtime-4.0_2.13" % icebergVersion % "provided,test"
+
   // Arrow dependencies for milvus-storage JNI
   lazy val arrowVersion = "17.0.0"
   lazy val arrowFormat = "org.apache.arrow" % "arrow-format" % arrowVersion

--- a/src/it/scala/operations/backfill/IcebergReadMinioIT.scala
+++ b/src/it/scala/operations/backfill/IcebergReadMinioIT.scala
@@ -1,0 +1,121 @@
+package com.zilliz.spark.connector.operations.backfill
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/** Integration tests for the Iceberg backfill input reader.
+  *
+  * Exercises the read mechanism `MilvusBackfill.readIceberg` relies on: an
+  * Iceberg table in a user-registered hadoop catalog on MinIO, loaded by
+  * catalog-qualified identifier via `spark.read.format("iceberg").load(...)`,
+  * including `snapshot-id` time travel. Reads go through Hadoop FS (S3A),
+  * matching the `--source-s3-*` per-bucket credential path.
+  *
+  * Note: Iceberg 1.10 routes raw *path* reads (`load("s3a://...")`) through a
+  * default catalog hardcoded to `type=hive`, which needs a Hive metastore;
+  * catalog-qualified identifiers are the supported hadoop-catalog read form.
+  *
+  * Prerequisites: MinIO running at localhost:9000 with a pre-created
+  * `a-bucket` and minioadmin/minioadmin credentials.
+  */
+class IcebergReadMinioIT extends AnyFunSuite with Matchers {
+
+  private val catalog = "iceberg_cat"
+  private val warehouse = "s3a://a-bucket/iceberg-warehouse"
+  private val table = "backfill_input"
+  private val tableIdentifier = s"$catalog.db.$table"
+
+  private def newSpark(): SparkSession =
+    SparkSession
+      .builder()
+      .appName("IcebergReadMinioTest")
+      .master("local[*]")
+      .config(
+        s"spark.sql.catalog.$catalog",
+        "org.apache.iceberg.spark.SparkCatalog"
+      )
+      .config(s"spark.sql.catalog.$catalog.type", "hadoop")
+      .config(s"spark.sql.catalog.$catalog.warehouse", warehouse)
+      .config("spark.hadoop.fs.s3a.endpoint", "localhost:9000")
+      .config("spark.hadoop.fs.s3a.access.key", "minioadmin")
+      .config("spark.hadoop.fs.s3a.secret.key", "minioadmin")
+      .config("spark.hadoop.fs.s3a.path.style.access", "true")
+      .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
+      .getOrCreate()
+
+  private def currentSnapshotId(spark: SparkSession): Long =
+    spark
+      .sql(
+        s"SELECT snapshot_id FROM $catalog.db.$table.snapshots " +
+          "ORDER BY committed_at DESC LIMIT 1"
+      )
+      .head()
+      .getLong(0)
+
+  test("read an Iceberg table by catalog identifier from MinIO") {
+    val spark = newSpark()
+    try {
+      import spark.implicits._
+      spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $catalog.db")
+      spark.sql(
+        s"CREATE TABLE $tableIdentifier " +
+          "(pk LONG, new_field STRING, embedding ARRAY<DOUBLE>) USING iceberg"
+      )
+      Seq(
+        (1L, "alpha", Seq(0.1, 0.2, 0.3)),
+        (2L, "beta", Seq(0.4, 0.5, 0.6))
+      ).toDF("pk", "new_field", "embedding")
+        .writeTo(tableIdentifier)
+        .append()
+
+      val df = spark.read.format("iceberg").load(tableIdentifier)
+      df.count() shouldBe 2
+      df.schema.fieldNames should contain allOf (
+        "pk",
+        "new_field",
+        "embedding"
+      )
+      df
+        .select("new_field")
+        .orderBy("pk")
+        .collect()
+        .map(_.getString(0)) shouldBe Array("alpha", "beta")
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableIdentifier")
+      spark.stop()
+    }
+  }
+
+  test("snapshot-id option time-travels an Iceberg input table") {
+    val spark = newSpark()
+    try {
+      import spark.implicits._
+      spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $catalog.db")
+      spark.sql(
+        s"CREATE TABLE $tableIdentifier (pk LONG, new_field STRING) USING iceberg"
+      )
+      Seq((1L, "v1"), (2L, "v2"))
+        .toDF("pk", "new_field")
+        .writeTo(tableIdentifier)
+        .append()
+      val firstSnapshot = currentSnapshotId(spark)
+
+      Seq((3L, "v3"), (4L, "v4"))
+        .toDF("pk", "new_field")
+        .writeTo(tableIdentifier)
+        .append()
+
+      spark.read.format("iceberg").load(tableIdentifier).count() shouldBe 4
+      spark.read
+        .format("iceberg")
+        .option("snapshot-id", firstSnapshot.toString)
+        .load(tableIdentifier)
+        .count() shouldBe 2
+    } finally {
+      spark.sql(s"DROP TABLE IF EXISTS $tableIdentifier")
+      spark.stop()
+    }
+  }
+}

--- a/src/it/scala/operations/backfill/IcebergReadMinioIT.scala
+++ b/src/it/scala/operations/backfill/IcebergReadMinioIT.scala
@@ -23,8 +23,16 @@ class IcebergReadMinioIT extends AnyFunSuite with Matchers {
 
   private val catalog = "iceberg_cat"
   private val warehouse = "s3a://a-bucket/iceberg-warehouse"
-  private val table = "backfill_input"
-  private val tableIdentifier = s"$catalog.db.$table"
+  private val tablePrefix = "backfill_input"
+  private var tableSeq = 0L
+
+  /** A per-test unique table identifier so a failed run cannot drop a
+    * pre-existing table from an earlier run (or from a concurrent test).
+    */
+  private def newTableIdentifier(): String = {
+    tableSeq += 1
+    s"$catalog.db.${tablePrefix}_${System.currentTimeMillis()}_$tableSeq"
+  }
 
   private def newSpark(): SparkSession =
     SparkSession
@@ -45,10 +53,13 @@ class IcebergReadMinioIT extends AnyFunSuite with Matchers {
       .config("spark.sql.shuffle.partitions", "1")
       .getOrCreate()
 
-  private def currentSnapshotId(spark: SparkSession): Long =
+  private def currentSnapshotId(
+      spark: SparkSession,
+      tableIdentifier: String
+  ): Long =
     spark
       .sql(
-        s"SELECT snapshot_id FROM $catalog.db.$table.snapshots " +
+        s"SELECT snapshot_id FROM $tableIdentifier.snapshots " +
           "ORDER BY committed_at DESC LIMIT 1"
       )
       .head()
@@ -56,6 +67,7 @@ class IcebergReadMinioIT extends AnyFunSuite with Matchers {
 
   test("read an Iceberg table by catalog identifier from MinIO") {
     val spark = newSpark()
+    val tableIdentifier = newTableIdentifier()
     try {
       import spark.implicits._
       spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $catalog.db")
@@ -90,6 +102,7 @@ class IcebergReadMinioIT extends AnyFunSuite with Matchers {
 
   test("snapshot-id option time-travels an Iceberg input table") {
     val spark = newSpark()
+    val tableIdentifier = newTableIdentifier()
     try {
       import spark.implicits._
       spark.sql(s"CREATE NAMESPACE IF NOT EXISTS $catalog.db")
@@ -100,7 +113,7 @@ class IcebergReadMinioIT extends AnyFunSuite with Matchers {
         .toDF("pk", "new_field")
         .writeTo(tableIdentifier)
         .append()
-      val firstSnapshot = currentSnapshotId(spark)
+      val firstSnapshot = currentSnapshotId(spark, tableIdentifier)
 
       Seq((3L, "v3"), (4L, "v4"))
         .toDF("pk", "new_field")

--- a/src/main/scala/operations/backfill/BackfillApp.scala
+++ b/src/main/scala/operations/backfill/BackfillApp.scala
@@ -17,9 +17,10 @@ import com.zilliz.spark.connector.MilvusOption
   * [--input-format parquet|iceberg|lance]
   *
   * --input-path <path> is a format-neutral alias for --parquet (mutually
-  * exclusive with it). --input-format selects the input reader; only "parquet"
-  * is implemented, iceberg/lance are validated but rejected until their readers
-  * land.
+  * exclusive with it). --input-format selects the input reader; "parquet"
+  * and "iceberg" are implemented, "lance" is validated but rejected until
+  * its reader lands. --iceberg-snapshot-id time-travels an iceberg input
+  * table to a specific snapshot (requires --input-format iceberg).
   *
   * --mode:
   *   - replace: parquet is absolute source of truth; unmatched source rows get
@@ -118,7 +119,8 @@ object BackfillApp {
     "output-result",
     "column-mapping",
     "mode",
-    "join-key"
+    "join-key",
+    "iceberg-snapshot-id"
   )
 
   private[backfill] val KnownFlags: Set[String] = BoolFlags ++ KvFlags
@@ -179,6 +181,7 @@ object BackfillApp {
         .map(_.trim)
         .filter(_.nonEmpty)
         .getOrElse(BackfillConfig.DefaultInputFormat),
+      icebergSnapshotId = parsed.get("iceberg-snapshot-id"),
       mode = parsed.getOrElse("mode", MilvusOption.BackfillModeCoalesce),
       joinKey = parsed
         .get("join-key")

--- a/src/main/scala/operations/backfill/BackfillConfig.scala
+++ b/src/main/scala/operations/backfill/BackfillConfig.scala
@@ -73,10 +73,16 @@ case class BackfillConfig(
     sourceS3UseIam: Option[Boolean] = None,
     sourceS3Region: Option[String] = None,
 
-    // Input data source format. "parquet" is the only implemented reader;
-    // "iceberg" and "lance" are recognized as valid format names but have no
-    // reader yet, so validate() rejects them until a reader lands.
+    // Input data source format. "parquet" and "iceberg" have readers; "lance"
+    // is recognized as a valid format name but has no reader yet, so
+    // validate() rejects it until a reader lands.
     inputFormat: String = BackfillConfig.DefaultInputFormat,
+
+    // Iceberg input read options. snapshot-id time-travels the input table to
+    // a specific Iceberg snapshot so a long-running backfill reads a stable
+    // view; ignored when inputFormat != "iceberg" (validate() rejects that
+    // combination).
+    icebergSnapshotId: Option[String] = None,
 
     // Writer configuration
     batchSize: Int = 1024,
@@ -201,6 +207,19 @@ case class BackfillConfig(
         s"inputFormat '$inputFormat' is recognized but not yet implemented; " +
           s"only ${BackfillConfig.ImplementedInputFormats.mkString("[", ", ", "]")} " +
           "have a reader"
+      )
+    } else if (
+      inputFormat.trim != "iceberg" && icebergSnapshotId.exists(_.trim.nonEmpty)
+    ) {
+      Left("icebergSnapshotId requires inputFormat='iceberg'")
+    } else if (
+      inputFormat.trim == "iceberg" && icebergSnapshotId.exists { id =>
+        id.trim.nonEmpty && scala.util.Try(id.trim.toLong).isFailure
+      }
+    ) {
+      Left(
+        s"icebergSnapshotId must be an integer snapshot id " +
+          s"(got '${icebergSnapshotId.get}')"
       )
     } else {
       // Same invariant for the source (input parquet) bucket. Any field
@@ -448,7 +467,7 @@ object BackfillConfig {
   // recognized-but-unimplemented formats here (fail-fast at config time), and
   // readBackfillData guards its per-format dispatch on the same set so the two
   // cannot drift. Each new reader extends this set and adds a dispatch arm.
-  private[backfill] val ImplementedInputFormats = Set("parquet")
+  private[backfill] val ImplementedInputFormats = Set("parquet", "iceberg")
 
   private[backfill] val HadoopS3CredentialsProvider =
     "fs.s3a.aws.credentials.provider"

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -758,7 +758,7 @@ object MilvusBackfill {
     }
   }
 
-  private def readIceberg(
+  private[backfill] def readIceberg(
       spark: SparkSession,
       rawPath: String,
       config: BackfillConfig
@@ -772,6 +772,19 @@ object MilvusBackfill {
     // configureHadoopS3ForPath unharmed; reads go through Hadoop FS, so the
     // scoped source-bucket S3A config still applies.
     val path = normalizeObjectStorageScheme(rawPath, config)
+    // Iceberg input must be a catalog-qualified identifier (catalog.db.table).
+    // Raw file/object-storage paths are unsupported and would otherwise fail
+    // later with a misleading Hive-metastore error from Iceberg's default
+    // catalog resolution; reject them up front with a clear message.
+    if (path != null && (path.contains("://") || path.startsWith("/"))) {
+      return Left(
+        DataReadError(
+          path = path,
+          message = "Iceberg input must be a catalog-qualified identifier " +
+            "(catalog.db.table), not a raw file/object-storage path"
+        )
+      )
+    }
     try {
       Right(withScopedHadoopStorage(spark, path, config, isSource = true) {
         // No full materialization is needed here, mirroring readParquet:

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -774,13 +774,17 @@ object MilvusBackfill {
     val path = normalizeObjectStorageScheme(rawPath, config)
     try {
       Right(withScopedHadoopStorage(spark, path, config, isSource = true) {
-        // Materialize while source-bucket credentials are installed, mirroring
-        // readParquet: Spark evaluates DataFrame reads lazily, so returning an
-        // unmaterialized DF would let later main-bucket configuration leak in.
+        // No full materialization is needed here, mirroring readParquet:
+        // S3A uses persistent per-bucket `fs.s3a.bucket.<b>.*` configuration,
+        // so a later lazy scan still resolves the source-bucket credentials
+        // even after this block returns. OSS keys are restored on exit, so
+        // oss:// inputs are materialized via localCheckpoint inside the scope.
+        // df.columns resolves the Iceberg schema (metadata read) inside the
+        // scope, failing fast on an empty table.
         var reader = spark.read.format("iceberg")
         config.icebergSnapshotId
           .filter(_.trim.nonEmpty)
-          .foreach(id => reader = reader.option("snapshot-id", id))
+          .foreach(id => reader = reader.option("snapshot-id", id.trim))
         val df = reader.load(path)
         if (df.columns.isEmpty) {
           throw new IllegalArgumentException(

--- a/src/main/scala/operations/backfill/MilvusBackfill.scala
+++ b/src/main/scala/operations/backfill/MilvusBackfill.scala
@@ -711,6 +711,7 @@ object MilvusBackfill {
     }
     format match {
       case "parquet" => readParquet(spark, rawPath, config)
+      case "iceberg" => readIceberg(spark, rawPath, config)
     }
   }
 
@@ -751,6 +752,54 @@ object MilvusBackfill {
           DataReadError(
             path = path,
             message = s"Failed to read Parquet file: ${e.getMessage}",
+            cause = Some(e)
+          )
+        )
+    }
+  }
+
+  private def readIceberg(
+      spark: SparkSession,
+      rawPath: String,
+      config: BackfillConfig
+  ): Either[BackfillError, BackfillSource] = {
+    // Iceberg loads by catalog-qualified identifier (catalog.db.table); the
+    // catalog must be registered via spark.sql.catalog.<name> at submit time.
+    // Raw object-storage *path* loads are not usable without a Hive metastore:
+    // Iceberg 1.10 routes path reads through a default_iceberg catalog that it
+    // hardcodes to type=hive, so we document identifiers as the supported form.
+    // Identifiers pass through normalizeObjectStorageScheme and
+    // configureHadoopS3ForPath unharmed; reads go through Hadoop FS, so the
+    // scoped source-bucket S3A config still applies.
+    val path = normalizeObjectStorageScheme(rawPath, config)
+    try {
+      Right(withScopedHadoopStorage(spark, path, config, isSource = true) {
+        // Materialize while source-bucket credentials are installed, mirroring
+        // readParquet: Spark evaluates DataFrame reads lazily, so returning an
+        // unmaterialized DF would let later main-bucket configuration leak in.
+        var reader = spark.read.format("iceberg")
+        config.icebergSnapshotId
+          .filter(_.trim.nonEmpty)
+          .foreach(id => reader = reader.option("snapshot-id", id))
+        val df = reader.load(path)
+        if (df.columns.isEmpty) {
+          throw new IllegalArgumentException(
+            "Backfill iceberg input is empty (no columns)"
+          )
+        }
+        if (path.startsWith("oss://")) {
+          localCheckpointBackfillData(spark, df)
+        } else {
+          BackfillSource(df, None)
+        }
+      })
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to read Iceberg table from $path", e)
+        Left(
+          DataReadError(
+            path = path,
+            message = s"Failed to read Iceberg table: ${e.getMessage}",
             cause = Some(e)
           )
         )

--- a/src/main/scala/operations/backfill/README.md
+++ b/src/main/scala/operations/backfill/README.md
@@ -97,13 +97,46 @@ passing both is an error.
 
 | Flag              | Default     | Description                                                                  |
 |-------------------|-------------|------------------------------------------------------------------------------|
-| `--input-format`  | `parquet`   | Input reader. `parquet` is the only implemented format; `iceberg` and `lance` are recognized but rejected at config validation until their readers land. |
+| `--input-format`  | `parquet`   | Input reader. `parquet` and `iceberg` are implemented; `lance` is recognized but rejected at config validation until its reader lands. |
+| `--iceberg-snapshot-id` | *(none)* | Iceberg snapshot to read the input table at (time travel); requires `--input-format iceberg`. |
 | `--mode`          | `coalesce`  | Merge semantics: `replace`, `coalesce` (fill-if-null), or `overwrite`. See "Merge modes" below. |
 | `--batch-size`    | `1024`      | Rows per Arrow batch flushed to the writer.                                  |
 | `--column-mapping`| *(none)*    | `src1:tgt1,src2:tgt2,...`. Rename/drop Parquet columns to Milvus field names. |
 | `--join-key`      | collection PK | Exact persisted snapshot field to use instead of the collection PK. |
 | `--output-result` | *(none)*    | Path to write the result JSON.                                               |
 | `--s3-cloud-provider` | `aws` | Native storage provider for the Milvus storage bucket: `aws`, `aliyun`, `gcp`, `azure`, `tencent`, or `huawei`. |
+
+### Iceberg input
+
+`--input-format iceberg` reads the new-field data from an Iceberg table
+instead of a parquet file. `--input-path` is a **catalog-qualified identifier**
+(`catalog.db.table`): the catalog must be registered on the SparkSession via
+`--conf spark.sql.catalog.<name>=...` (e.g. `org.apache.iceberg.spark.SparkCatalog`
+with `type=hadoop` and `warehouse=...`). Reads go through Hadoop FS, so the
+`--source-s3-*` per-bucket credentials apply to the warehouse bucket too.
+
+Raw object-storage *path* reads (`--input-path s3a://.../table`) are **not**
+supported: Iceberg 1.10 routes path loads through a `default_iceberg` catalog
+that it hardcodes to `type=hive`, which requires a Hive metastore. Use a
+catalog-qualified identifier instead.
+
+Spark 4.0 does not ship Iceberg, so the runtime jar must be supplied at submit
+time (the connector declares it `provided` and excludes it from the assembly):
+
+```bash
+spark-submit \
+  --packages org.apache.iceberg:iceberg-spark-runtime-4.0_2.13:1.10.2 \
+  --conf spark.sql.catalog.backfill=org.apache.iceberg.spark.SparkCatalog \
+  --conf spark.sql.catalog.backfill.type=hadoop \
+  --conf spark.sql.catalog.backfill.warehouse=s3a://warehouse \
+  ... --input-format iceberg \
+      --input-path backfill.db.backfill_table \
+      --iceberg-snapshot-id 4325893492
+```
+
+`--iceberg-snapshot-id` time-travels the input table to a specific Iceberg
+snapshot so a long-running backfill reads a stable view. Column mapping, join
+keys and merge modes are identical to the parquet input.
 
 ## Join keys and column mapping
 

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -963,6 +963,25 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
       }
   }
 
+  test("readIceberg rejects raw object-storage paths up front") {
+    val cfg = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "b",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "iceberg"
+    )
+    // The rejection happens before any Spark/Iceberg I/O, so the shared local
+    // SparkSession is sufficient; a raw path must not reach the reader.
+    MilvusBackfill.readIceberg(spark, "s3a://warehouse/db/backfill_table", cfg) match {
+      case Left(error) =>
+        error.message should include("catalog-qualified identifier")
+        error.message should include("raw file/object-storage path")
+      case Right(_) =>
+        fail("expected a raw object-storage path to be rejected")
+    }
+  }
+
   test("getMilvusReadOptions includes AK/SK when s3UseIam=false") {
     val cfg = BackfillConfig(
       s3Endpoint = "minio:9000",

--- a/src/test/scala/operations/backfill/BackfillAppTest.scala
+++ b/src/test/scala/operations/backfill/BackfillAppTest.scala
@@ -216,6 +216,36 @@ class BackfillAppTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
     defaulted.inputFormat shouldBe BackfillConfig.DefaultInputFormat
   }
 
+  test("buildConfig maps --iceberg-snapshot-id") {
+    val withSnapshot = BackfillApp.buildConfig(
+      Map(
+        "s3-endpoint" -> "endpoint",
+        "s3-bucket" -> "bucket",
+        "input-format" -> "iceberg",
+        "iceberg-snapshot-id" -> "4325893492"
+      )
+    )
+    withSnapshot.icebergSnapshotId shouldBe Some("4325893492")
+
+    val withoutSnapshot = BackfillApp.buildConfig(
+      Map("s3-endpoint" -> "endpoint", "s3-bucket" -> "bucket")
+    )
+    withoutSnapshot.icebergSnapshotId shouldBe None
+  }
+
+  test("parseArgs accepts --iceberg-snapshot-id") {
+    val parsed = BackfillApp.parseArgs(
+      Array(
+        "--input-format",
+        "iceberg",
+        "--iceberg-snapshot-id",
+        "4325893492"
+      )
+    )
+    parsed("input-format") shouldBe "iceberg"
+    parsed("iceberg-snapshot-id") shouldBe "4325893492"
+  }
+
   test("parseArgs throws when key/value flag is followed by another flag") {
     val ex = intercept[IllegalArgumentException] {
       BackfillApp.parseArgs(Array("--parquet", "--snapshot", "/tmp/snap.json"))

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -99,6 +99,52 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     }
   }
 
+  test("validate accepts iceberg inputFormat with a valid snapshot id") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "iceberg",
+      icebergSnapshotId = Some("4325893492")
+    )
+    config.validate() shouldBe Right(())
+  }
+
+  test("validate rejects a non-integer icebergSnapshotId") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "iceberg",
+      icebergSnapshotId = Some("not-a-snapshot")
+    )
+    config.validate() match {
+      case Right(_) =>
+        fail("expected validation error for non-integer icebergSnapshotId")
+      case Left(message) =>
+        message should include("icebergSnapshotId must be an integer snapshot id")
+    }
+  }
+
+  test("validate rejects icebergSnapshotId for non-iceberg inputFormat") {
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "parquet",
+      icebergSnapshotId = Some("4325893492")
+    )
+    config.validate() match {
+      case Right(_) =>
+        fail("expected validation error for icebergSnapshotId without iceberg")
+      case Left(message) =>
+        message should include("icebergSnapshotId requires inputFormat='iceberg'")
+    }
+  }
+
   test(
     "Empty milvusUri/collectionName is allowed by validate() in snapshot mode"
   ) {

--- a/src/test/scala/operations/backfill/BackfillConfigTest.scala
+++ b/src/test/scala/operations/backfill/BackfillConfigTest.scala
@@ -111,6 +111,20 @@ class BackfillConfigTest extends AnyFunSuite with Matchers {
     config.validate() shouldBe Right(())
   }
 
+  test("validate accepts a whitespace-padded icebergSnapshotId") {
+    // validate() trims before parsing and readIceberg trims before passing the
+    // value to the snapshot-id option, so a padded id must not be rejected.
+    val config = BackfillConfig(
+      s3Endpoint = "localhost:9000",
+      s3BucketName = "test-bucket",
+      s3AccessKey = "minioadmin",
+      s3SecretKey = "minioadmin",
+      inputFormat = "iceberg",
+      icebergSnapshotId = Some("  4325893492  ")
+    )
+    config.validate() shouldBe Right(())
+  }
+
   test("validate rejects a non-integer icebergSnapshotId") {
     val config = BackfillConfig(
       s3Endpoint = "localhost:9000",


### PR DESCRIPTION
<!-- pr-agent-generated -->
### **User description**
Backfill input reads now accept --input-format iceberg alongside parquet, loading new-field data from an Iceberg table by catalog-qualified identifier (catalog.db.table). The catalog is registered on the Spark session via spark.sql.catalog.<name>; reads go through Hadoop FS so the existing --source-s3-* per-bucket credentials apply to the warehouse.

ImplementedInputFormats gains iceberg, and validate() enforces the new --iceberg-snapshot-id option: it requires the iceberg format and must be an integer snapshot id, mirroring the s3RoleArn validation style.

Raw object-storage path loads are deliberately not supported: Iceberg 1.10 routes them through a default_iceberg catalog hardcoded to type=hive that needs a Hive metastore. The runtime jar stays provided-scope (Spark 4.0 does not ship Iceberg); operators inject it with --packages/--jars.

An IcebergReadMinioIT exercises identifier reads and snapshot-id time travel against MinIO, and the backfill README + user guide document the new flags and the identifier-only read form.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add `iceberg` to implemented backfill input formats

- Add `--iceberg-snapshot-id` validation and time travel

- Read catalog-qualified Iceberg tables through Hadoop S3

- Reject raw object-storage Iceberg path inputs

- Add MinIO integration tests for Iceberg reads

- Document Iceberg flags and Spark package setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BackfillApp parses --input-format and --iceberg-snapshot-id"] -- "builds config" --> B["BackfillConfig.validate enforces format/snapshot rules"]
  B -- "valid config" --> C["MilvusBackfill.readIceberg"]
  C -- "reads catalog-qualified identifier" --> D["Spark Iceberg reader via Hadoop S3A"]
  D -- "returns" --> E["BackfillSource DataFrame"]
  F["IcebergReadMinioIT"] -- "exercises" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>build.sbt</strong><dd><code>Add Iceberg Spark runtime to root libraryDependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dependencies.scala</strong><dd><code>Define Iceberg Spark runtime dependency provided/test</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>IcebergReadMinioIT.scala</strong><dd><code>Add MinIO integration tests for Iceberg reads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-26ddff22a35ebddfea1f21174badba675d6a9db4203211d3b51b88f98f711d70">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>BackfillAppTest.scala</strong><dd><code>Test new Iceberg flags and raw path rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-87730bd983f20364bcedb88677dad0538279695546981d0a82fae577d37f9ba9">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackfillConfigTest.scala</strong><dd><code>Validate iceberg snapshot ID configuration rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-cacdf05a7f21cd0f2b54ff15a746c89613857e738bf391c8b775ded04394c190">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>BackfillApp.scala</strong><dd><code>Parse and map new Iceberg snapshot ID flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-742ec79c2f6549ca87764496394c9af6ee4e5e60ae3da4bb891f4dd783b61e24">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BackfillConfig.scala</strong><dd><code>Add iceberg snapshot validation and implemented format</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-35134c516417b25bb6145dd914011875866e9b14fa74c930428042ee820a0ec3">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MilvusBackfill.scala</strong><dd><code>Implement catalog-qualified Iceberg input reader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-9bc89e38c434b97e18d65ebc3bd3a4b8b6d88e37f42ad9232524110d2d60a4a9">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>user-guide-snapshot-backfill.md</strong><dd><code>Document Iceberg input format and snapshot flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-f7e51f0998534701922e9718d8c3c109a417ff77ebd3eb797029acbdc4941db3">+32/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Document Iceberg backfill setup and examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/zilliztech/spark-milvus/pull/123/files#diff-5b6943e0bc71199a6f8c69775f6bad16332da7207928658845ce5f9cdecac6a7">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

