### PR TITLE
fix: harden native Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates wget curl git g++ gcc make ccache gdb \
     python3 python3-pip \
     zip unzip \
-    automake autoconf libtool patchelf libaio-dev \
+    automake autoconf libtool patchelf libaio-dev libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/aclocal-1.16 /usr/bin/aclocal-1.15 \
     && ln -sf /usr/bin/automake-1.16 /usr/bin/automake-1.15

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,9 @@ RUN set -eux; \
     boost_ref='boost/1.83.0#4e8a94ac1b88312af95eded83cd81ca8'; \
     conan download "${boost_ref}" -r default-conan-local2 --only-recipe; \
     boost_recipe="$(conan cache path "${boost_ref}")"; \
-    sed -i 's#https://boostorg.jfrog.io/artifactory/main/release/#https://downloads.sourceforge.net/project/boost/boost/#' \
+    sed -i 's#https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/#https://downloads.sourceforge.net/project/boost/boost/1.83.0/#' \
         "${boost_recipe}/conandata.yml"; \
-    grep -Fq 'https://downloads.sourceforge.net/project/boost/boost/1.83.0/' \
+    grep -Fq 'https://downloads.sourceforge.net/project/boost/boost/1.83.0/boost_1_83_0.tar.bz2' \
         "${boost_recipe}/conandata.yml"
 
 # Build milvus-storage native libraries using its Conan 2 Makefile.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip unzip \
     automake autoconf libtool patchelf libaio-dev libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
-    && pkg-config --exists openssl \
-    && test -f /usr/include/openssl/ssl.h \
     && ln -sf /usr/bin/aclocal-1.16 /usr/bin/aclocal-1.15 \
     && ln -sf /usr/bin/automake-1.16 /usr/bin/automake-1.15
 
@@ -95,6 +93,8 @@ RUN git config --global --add safe.directory /workspace && \
 # Keep the pinned recipes and checksums, but replace obsolete primary source
 # endpoints with their durable upstream archives.
 RUN set -eux; \
+    pkg-config --exists openssl; \
+    test -f /usr/include/openssl/ssl.h; \
     avro_ref='libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d'; \
     conan download "${avro_ref}" -r default-conan-local2 --only-recipe; \
     avro_recipe="$(conan cache path "${avro_ref}")"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates wget curl git g++ gcc make ccache gdb \
     python3 python3-pip \
     zip unzip \
-    automake autoconf libtool patchelf libaio-dev libssl-dev pkg-config \
+    automake autoconf libtool patchelf libaio-dev libssl-dev libclang-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/aclocal-1.16 /usr/bin/aclocal-1.15 \
     && ln -sf /usr/bin/automake-1.16 /usr/bin/automake-1.15
@@ -60,6 +60,7 @@ RUN conan profile detect --force \
 # The current milvus-storage format bridge is built from Rust sources.
 ENV RUSTUP_HOME=/root/.rustup
 ENV CARGO_HOME=/root/.cargo
+ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib
 ENV PATH=/root/.cargo/bin:${PATH}
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --profile minimal --default-toolchain stable
@@ -95,6 +96,7 @@ RUN git config --global --add safe.directory /workspace && \
 RUN set -eux; \
     pkg-config --exists openssl; \
     test -f /usr/include/openssl/ssl.h; \
+    test -f "${LIBCLANG_PATH}/libclang.so"; \
     avro_ref='libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d'; \
     conan download "${avro_ref}" -r default-conan-local2 --only-recipe; \
     avro_recipe="$(conan cache path "${avro_ref}")"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip unzip \
     automake autoconf libtool patchelf libaio-dev libssl-dev pkg-config \
     && rm -rf /var/lib/apt/lists/* \
+    && pkg-config --exists openssl \
+    && test -f /usr/include/openssl/ssl.h \
     && ln -sf /usr/bin/aclocal-1.16 /usr/bin/aclocal-1.15 \
     && ln -sf /usr/bin/automake-1.16 /usr/bin/automake-1.15
 
@@ -90,15 +92,21 @@ RUN git config --global --add safe.directory /workspace && \
     git config --global --add safe.directory /workspace/milvus-storage && \
     git submodule update --init --recursive
 
-# Apache removes superseded releases from dlcdn; keep the pinned recipe and
-# checksum, but use the durable archive endpoint for its Avro source.
+# Keep the pinned recipes and checksums, but replace obsolete primary source
+# endpoints with their durable upstream archives.
 RUN set -eux; \
     avro_ref='libavrocpp/1.12.1.1@milvus/dev#cde7bb587a29f6f233bae7e18b71815d'; \
     conan download "${avro_ref}" -r default-conan-local2 --only-recipe; \
     avro_recipe="$(conan cache path "${avro_ref}")"; \
     sed -i 's#https://dlcdn.apache.org/avro/#https://archive.apache.org/dist/avro/#' \
         "${avro_recipe}/conandata.yml"; \
-    grep -Fq 'https://archive.apache.org/dist/avro/' "${avro_recipe}/conandata.yml"
+    grep -Fq 'https://archive.apache.org/dist/avro/' "${avro_recipe}/conandata.yml"; \
+    boost_ref='boost/1.83.0#4e8a94ac1b88312af95eded83cd81ca8'; \
+    conan download "${boost_ref}" -r default-conan-local2 --only-recipe; \
+    boost_recipe="$(conan cache path "${boost_ref}")"; \
+    sed -i 's#https://boostorg.jfrog.io/artifactory/main/#https://archives.boost.io/#' \
+        "${boost_recipe}/conandata.yml"; \
+    grep -Fq 'https://archives.boost.io/release/1.83.0/' "${boost_recipe}/conandata.yml"
 
 # Build milvus-storage native libraries using its Conan 2 Makefile.
 RUN cd milvus-storage/cpp && make java-lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ RUN git config --global --add safe.directory /workspace && \
     git submodule update --init --recursive
 
 # Keep the pinned recipes and checksums, but replace obsolete primary source
-# endpoints with their durable upstream archives.
+# endpoints with durable upstream download locations.
 RUN set -eux; \
     pkg-config --exists openssl; \
     test -f /usr/include/openssl/ssl.h; \
@@ -104,9 +104,10 @@ RUN set -eux; \
     boost_ref='boost/1.83.0#4e8a94ac1b88312af95eded83cd81ca8'; \
     conan download "${boost_ref}" -r default-conan-local2 --only-recipe; \
     boost_recipe="$(conan cache path "${boost_ref}")"; \
-    sed -i 's#https://boostorg.jfrog.io/artifactory/main/#https://archives.boost.io/#' \
+    sed -i 's#https://boostorg.jfrog.io/artifactory/main/release/#https://downloads.sourceforge.net/project/boost/boost/#' \
         "${boost_recipe}/conandata.yml"; \
-    grep -Fq 'https://archives.boost.io/release/1.83.0/' "${boost_recipe}/conandata.yml"
+    grep -Fq 'https://downloads.sourceforge.net/project/boost/boost/1.83.0/' \
+        "${boost_recipe}/conandata.yml"
 
 # Build milvus-storage native libraries using its Conan 2 Makefile.
 RUN cd milvus-storage/cpp && make java-lib


### PR DESCRIPTION
## Summary

- install the OpenSSL, pkg-config, and libclang dependencies required by the pinned milvus-storage Rust/C++ build
- fail fast when OpenSSL headers, pkg-config metadata, or libclang are unavailable
- keep the pinned Conan recipes and checksums while replacing obsolete Avro and Boost download endpoints
- preserve the existing architecture-native AMD64/ARM64 packaging flow

## Validation

- full cold AMD64 Docker build in the documented remote build environment with `PUBLISH_MAVEN=false`
- output image: `linux/amd64`
- output artifact: `spark-connector-assembly-pr124-validation-amd64-SNAPSHOT.jar` (432 MB)
- verified `native/linux-x86_64/libmilvus-storage.so` and `libmilvus-storage-jni.so`
- verified all 256 bundled ELF shared libraries are x86_64
- verified no ARM64 native entries are present in the AMD64 artifact
- verified all bundled native dependencies resolve after installing `libaio1`, which spark-data-service already installs and checks at runtime
- GitHub Build & unit tests passed
